### PR TITLE
Feat/#10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-# 배포 환경
-FROM openjdk:21-jdk-slim
-
-ARG JAR_FILE=./build/libs/*.jar
-
-COPY ${JAR_FILE} /app.jar
-
-ENTRYPOINT ["java", "-jar", "/app.jar" ]
-
-## 개발 환경
+## 배포 환경
 #FROM openjdk:21-jdk-slim
 #
-#WORKDIR /app
+#ARG JAR_FILE=./build/libs/*.jar
 #
-#COPY . .
+#COPY ${JAR_FILE} /app.jar
 #
-#RUN chmod +x ./gradlew
-#
-#ENTRYPOINT ["./gradlew", "bootRun"]
+#ENTRYPOINT ["java", "-jar", "/app.jar" ]
+
+# 개발 환경
+FROM openjdk:21-jdk-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN chmod +x ./gradlew
+
+ENTRYPOINT ["./gradlew", "bootRun"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-## 배포 환경
-#FROM openjdk:21-jdk-slim
-#
-#ARG JAR_FILE=./build/libs/*.jar
-#
-#COPY ${JAR_FILE} /app.jar
-#
-#ENTRYPOINT ["java", "-jar", "/app.jar" ]
-
-# 개발 환경
+# 배포 환경
 FROM openjdk:21-jdk-slim
 
-WORKDIR /app
+ARG JAR_FILE=./build/libs/*.jar
 
-COPY . .
+COPY ${JAR_FILE} /app.jar
 
-RUN chmod +x ./gradlew
+ENTRYPOINT ["java", "-jar", "/app.jar" ]
 
-ENTRYPOINT ["./gradlew", "bootRun"]
+## 개발 환경
+#FROM openjdk:21-jdk-slim
+#
+#WORKDIR /app
+#
+#COPY . .
+#
+#RUN chmod +x ./gradlew
+#
+#ENTRYPOINT ["./gradlew", "bootRun"]

--- a/src/main/java/PoorToRich/PoorToRich/PoorToRichApplication.java
+++ b/src/main/java/PoorToRich/PoorToRich/PoorToRichApplication.java
@@ -2,8 +2,10 @@ package PoorToRich.PoorToRich;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
+@EntityScan(basePackages = {"PoorToRich.PoorToRich.category.entity"})
 public class PoorToRichApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/PoorToRich/PoorToRich/category/entity/Category.java
+++ b/src/main/java/PoorToRich/PoorToRich/category/entity/Category.java
@@ -1,18 +1,17 @@
 package PoorToRich.PoorToRich.category.entity;
 
-import jakarta.persistence.Table;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
-
-import java.sql.Timestamp;
 
 @Entity
 @Getter

--- a/src/main/java/PoorToRich/PoorToRich/email/controller/MailController.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/controller/MailController.java
@@ -23,7 +23,8 @@ public class MailController {
 
     @PostMapping("/send")
     public ResponseEntity<BaseResponse> sendVerificationCode(
-            @RequestBody @Valid EmailVerificationRequest emailVerificationRequest) {
+            @RequestBody @Valid EmailVerificationRequest emailVerificationRequest
+    ) {
         emailFacade.sendVerificationCode(emailVerificationRequest);
         return BaseResponse.toResponseEntity(EmailResponse.VERIFICATION_CODE_SENT);
     }

--- a/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
@@ -6,8 +6,21 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum EmailResponse implements Response {
-    VERIFICATION_CODE_SENT(HttpStatus.OK, "인증 코드 전송 성공");
 
+    VERIFICATION_CODE_SENT("verification_code_sent", HttpStatus.OK, "인증 코드 전송 성공"),
+    EMAIL_VERIFICATION_SUCCESS("email_verification_success", HttpStatus.OK, "이메일 인증 성공"),
+    INVALID_VERIFICATION_CODE("invalid_verification_code", HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않습니다."),
+    VERIFICATION_CODE_EXPIRED("verification_code_expired", HttpStatus.GONE, "인증 코드가 만료되었습니다."),
+    TOO_MANY_REQUESTS("too_many_request", HttpStatus.TOO_MANY_REQUESTS, "인증 요청 횟수를 초과하였습니다."),
+    
+    INVALID_EMAIL("invalid_email", HttpStatus.BAD_REQUEST, "유효하지 않은 이메일입니다."),
+    INVALID_PURPOSE("invalid_purpose", HttpStatus.BAD_REQUEST, "유효하지 않은 인증 목적입니다."),
+    EMAIL_SEND_FAILURE("mail_send_failure", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
+    EMAIL_NOT_FOUND("mail_not_found", HttpStatus.NOT_FOUND, "존재하지 않는 이메일 주소입니다."),
+
+    DEFAULT("default_email_exception", HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러 발생");
+
+    private final String identifier;
     private final HttpStatus httpStatus;
     private final String message;
 
@@ -19,5 +32,14 @@ public enum EmailResponse implements Response {
     @Override
     public String getMessage() {
         return message;
+    }
+
+    public static Response getResponseByIdentifier(String identifier) {
+        for (EmailResponse response : EmailResponse.values()) {
+            if (response.identifier.equals(identifier)) {
+                return response;
+            }
+        }
+        return EmailResponse.DEFAULT;
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
@@ -8,13 +8,13 @@ import org.springframework.http.HttpStatus;
 public enum EmailResponse implements Response {
 
     VERIFICATION_CODE_SENT("verification_code_sent", HttpStatus.OK, "인증 코드 전송 성공"),
-    EMAIL_VERIFICATION_SUCCESS("email_verification_success", HttpStatus.OK, "이메일 인증 성공"),
+    INVALID_PURPOSE("invalid_purpose", HttpStatus.BAD_REQUEST, "유효하지 않은 인증 목적입니다."),
     INVALID_VERIFICATION_CODE("invalid_verification_code", HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않습니다."),
     VERIFICATION_CODE_EXPIRED("verification_code_expired", HttpStatus.GONE, "인증 코드가 만료되었습니다."),
     TOO_MANY_REQUESTS("too_many_request", HttpStatus.TOO_MANY_REQUESTS, "인증 요청 횟수를 초과하였습니다."),
 
+    EMAIL_VERIFICATION_SUCCESS("email_verification_success", HttpStatus.OK, "이메일 인증 성공"),
     INVALID_EMAIL("invalid_email", HttpStatus.BAD_REQUEST, "유효하지 않은 이메일입니다."),
-    INVALID_PURPOSE("invalid_purpose", HttpStatus.BAD_REQUEST, "유효하지 않은 인증 목적입니다."),
     EMAIL_SEND_FAILURE("mail_send_failure", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
     EMAIL_NOT_FOUND("mail_not_found", HttpStatus.NOT_FOUND, "존재하지 않는 이메일 주소입니다."),
 

--- a/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
@@ -12,7 +12,7 @@ public enum EmailResponse implements Response {
     INVALID_VERIFICATION_CODE("invalid_verification_code", HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않습니다."),
     VERIFICATION_CODE_EXPIRED("verification_code_expired", HttpStatus.GONE, "인증 코드가 만료되었습니다."),
     TOO_MANY_REQUESTS("too_many_request", HttpStatus.TOO_MANY_REQUESTS, "인증 요청 횟수를 초과하였습니다."),
-    
+
     INVALID_EMAIL("invalid_email", HttpStatus.BAD_REQUEST, "유효하지 않은 이메일입니다."),
     INVALID_PURPOSE("invalid_purpose", HttpStatus.BAD_REQUEST, "유효하지 않은 인증 목적입니다."),
     EMAIL_SEND_FAILURE("mail_send_failure", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),

--- a/src/main/java/PoorToRich/PoorToRich/email/enums/EmailTemplateType.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/enums/EmailTemplateType.java
@@ -1,5 +1,6 @@
 package PoorToRich.PoorToRich.email.enums;
 
+import PoorToRich.PoorToRich.global.exceptions.BadRequestException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -34,6 +35,6 @@ public enum EmailTemplateType {
                 return templateType;
             }
         }
-        throw new RuntimeException("Need Exception Handler(invalid purpose)");
+        throw new BadRequestException(EmailResponse.INVALID_PURPOSE);
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
@@ -1,4 +1,33 @@
 package PoorToRich.PoorToRich.email.handler;
 
+import PoorToRich.PoorToRich.email.controller.MailController;
+import PoorToRich.PoorToRich.email.enums.EmailResponse;
+import PoorToRich.PoorToRich.global.response.BaseResponse;
+import PoorToRich.PoorToRich.global.response.Response;
+import jakarta.mail.internet.AddressException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mail.MailSendException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = {MailController.class})
 public class EmailExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse> handleEmailMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception) {
+        Response response = EmailResponse.getResponseByIdentifier(exception.getMessage());
+        return BaseResponse.toResponseEntity(response);
+    }
+
+    @ExceptionHandler(MailSendException.class)
+    public ResponseEntity<BaseResponse> handleMailSendException(MailSendException exception) {
+        return BaseResponse.toResponseEntity(EmailResponse.EMAIL_SEND_FAILURE);
+    }
+
+    @ExceptionHandler(AddressException.class)
+    public ResponseEntity<BaseResponse> handleAddressException(AddressException exception) {
+        return BaseResponse.toResponseEntity(EmailResponse.EMAIL_NOT_FOUND);
+    }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
@@ -1,0 +1,4 @@
+package PoorToRich.PoorToRich.email.handler;
+
+public class EmailExceptionHandler {
+}

--- a/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
@@ -17,7 +17,12 @@ public class EmailExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse> handleEmailMethodArgumentNotValidException(
             MethodArgumentNotValidException exception) {
-        Response response = EmailResponse.getResponseByIdentifier(exception.getMessage());
+        StringBuilder errorMessageBuilder = new StringBuilder();
+        exception.getBindingResult().getAllErrors().forEach(error -> {
+            errorMessageBuilder.append(error.getDefaultMessage()).append(" ");
+        });
+
+        Response response = EmailResponse.getResponseByIdentifier(errorMessageBuilder.toString());
         return BaseResponse.toResponseEntity(response);
     }
 

--- a/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
@@ -5,7 +5,8 @@ import PoorToRich.PoorToRich.email.enums.EmailResponse;
 import PoorToRich.PoorToRich.global.response.BaseResponse;
 import PoorToRich.PoorToRich.global.response.Response;
 import jakarta.mail.internet.AddressException;
-import java.util.Objects;
+import java.util.Optional;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.MailSendException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,8 +18,12 @@ public class EmailExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse> handleEmailMethodArgumentNotValidException(
-            MethodArgumentNotValidException exception) {
-        String errorMessage = Objects.requireNonNull(exception.getBindingResult().getFieldError()).getDefaultMessage();
+            MethodArgumentNotValidException exception
+    ) {
+        String errorMessage = Optional.ofNullable(exception.getBindingResult().getFieldError())
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse(EmailResponse.DEFAULT.getMessage());
+
         Response response = EmailResponse.getResponseByIdentifier(errorMessage);
         return BaseResponse.toResponseEntity(response);
     }

--- a/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/handler/EmailExceptionHandler.java
@@ -5,6 +5,7 @@ import PoorToRich.PoorToRich.email.enums.EmailResponse;
 import PoorToRich.PoorToRich.global.response.BaseResponse;
 import PoorToRich.PoorToRich.global.response.Response;
 import jakarta.mail.internet.AddressException;
+import java.util.Objects;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.MailSendException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,12 +18,8 @@ public class EmailExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse> handleEmailMethodArgumentNotValidException(
             MethodArgumentNotValidException exception) {
-        StringBuilder errorMessageBuilder = new StringBuilder();
-        exception.getBindingResult().getAllErrors().forEach(error -> {
-            errorMessageBuilder.append(error.getDefaultMessage()).append(" ");
-        });
-
-        Response response = EmailResponse.getResponseByIdentifier(errorMessageBuilder.toString());
+        String errorMessage = Objects.requireNonNull(exception.getBindingResult().getFieldError()).getDefaultMessage();
+        Response response = EmailResponse.getResponseByIdentifier(errorMessage);
         return BaseResponse.toResponseEntity(response);
     }
 

--- a/src/main/java/PoorToRich/PoorToRich/email/request/EmailVerificationRequest.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/request/EmailVerificationRequest.java
@@ -3,6 +3,7 @@ package PoorToRich.PoorToRich.email.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record EmailVerificationRequest(@Email @NotBlank String email, @NotBlank String purpose) {
-
+public record EmailVerificationRequest(
+        @NotBlank(message = "invalid_email") @Email(message = "invalid_email") String email,
+        @NotBlank(message = "invalid_purpose") String purpose) {
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/request/EmailVerificationRequest.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/request/EmailVerificationRequest.java
@@ -4,6 +4,11 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record EmailVerificationRequest(
-        @NotBlank(message = "invalid_email") @Email(message = "invalid_email") String email,
-        @NotBlank(message = "invalid_purpose") String purpose) {
+        @NotBlank(message = "invalid_email")
+        @Email(message = "invalid_email")
+        String email,
+
+        @NotBlank(message = "invalid_purpose")
+        String purpose
+) {
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/service/MailService.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/service/MailService.java
@@ -23,7 +23,8 @@ public class MailService {
         mailMessage.setTo(email);
         mailMessage.setSubject(emailTemplate.getSubject());
         mailMessage.setText(
-                String.format(EmailTemplateType.BODY_TEMPLATE, emailTemplate.getDescription(), verificationCode));
+                String.format(EmailTemplateType.BODY_TEMPLATE, emailTemplate.getDescription(), verificationCode)
+        );
 
         return mailMessage;
     }

--- a/src/main/java/PoorToRich/PoorToRich/email/service/MailService.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/service/MailService.java
@@ -30,10 +30,6 @@ public class MailService {
 
     public void sendEmail(String email, String purpose, String verificationCode) {
         SimpleMailMessage mailMessage = this.createMailMessage(email, purpose, verificationCode);
-        try {
-            emailSender.send(mailMessage);
-        } catch (Exception e) {
-            System.err.println(e.getMessage());
-        }
+        emailSender.send(mailMessage);
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/global/exceptions/AuthenticationException.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/exceptions/AuthenticationException.java
@@ -1,0 +1,16 @@
+package PoorToRich.PoorToRich.global.exceptions;
+
+import PoorToRich.PoorToRich.global.response.Response;
+import lombok.Getter;
+
+@Getter
+public class AuthenticationException extends RuntimeException {
+
+    private final Response response;
+
+    public AuthenticationException(Response response) {
+        super(response.getMessage());
+        this.response = response;
+    }
+
+}

--- a/src/main/java/PoorToRich/PoorToRich/global/exceptions/AuthorizationException.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/exceptions/AuthorizationException.java
@@ -1,0 +1,15 @@
+package PoorToRich.PoorToRich.global.exceptions;
+
+import PoorToRich.PoorToRich.global.response.Response;
+import lombok.Getter;
+
+@Getter
+public class AuthorizationException extends RuntimeException {
+
+    private final Response response;
+
+    public AuthorizationException(Response response) {
+        super(response.getMessage());
+        this.response = response;
+    }
+}

--- a/src/main/java/PoorToRich/PoorToRich/global/exceptions/BadRequestException.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/exceptions/BadRequestException.java
@@ -1,0 +1,16 @@
+package PoorToRich.PoorToRich.global.exceptions;
+
+import PoorToRich.PoorToRich.global.response.Response;
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+
+    private final Response response;
+
+    public BadRequestException(Response response) {
+        super(response.getMessage());
+        this.response = response;
+    }
+
+}

--- a/src/main/java/PoorToRich/PoorToRich/global/exceptions/ConflictException.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/exceptions/ConflictException.java
@@ -1,0 +1,16 @@
+package PoorToRich.PoorToRich.global.exceptions;
+
+import PoorToRich.PoorToRich.global.response.Response;
+import lombok.Getter;
+
+@Getter
+public class ConflictException extends RuntimeException {
+
+    private final Response response;
+
+    public ConflictException(Response response) {
+        super(response.getMessage());
+        this.response = response;
+    }
+
+}

--- a/src/main/java/PoorToRich/PoorToRich/global/exceptions/InternalServerErrorException.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/exceptions/InternalServerErrorException.java
@@ -1,0 +1,16 @@
+package PoorToRich.PoorToRich.global.exceptions;
+
+import PoorToRich.PoorToRich.global.response.Response;
+import lombok.Getter;
+
+@Getter
+public class InternalServerErrorException extends RuntimeException {
+
+    private final Response response;
+
+    public InternalServerErrorException(Response response) {
+        super(response.getMessage());
+        this.response = response;
+    }
+
+}

--- a/src/main/java/PoorToRich/PoorToRich/global/exceptions/NotFoundException.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/exceptions/NotFoundException.java
@@ -1,0 +1,15 @@
+package PoorToRich.PoorToRich.global.exceptions;
+
+import PoorToRich.PoorToRich.global.response.Response;
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+    private final Response response;
+
+    public NotFoundException(Response response) {
+        super(response.getMessage());
+        this.response = response;
+    }
+
+}

--- a/src/main/java/PoorToRich/PoorToRich/global/exceptions/UnauthorizedException.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/exceptions/UnauthorizedException.java
@@ -1,0 +1,16 @@
+package PoorToRich.PoorToRich.global.exceptions;
+
+import PoorToRich.PoorToRich.global.response.Response;
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedException extends RuntimeException {
+
+    private final Response response;
+
+    public UnauthorizedException(Response response) {
+        super(response.getMessage());
+        this.response = response;
+    }
+
+}

--- a/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,60 @@
+package PoorToRich.PoorToRich.global.handler;
+
+import PoorToRich.PoorToRich.global.exceptions.AuthenticationException;
+import PoorToRich.PoorToRich.global.exceptions.AuthorizationException;
+import PoorToRich.PoorToRich.global.exceptions.BadRequestException;
+import PoorToRich.PoorToRich.global.exceptions.ConflictException;
+import PoorToRich.PoorToRich.global.exceptions.InternalServerErrorException;
+import PoorToRich.PoorToRich.global.exceptions.NotFoundException;
+import PoorToRich.PoorToRich.global.exceptions.UnauthorizedException;
+import PoorToRich.PoorToRich.global.response.BaseResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception) {
+        return BaseResponse.toResponseEntity(HttpStatus.BAD_REQUEST, exception.getMessage());
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<BaseResponse> handleAuthorizationException(AuthorizationException exception) {
+        return BaseResponse.toResponseEntity(exception.getResponse());
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<BaseResponse> handleAuthenticationException(AuthenticationException exception) {
+        return BaseResponse.toResponseEntity(exception.getResponse());
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<BaseResponse> handleBadRequestException(BadRequestException exception) {
+        return BaseResponse.toResponseEntity(exception.getResponse());
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<BaseResponse> handleConflicException(ConflictException exception) {
+        return BaseResponse.toResponseEntity(exception.getResponse());
+    }
+
+    @ExceptionHandler(InternalServerErrorException.class)
+    public ResponseEntity<BaseResponse> handleInternalServerErrorException(InternalServerErrorException exception) {
+        return BaseResponse.toResponseEntity(exception.getResponse());
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<BaseResponse> handleNotFoundException(NotFoundException exception) {
+        return BaseResponse.toResponseEntity(exception.getResponse());
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<BaseResponse> handleUnauthorizedException(UnauthorizedException exception) {
+        return BaseResponse.toResponseEntity(exception.getResponse());
+    }
+}

--- a/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
@@ -8,7 +8,8 @@ import PoorToRich.PoorToRich.global.exceptions.InternalServerErrorException;
 import PoorToRich.PoorToRich.global.exceptions.NotFoundException;
 import PoorToRich.PoorToRich.global.exceptions.UnauthorizedException;
 import PoorToRich.PoorToRich.global.response.BaseResponse;
-import java.util.Objects;
+import java.util.Optional;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,10 +19,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final String DEFAULT_ERROR_MESSAGE = "잘못된 요청입니다.";
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse> handleMethodArgumentNotValidException(
-            MethodArgumentNotValidException exception) {
-        String errorMessage = Objects.requireNonNull(exception.getBindingResult().getFieldError()).getDefaultMessage();
+            MethodArgumentNotValidException exception
+    ) {
+        String errorMessage = Optional.ofNullable(exception.getBindingResult().getFieldError())
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse(DEFAULT_ERROR_MESSAGE);
+
         return BaseResponse.toResponseEntity(HttpStatus.BAD_REQUEST, errorMessage);
     }
 
@@ -41,7 +48,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ConflictException.class)
-    public ResponseEntity<BaseResponse> handleConflicException(ConflictException exception) {
+    public ResponseEntity<BaseResponse> handleConflictException(ConflictException exception) {
         return BaseResponse.toResponseEntity(exception.getResponse());
     }
 

--- a/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import PoorToRich.PoorToRich.global.exceptions.InternalServerErrorException;
 import PoorToRich.PoorToRich.global.exceptions.NotFoundException;
 import PoorToRich.PoorToRich.global.exceptions.UnauthorizedException;
 import PoorToRich.PoorToRich.global.response.BaseResponse;
+import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -20,11 +21,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse> handleMethodArgumentNotValidException(
             MethodArgumentNotValidException exception) {
-        StringBuilder errorMessageBuilder = new StringBuilder();
-        exception.getBindingResult().getAllErrors().forEach(error -> {
-            errorMessageBuilder.append(error.getDefaultMessage()).append(" ");
-        });
-        return BaseResponse.toResponseEntity(HttpStatus.BAD_REQUEST, errorMessageBuilder.toString());
+        String errorMessage = Objects.requireNonNull(exception.getBindingResult().getFieldError()).getDefaultMessage();
+        return BaseResponse.toResponseEntity(HttpStatus.BAD_REQUEST, errorMessage);
     }
 
     @ExceptionHandler(AuthorizationException.class)

--- a/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
@@ -20,7 +20,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse> handleMethodArgumentNotValidException(
             MethodArgumentNotValidException exception) {
-        return BaseResponse.toResponseEntity(HttpStatus.BAD_REQUEST, exception.getMessage());
+        StringBuilder errorMessageBuilder = new StringBuilder();
+        exception.getBindingResult().getAllErrors().forEach(error -> {
+            errorMessageBuilder.append(error.getDefaultMessage()).append(" ");
+        });
+        return BaseResponse.toResponseEntity(HttpStatus.BAD_REQUEST, errorMessageBuilder.toString());
     }
 
     @ExceptionHandler(AuthorizationException.class)

--- a/src/main/java/PoorToRich/PoorToRich/global/response/BaseResponse.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/response/BaseResponse.java
@@ -14,14 +14,18 @@ public class BaseResponse {
     private final String resultMessage;
 
     public static ResponseEntity<BaseResponse> toResponseEntity(Response response) {
-        BaseResponse baseResponse = BaseResponse.builder().resultCode(response.getHttpStatus().value())
-                .resultMessage(response.getMessage()).build();
+        BaseResponse baseResponse = BaseResponse.builder()
+                .resultCode(response.getHttpStatus().value())
+                .resultMessage(response.getMessage())
+                .build();
 
         return ResponseEntity.status(response.getHttpStatus()).body(baseResponse);
     }
 
     public static ResponseEntity<BaseResponse> toResponseEntity(HttpStatus httpStatus, String message) {
-        BaseResponse baseResponse = BaseResponse.builder().resultCode(httpStatus.value()).resultMessage(message)
+        BaseResponse baseResponse = BaseResponse.builder()
+                .resultCode(httpStatus.value())
+                .resultMessage(message)
                 .build();
 
         return ResponseEntity.status(httpStatus.value()).body(baseResponse);

--- a/src/main/java/PoorToRich/PoorToRich/global/response/BaseResponse.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/response/BaseResponse.java
@@ -2,6 +2,7 @@ package PoorToRich.PoorToRich.global.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @Builder
@@ -17,5 +18,12 @@ public class BaseResponse {
                 .resultMessage(response.getMessage()).build();
 
         return ResponseEntity.status(response.getHttpStatus()).body(baseResponse);
+    }
+
+    public static ResponseEntity<BaseResponse> toResponseEntity(HttpStatus httpStatus, String message) {
+        BaseResponse baseResponse = BaseResponse.builder().resultCode(httpStatus.value()).resultMessage(message)
+                .build();
+
+        return ResponseEntity.status(httpStatus.value()).body(baseResponse);
     }
 }


### PR DESCRIPTION
## #️⃣10

## 📝작업 내용

# 1. CustomException 설계
모든 컨트롤러에서 발생할 수 있는 예외를 처리하기 위해, `CustomException`을 생성했습니다. 이를 통해 예외 발생 시 적절한 `HttpStatus`와 함께 예외 메시지를 클라이언트에게 전달할 수 있도록 했습니다.
* `CustomeException`은 Unckecked Exception인 `RuntimeException`을 상속받아 발생 가능한 예외를 처리합니다.
* 각 `CustomException`은 `Response` 인터페이스를 멤버 변수로 가지고 있어, 예외에 대한 구체적인 응답을 정의할 수 있습니다.
* 이 예외들은 로직 구현 시 필요에 따라 직접 던질 수 있습니다.

# 2. EmailExceptionHandler 분리
`EmailController`에서만 발생할 수 있는 예외를 처리하기 위해 `EmailExceptionHandler`를 별도로 생성했습니다.
* __이유__: 전역 예외 핸들러에서 다룰 필요가 없는 `EmailController` 관련 예외들을 처리하기 위함입니다.
* 이를 통해 특정 컨트롤러에서 발생하는 예외를 구체적으로 다루고, 다른 컨트롤러에 영향을 미치지 않도록 분리할 수 있습니다.

# 3. `Valid` 애너테이션을 활용한 유효성 검사
`@Valid` 애너테이션을 사용하여 Request Body의 유효성 검사를 수행하고, `@NotBlank`, `@Email` 등에서 발생하는 예외는 `MethodArgumentNotValidException`을 던지게 됩니다.
* __고민__:  `MethodArgumentNotValidException`이 발생할 경우, 예외 메시지를 전달하는 `message` 필드를 사용하는 방식은 `EmailResponse`에 Bad Request에 해당하는 응답이 중복으로 존재해야하거나 삭제되어야 합니다. 이는 `EmailResponse` 가 무의미해집니다.
* __해결책__: `EmailResponse`에 각 응답을 식별할 수 있는 `identifier`를 추가하고, 예외 메시지의 `message` 필드에 해당 `identifier`를 작성하여, 이를 기반으로 `EmailResponse`를 찾아 반환하도록 구현했습니다.
* `GloabalExceptionHandler`도 `MethodArgumentNotValidException`을 처리합니다. 이는  API 구현 시 `예외 처리기를 분리할 필요가 없는 경우`에도 작동하게끔 하기 위하여 추가했습니다. 필요 없다면 삭제하도록 하겠습니다.
* 해당 해결 방법보다 혹시 더 좋은 방법이 생각난다면 피드백 부탁드리겠습니다.

## 1차 수정

* 메소드명 오탈자 수정
* `EmailResponse`의 enum value 재분류
* `stream` 구문 코드 리팩터링
* `Optional` 사용으로 `NullPointerException` 발생 가능성 방지

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d2a8b6ca-59bb-4996-a9aa-2642bc7b12d1)


