### PR TITLE
Feat/#18

### DIFF
--- a/src/main/java/PoorToRich/PoorToRich/email/config/emailConfig.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/config/emailConfig.java
@@ -1,6 +1,5 @@
 package PoorToRich.PoorToRich.email.config;
 
-import PoorToRich.PoorToRich.email.util.VerificationCodeGenerator;
 import java.util.Properties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -66,10 +65,5 @@ public class emailConfig {
         mailSender.setJavaMailProperties(getMailProperties());
 
         return mailSender;
-    }
-
-    @Bean
-    public VerificationCodeGenerator verificationCodeGenerator() {
-        return new VerificationCodeGenerator();
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/controller/MailController.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/controller/MailController.java
@@ -1,9 +1,10 @@
 package PoorToRich.PoorToRich.email.controller;
 
-import PoorToRich.PoorToRich.email.enums.EmailResponse;
 import PoorToRich.PoorToRich.email.facade.EmailFacade;
 import PoorToRich.PoorToRich.email.request.EmailVerificationRequest;
+import PoorToRich.PoorToRich.email.request.VerifyEmailCodeRequest;
 import PoorToRich.PoorToRich.global.response.BaseResponse;
+import PoorToRich.PoorToRich.global.response.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,15 @@ public class MailController {
     public ResponseEntity<BaseResponse> sendVerificationCode(
             @RequestBody @Valid EmailVerificationRequest emailVerificationRequest
     ) {
-        emailFacade.sendVerificationCode(emailVerificationRequest);
-        return BaseResponse.toResponseEntity(EmailResponse.VERIFICATION_CODE_SENT);
+        Response response = emailFacade.sendVerificationCode(emailVerificationRequest);
+        return BaseResponse.toResponseEntity(response);
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<BaseResponse> verifyEmailCode(
+            @RequestBody @Valid VerifyEmailCodeRequest verifyEmailCodeRequest
+    ) {
+        Response response = emailFacade.verifyEmailCode(verifyEmailCodeRequest);
+        return BaseResponse.toResponseEntity(response);
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
@@ -10,15 +10,23 @@ public enum EmailResponse implements Response {
     VERIFICATION_CODE_SENT("verification_code_sent", HttpStatus.OK, "인증 코드 전송 성공"),
     INVALID_PURPOSE("invalid_purpose", HttpStatus.BAD_REQUEST, "유효하지 않은 인증 목적입니다."),
     INVALID_VERIFICATION_CODE("invalid_verification_code", HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않습니다."),
-    VERIFICATION_CODE_EXPIRED("verification_code_expired", HttpStatus.GONE, "인증 코드가 만료되었습니다."),
-    TOO_MANY_REQUESTS("too_many_request", HttpStatus.TOO_MANY_REQUESTS, "인증 요청 횟수를 초과하였습니다."),
+    VERIFICATION_CODE_EXPIRED("verification_code_expired", HttpStatus.UNAUTHORIZED, "인증 코드가 만료되었습니다."),
+    TOO_MANY_VERIFICATION_REQUESTS("too_many_verification_request", HttpStatus.TOO_MANY_REQUESTS, "인증 요청 횟수를 초과하였습니다."),
+    VERIFICATION_CODE_REQUIRED("verification_code_required", HttpStatus.BAD_REQUEST, "인증 코드를 먼저 발급받으세요."),
 
     EMAIL_VERIFICATION_SUCCESS("email_verification_success", HttpStatus.OK, "이메일 인증 성공"),
     INVALID_EMAIL("invalid_email", HttpStatus.BAD_REQUEST, "유효하지 않은 이메일입니다."),
     EMAIL_SEND_FAILURE("mail_send_failure", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
     EMAIL_NOT_FOUND("mail_not_found", HttpStatus.NOT_FOUND, "존재하지 않는 이메일 주소입니다."),
+    TOO_MANY_REQUEST_MAIL("too_many_request_mail", HttpStatus.TOO_MANY_REQUESTS, "인증 요청 횟수를 초과하였습니다. 30분 후에 다시 시도하세요."),
 
-    DEFAULT("default_email_exception", HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러 발생");
+    TOO_MANY_CODE_RESEND_REQUESTS(
+            "too_many_code_resend_requests",
+            HttpStatus.TOO_MANY_REQUESTS,
+            "인증 코드 재발급 횟수를 초과하였습니다."
+    ),
+
+    DEFAULT("default_email_exception", HttpStatus.INTERNAL_SERVER_ERROR, "내부 로직 예외 발생");
 
     private final String identifier;
     private final HttpStatus httpStatus;

--- a/src/main/java/PoorToRich/PoorToRich/email/enums/EmailVerificationType.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/enums/EmailVerificationType.java
@@ -18,15 +18,15 @@ public enum EmailVerificationType {
 
     private static final String KEY_PATTERN = "%s:%s";
 
-    private final String key;
-    private final String minState;
-    private final String maxState;
+    private final String purpose;
+    private final String minStandard;
+    private final String maxStandard;
     private final Integer timeToLive;
     private final TimeUnit timeUnit;
 
-    public static EmailVerificationType getByKey(String key) {
+    public static EmailVerificationType getTypeByPurpose(String key) {
         for (EmailVerificationType type : EmailVerificationType.values()) {
-            if (type.key.equals(key)) {
+            if (type.purpose.equals(key)) {
                 return type;
             }
         }
@@ -34,6 +34,6 @@ public enum EmailVerificationType {
     }
 
     public String getKey(String mail) {
-        return String.format(KEY_PATTERN, mail, this.key);
+        return String.format(KEY_PATTERN, mail, this.purpose);
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/enums/EmailVerificationType.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/enums/EmailVerificationType.java
@@ -16,7 +16,7 @@ public enum EmailVerificationType {
     AUTH_BLOCK("block", "false", "true", 30, TimeUnit.MINUTES),
     EMAIL_VERIFICATION("verified", "false", "true", 1, TimeUnit.DAYS);
 
-    private static final String KEY_PATTERN = "%s:%s";
+    private static final String REDIS_KEY_PATTERN = "%s:%s";
 
     private final String purpose;
     private final String minStandard;
@@ -33,7 +33,7 @@ public enum EmailVerificationType {
         throw new BadRequestException(EmailResponse.INVALID_PURPOSE);
     }
 
-    public String getKey(String mail) {
-        return String.format(KEY_PATTERN, mail, this.purpose);
+    public String getRedisKey(String mail) {
+        return String.format(REDIS_KEY_PATTERN, mail, this.purpose);
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/enums/EmailVerificationType.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/enums/EmailVerificationType.java
@@ -1,0 +1,39 @@
+package PoorToRich.PoorToRich.email.enums;
+
+import PoorToRich.PoorToRich.global.exceptions.BadRequestException;
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EmailVerificationType {
+
+    REGISTER("register", null, null, 10, TimeUnit.MINUTES),
+    CHANGE_EMAIL("changeEmail", null, null, 10, TimeUnit.MINUTES),
+    AUTH_ATTEMPT("attempt", "0", "5", 30, TimeUnit.MINUTES),
+    CODE_RESEND("resend", "0", "3", 30, TimeUnit.MINUTES),
+    AUTH_BLOCK("block", "false", "true", 30, TimeUnit.MINUTES),
+    EMAIL_VERIFICATION("verified", "false", "true", 1, TimeUnit.DAYS);
+
+    private static final String KEY_PATTERN = "%s:%s";
+
+    private final String key;
+    private final String minState;
+    private final String maxState;
+    private final Integer timeToLive;
+    private final TimeUnit timeUnit;
+
+    public static EmailVerificationType getByKey(String key) {
+        for (EmailVerificationType type : EmailVerificationType.values()) {
+            if (type.key.equals(key)) {
+                return type;
+            }
+        }
+        throw new BadRequestException(EmailResponse.INVALID_PURPOSE);
+    }
+
+    public String getKey(String mail) {
+        return String.format(KEY_PATTERN, mail, this.key);
+    }
+}

--- a/src/main/java/PoorToRich/PoorToRich/email/facade/EmailFacade.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/facade/EmailFacade.java
@@ -1,9 +1,12 @@
 package PoorToRich.PoorToRich.email.facade;
 
+import PoorToRich.PoorToRich.email.enums.EmailResponse;
 import PoorToRich.PoorToRich.email.request.EmailVerificationRequest;
+import PoorToRich.PoorToRich.email.request.VerifyEmailCodeRequest;
 import PoorToRich.PoorToRich.email.service.EmailVerificationService;
 import PoorToRich.PoorToRich.email.service.MailService;
 import PoorToRich.PoorToRich.email.util.VerificationCodeGenerator;
+import PoorToRich.PoorToRich.global.response.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,13 +20,27 @@ public class EmailFacade {
     private final VerificationCodeGenerator codeGenerator;
 
     @Transactional
-    public void sendVerificationCode(EmailVerificationRequest emailVerificationRequest) {
-        String toEmail = emailVerificationRequest.email();
-        String verificationPurpose = emailVerificationRequest.purpose();
+    public Response sendVerificationCode(EmailVerificationRequest emailVerificationRequest) {
+        String toEmail = emailVerificationRequest.getEmail();
+        String verificationPurpose = emailVerificationRequest.getPurpose();
         String verificationCode = codeGenerator.generate();
 
-        verificationService.saveVerificationCode(toEmail, verificationPurpose, verificationCode);
+        verificationService.saveCode(toEmail, verificationPurpose, verificationCode);
         mailService.sendEmail(toEmail, verificationPurpose, verificationCode);
+
+        return EmailResponse.VERIFICATION_CODE_SENT;
     }
 
+
+    @Transactional
+    public Response verifyEmailCode(VerifyEmailCodeRequest verifyEmailCodeRequest) {
+        String toMail = verifyEmailCodeRequest.getEmail();
+        String verificationPurpose = verifyEmailCodeRequest.getPurpose();
+        String verificationCode = verifyEmailCodeRequest.getVerificationCode();
+
+        if (!verificationService.verifyCode(toMail, verificationPurpose, verificationCode)) {
+            return EmailResponse.INVALID_VERIFICATION_CODE;
+        }
+        return EmailResponse.EMAIL_VERIFICATION_SUCCESS;
+    }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/request/VerifyEmailCodeRequest.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/request/VerifyEmailCodeRequest.java
@@ -4,14 +4,19 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @AllArgsConstructor
-public class EmailVerificationRequest {
+public class VerifyEmailCodeRequest {
     @NotBlank(message = "invalid_email")
     @Email(message = "invalid_email")
     private String email;
 
     @NotBlank(message = "invalid_purpose")
     private String purpose;
+
+    @NotBlank(message = "invalid_verification_code")
+    @Length(min = 6, max = 6, message = "invalid_verification_code")
+    private String verificationCode;
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
@@ -29,7 +29,7 @@ public class EmailVerificationService {
         verificationPolicyManager.checkBeforeCodeSaved(mail);
 
         valueOps.set(
-                type.getKey(mail),
+                type.getRedisKey(mail),
                 code,
                 type.getTimeToLive(),
                 type.getTimeUnit()
@@ -52,7 +52,7 @@ public class EmailVerificationService {
 
     private void setVerifiedEmail(String mail) {
         valueOps.set(
-                EmailVerificationType.EMAIL_VERIFICATION.getKey(mail),
+                EmailVerificationType.EMAIL_VERIFICATION.getRedisKey(mail),
                 EmailVerificationType.EMAIL_VERIFICATION.getMaxStandard(),
                 EmailVerificationType.EMAIL_VERIFICATION.getTimeToLive(),
                 EmailVerificationType.EMAIL_VERIFICATION.getTimeUnit()
@@ -60,7 +60,7 @@ public class EmailVerificationService {
     }
 
     private String getCode(String mail, EmailVerificationType type) {
-        return valueOps.get(type.getKey(mail));
+        return valueOps.get(type.getRedisKey(mail));
     }
 
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
@@ -1,6 +1,9 @@
 package PoorToRich.PoorToRich.email.service;
 
-import java.util.concurrent.TimeUnit;
+import PoorToRich.PoorToRich.email.enums.EmailVerificationType;
+import PoorToRich.PoorToRich.email.util.EmailVerificationPolicyManager;
+import jakarta.annotation.PostConstruct;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -10,17 +13,53 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailVerificationService {
 
-    private static final String KEY_PATTERN = "%s:%s";
-    private static final Integer CODE_EXPIRATION_MINUTES = 10;
-
     private final StringRedisTemplate redisTemplate;
+    private ValueOperations<String, String> valueOps;
 
-    private String getKey(String mail, String purpose) {
-        return String.format(KEY_PATTERN, mail, purpose);
+    private final EmailVerificationPolicyManager verificationPolicyManager;
+
+    @PostConstruct
+    public void init() {
+        valueOps = redisTemplate.opsForValue();
     }
 
-    public void saveVerificationCode(String mail, String purpose, String code) {
-        ValueOperations<String, String> valueOps = redisTemplate.opsForValue();
-        valueOps.set(getKey(mail, purpose), code, CODE_EXPIRATION_MINUTES, TimeUnit.MINUTES);
+    public void saveCode(String mail, String purpose, String code) {
+        EmailVerificationType type = EmailVerificationType.getByKey(purpose);
+
+        verificationPolicyManager.checkBeforeCodeSaved(mail);
+
+        valueOps.set(
+                type.getKey(mail),
+                code,
+                type.getTimeToLive(),
+                type.getTimeUnit()
+        );
     }
+
+    public boolean verifyCode(String mail, String purpose, String code) {
+        EmailVerificationType type = EmailVerificationType.getByKey(purpose);
+
+        verificationPolicyManager.checkBeforeVerified(mail, purpose);
+
+        boolean isVerified = Objects.equals(getCode(mail, type), code);
+        if (isVerified) {
+            setVerifiedEmail(mail);
+        }
+
+        return isVerified;
+    }
+
+    public void setVerifiedEmail(String mail) {
+        valueOps.set(
+                EmailVerificationType.EMAIL_VERIFICATION.getKey(mail),
+                EmailVerificationType.EMAIL_VERIFICATION.getMaxState(),
+                EmailVerificationType.EMAIL_VERIFICATION.getTimeToLive(),
+                EmailVerificationType.EMAIL_VERIFICATION.getTimeUnit()
+        );
+    }
+
+    private String getCode(String mail, EmailVerificationType type) {
+        return valueOps.get(type.getKey(mail));
+    }
+
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
@@ -24,7 +24,7 @@ public class EmailVerificationService {
     }
 
     public void saveCode(String mail, String purpose, String code) {
-        EmailVerificationType type = EmailVerificationType.getByKey(purpose);
+        EmailVerificationType type = EmailVerificationType.getTypeByPurpose(purpose);
 
         verificationPolicyManager.checkBeforeCodeSaved(mail);
 
@@ -37,7 +37,7 @@ public class EmailVerificationService {
     }
 
     public boolean verifyCode(String mail, String purpose, String code) {
-        EmailVerificationType type = EmailVerificationType.getByKey(purpose);
+        EmailVerificationType type = EmailVerificationType.getTypeByPurpose(purpose);
 
         verificationPolicyManager.checkBeforeVerified(mail, purpose);
 
@@ -50,10 +50,10 @@ public class EmailVerificationService {
         return isVerified;
     }
 
-    public void setVerifiedEmail(String mail) {
+    private void setVerifiedEmail(String mail) {
         valueOps.set(
                 EmailVerificationType.EMAIL_VERIFICATION.getKey(mail),
-                EmailVerificationType.EMAIL_VERIFICATION.getMaxState(),
+                EmailVerificationType.EMAIL_VERIFICATION.getMaxStandard(),
                 EmailVerificationType.EMAIL_VERIFICATION.getTimeToLive(),
                 EmailVerificationType.EMAIL_VERIFICATION.getTimeUnit()
         );

--- a/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
@@ -43,6 +43,7 @@ public class EmailVerificationService {
 
         boolean isVerified = Objects.equals(getCode(mail, type), code);
         if (isVerified) {
+            verificationPolicyManager.checkAfterVerifiedSuccess(mail, purpose);
             setVerifiedEmail(mail);
         }
 

--- a/src/main/java/PoorToRich/PoorToRich/email/util/EmailVerificationPolicyManager.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/util/EmailVerificationPolicyManager.java
@@ -50,19 +50,19 @@ public class EmailVerificationPolicyManager {
     }
 
     private void checkBlockPolicy(String mail) {
-        if (Boolean.parseBoolean(valueOps.get(EmailVerificationType.AUTH_BLOCK.getKey(mail)))) {
+        if (Boolean.parseBoolean(valueOps.get(EmailVerificationType.AUTH_BLOCK.getRedisKey(mail)))) {
             throw new TooManyRequestException(EmailResponse.TOO_MANY_REQUEST_MAIL);
         }
     }
 
     private void checkFirstRequest(String mail, EmailVerificationType type) {
-        if (valueOps.get(type.getKey(mail)) == null) {
+        if (valueOps.get(type.getRedisKey(mail)) == null) {
             setPolicy(mail, type, type.getMinStandard());
         }
     }
 
     private void checkExceedCodeResend(String mail) {
-        String codeResendAttempts = valueOps.get(EmailVerificationType.CODE_RESEND.getKey(mail));
+        String codeResendAttempts = valueOps.get(EmailVerificationType.CODE_RESEND.getRedisKey(mail));
         if (EmailVerificationType.CODE_RESEND.getMaxStandard().equals(codeResendAttempts)) {
             deleteAllPolicy(mail);
             setBlockPolicy(mail);
@@ -71,7 +71,7 @@ public class EmailVerificationPolicyManager {
     }
 
     private void checkExceedVerifiedCode(String mail) {
-        String authAttempts = valueOps.get(EmailVerificationType.AUTH_ATTEMPT.getKey(mail));
+        String authAttempts = valueOps.get(EmailVerificationType.AUTH_ATTEMPT.getRedisKey(mail));
 
         if (EmailVerificationType.AUTH_ATTEMPT.getMaxStandard().equals(authAttempts)) {
             deleteAllPolicy(mail);
@@ -81,7 +81,7 @@ public class EmailVerificationPolicyManager {
     }
 
     private void increaseAttempts(String mail, EmailVerificationType type) {
-        String attempts = valueOps.get(type.getKey(mail));
+        String attempts = valueOps.get(type.getRedisKey(mail));
 
         if (attempts != null) {
             int newAttempts = Integer.parseInt(attempts);
@@ -90,7 +90,7 @@ public class EmailVerificationPolicyManager {
     }
 
     private void checkCodeIssued(String mail) {
-        String isVerified = valueOps.get(EmailVerificationType.EMAIL_VERIFICATION.getKey(mail));
+        String isVerified = valueOps.get(EmailVerificationType.EMAIL_VERIFICATION.getRedisKey(mail));
 
         if (isVerified == null) {
             throw new BadRequestException(EmailResponse.VERIFICATION_CODE_REQUIRED);
@@ -98,7 +98,7 @@ public class EmailVerificationPolicyManager {
     }
 
     private void checkCodeExpiration(String mail, String purpose) {
-        String verificationCode = valueOps.get(EmailVerificationType.getTypeByPurpose(purpose).getKey(mail));
+        String verificationCode = valueOps.get(EmailVerificationType.getTypeByPurpose(purpose).getRedisKey(mail));
 
         if (verificationCode == null) {
             throw new UnauthorizedException(EmailResponse.VERIFICATION_CODE_EXPIRED);
@@ -111,7 +111,7 @@ public class EmailVerificationPolicyManager {
 
     private void setPolicy(String mail, EmailVerificationType type, String value) {
         valueOps.set(
-                type.getKey(mail),
+                type.getRedisKey(mail),
                 value,
                 type.getTimeToLive(),
                 type.getTimeUnit()
@@ -126,6 +126,6 @@ public class EmailVerificationPolicyManager {
     }
 
     private void deletePolicy(String mail, EmailVerificationType type) {
-        valueOps.getOperations().delete(type.getKey(mail));
+        valueOps.getOperations().delete(type.getRedisKey(mail));
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/util/EmailVerificationPolicyManager.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/util/EmailVerificationPolicyManager.java
@@ -1,0 +1,117 @@
+package PoorToRich.PoorToRich.email.util;
+
+import PoorToRich.PoorToRich.email.enums.EmailResponse;
+import PoorToRich.PoorToRich.email.enums.EmailVerificationType;
+import PoorToRich.PoorToRich.global.exceptions.TooManyRequestException;
+import PoorToRich.PoorToRich.global.exceptions.UnauthorizedException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationPolicyManager {
+
+    private final StringRedisTemplate redisTemplate;
+    private ValueOperations<String, String> valueOps;
+
+    @PostConstruct
+    public void init() {
+        valueOps = redisTemplate.opsForValue();
+    }
+
+    public void checkBeforeCodeSaved(String mail) {
+        checkBlockPolicy(mail);
+        checkFirstRequest(mail, EmailVerificationType.CODE_RESEND);
+        checkExceedCodeResend(mail);
+        increaseAttempts(mail, EmailVerificationType.CODE_RESEND);
+        setPolicy(
+                mail,
+                EmailVerificationType.EMAIL_VERIFICATION,
+                EmailVerificationType.EMAIL_VERIFICATION.getMinState()
+        );
+    }
+
+    public void checkBeforeVerified(String mail, String purpose) {
+        checkBlockPolicy(mail);
+        checkCodeExpiration(mail, purpose);
+        checkFirstRequest(mail, EmailVerificationType.AUTH_ATTEMPT);
+        checkExceedVerifiedCode(mail);
+        increaseAttempts(mail, EmailVerificationType.AUTH_ATTEMPT);
+    }
+
+
+    private void checkFirstRequest(String mail, EmailVerificationType type) {
+        if (valueOps.get(type.getKey(mail)) == null) {
+            setPolicy(mail, type, type.getMinState());
+        }
+    }
+
+    private void checkCodeExpiration(String mail, String purpose) {
+        String isVerified = valueOps.get(EmailVerificationType.EMAIL_VERIFICATION.getKey(mail));
+        String verificationCode = valueOps.get(EmailVerificationType.getByKey(purpose).getKey(mail));
+
+        if (isVerified != null && !Boolean.parseBoolean(isVerified) && verificationCode == null) {
+            throw new UnauthorizedException(EmailResponse.VERIFICATION_CODE_EXPIRED);
+        }
+    }
+
+    private void checkExceedVerifiedCode(String mail) {
+        String authAttempts = valueOps.get(EmailVerificationType.AUTH_ATTEMPT.getKey(mail));
+
+        if (EmailVerificationType.AUTH_ATTEMPT.getMaxState().equals(authAttempts)) {
+            deleteAllPolicy(mail);
+            setBlockPolicy(mail);
+            throw new TooManyRequestException(EmailResponse.TOO_MANY_VERIFICATION_REQUESTS);
+        }
+    }
+
+    private void checkExceedCodeResend(String mail) {
+        String codeResendAttempts = valueOps.get(EmailVerificationType.CODE_RESEND.getKey(mail));
+        if (EmailVerificationType.CODE_RESEND.getMaxState().equals(codeResendAttempts)) {
+            deleteAllPolicy(mail);
+            setBlockPolicy(mail);
+            throw new TooManyRequestException(EmailResponse.TOO_MANY_CODE_RESEND_REQUESTS);
+        }
+    }
+
+    private void checkBlockPolicy(String mail) {
+        if (Boolean.parseBoolean(valueOps.get(EmailVerificationType.AUTH_BLOCK.getKey(mail)))) {
+            throw new TooManyRequestException(EmailResponse.TOO_MANY_REQUEST_MAIL);
+        }
+    }
+
+    private void increaseAttempts(String mail, EmailVerificationType type) {
+        String attempts = valueOps.get(type.getKey(mail));
+
+        if (attempts != null) {
+            int newAttempts = Integer.parseInt(attempts);
+            setPolicy(mail, type, String.valueOf(++newAttempts));
+        }
+    }
+
+    private void setBlockPolicy(String mail) {
+        setPolicy(mail, EmailVerificationType.AUTH_BLOCK, EmailVerificationType.AUTH_BLOCK.getMaxState());
+    }
+
+    private void setPolicy(String mail, EmailVerificationType type, String value) {
+        valueOps.set(
+                type.getKey(mail),
+                value,
+                type.getTimeToLive(),
+                type.getTimeUnit()
+        );
+    }
+
+    private void deleteAllPolicy(String mail) {
+        deletePolicy(mail, EmailVerificationType.AUTH_BLOCK);
+        deletePolicy(mail, EmailVerificationType.AUTH_ATTEMPT);
+        deletePolicy(mail, EmailVerificationType.CODE_RESEND);
+    }
+
+    private void deletePolicy(String mail, EmailVerificationType type) {
+        valueOps.getOperations().delete(type.getKey(mail));
+    }
+}

--- a/src/main/java/PoorToRich/PoorToRich/email/util/VerificationCodeGenerator.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/util/VerificationCodeGenerator.java
@@ -2,7 +2,9 @@ package PoorToRich.PoorToRich.email.util;
 
 import java.security.SecureRandom;
 import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
 @NoArgsConstructor
 public class VerificationCodeGenerator {
 

--- a/src/main/java/PoorToRich/PoorToRich/global/exceptions/TooManyRequestException.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/exceptions/TooManyRequestException.java
@@ -1,0 +1,15 @@
+package PoorToRich.PoorToRich.global.exceptions;
+
+import PoorToRich.PoorToRich.global.response.Response;
+import lombok.Getter;
+
+@Getter
+public class TooManyRequestException extends RuntimeException {
+
+    Response response;
+
+    public TooManyRequestException(Response response) {
+        super(response.getMessage());
+        this.response = response;
+    }
+}

--- a/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
@@ -69,7 +69,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(TooManyRequestException.class)
-    public ResponseEntity<BaseResponse> handleTooManyRequest(TooManyRequestException exception) {
+    public ResponseEntity<BaseResponse> handleTooManyRequestException(TooManyRequestException exception) {
         return BaseResponse.toResponseEntity(exception.getResponse());
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/PoorToRich/PoorToRich/global/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import PoorToRich.PoorToRich.global.exceptions.BadRequestException;
 import PoorToRich.PoorToRich.global.exceptions.ConflictException;
 import PoorToRich.PoorToRich.global.exceptions.InternalServerErrorException;
 import PoorToRich.PoorToRich.global.exceptions.NotFoundException;
+import PoorToRich.PoorToRich.global.exceptions.TooManyRequestException;
 import PoorToRich.PoorToRich.global.exceptions.UnauthorizedException;
 import PoorToRich.PoorToRich.global.response.BaseResponse;
 import java.util.Optional;
@@ -64,6 +65,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<BaseResponse> handleUnauthorizedException(UnauthorizedException exception) {
+        return BaseResponse.toResponseEntity(exception.getResponse());
+    }
+
+    @ExceptionHandler(TooManyRequestException.class)
+    public ResponseEntity<BaseResponse> handleTooManyRequest(TooManyRequestException exception) {
         return BaseResponse.toResponseEntity(exception.getResponse());
     }
 }


### PR DESCRIPTION
## #️⃣18

## 📝작업 내용

# 1. `EmailVerificationType` 설계
`EmailVerificationService`에서 정적 변수로 레디스에 저장할 데이터 폼을 관리했으나, 인증 코드 검증을 구현하면서 보안상 **인증 횟수 제한**, **코드 재발급 횟수 제한**, **차단 정책**이 필요해졌습니다.  
레디스 데이터 폼 관련 정적 변수가 많아져 가독성이 떨어졌기 때문에 `EmailVerificationService`에서 분리하여 `EmailVerificationType`을 설계했습니다.

## 필드
| 필드명         | 설명 |
|---------------|------|
| `purpose`        | 인증 목적 (`{mail}:{key}` 패턴으로 저장) |
| `minState`   | 최소 기준 값 |
| `maxState`   | 최대 기준 값 |
| `timeToLive` | 인증 유형의 만료 시간 (TTL) |
| `timeUnit`   | TTL의 단위 (`TimeUnit.MINUTES`, `TimeUnit.DAYS` 등) |

## 인증 유형
| 유형               | 설명 |
|-------------------|------|
| `REGISTER`       | 신규 회원가입 |
| `CHANGE_EMAIL`   | 이메일 변경 요청 |
| `AUTH_ATTEMPT`   | 인증 시도 횟수 제한 (최소 `0`, 최대 `5`) |
| `CODE_RESEND`    | 인증 코드 발급 제한 (최소 `0`, 최대 `3`) |
| `AUTH_BLOCK`     | 일정 횟수 초과 시 차단 (`false -> true`) |
| `EMAIL_VERIFICATION` | 이메일 인증 완료 여부 (`false -> true`) |

---

# 2. `EmailVerificationPolicyManager` 설계
**인증 횟수 제한, 코드 발급 횟수 제한, 차단 정책**을 관리하는 유틸성 객체입니다.  
크게 `코드 저장 전`, `인증 검증 전`, `인증 검증 후` 정책 위배 검사 및 관리 기능을 제공합니다.

> `EmailVerificationService`는 인증 코드를 저장, 검증하는 기능을 담당하므로,  
> **단일 책임 원칙(SRP, Single Responsibility Principle)**에 따라 인증 정책 관리를 별도로 분리했습니다.

## 주요 기능
### 1) 차단 및 정책 검사
- __checkBlockPolicy(String mail)__ 
  - `AUTH_BLOCK` 값이 `"true"`면 차단된 것으로 판단하여 예외 발생
  - 값이 `"false"`, `null`이면 정상 처리 (`Boolean.parseBoolean()` 활용)
  
- __checkFirstRequest(String mail, EmailVerificationType type)__
  - 인증 코드 검증 및 발급의 첫 요청 여부 확인
  - `mail` 관련 정책이 설정되지 않았다면 `minState`로 초기화

### 2) 인증 코드 정책 검사
- __checkExceedCodeResend(String mail)__
  - 코드 재발급 횟수 제한 초과 여부 검사 (`CODE_RESEND`)
  - 초과 시 모든 정책 삭제 후 차단, 예외 응답 반환
  
- __increaseAttempts(String mail, EmailVerificationType type)__
  - 코드 발급 횟수 또는 검증 횟수를 1 증가
  - 레디스에 해당 상태값이 없을 경우 대비하여 `null` 체크 후 증가
  
- __checkCodeIssued(String mail)__
  - 인증 코드가 발급되지 않은 경우 예외 발생 (`VERIFICATION_CODE_REQUIRED`)
  
- __checkCodeExpiration(String mail, String purpose)__
  - 특정 `purpose`의 인증 코드가 만료되었는지 확인
  - `checkCodeIssued()` 이후 실행되어야 하며, 값이 `null`이면 만료된 것으로 판단

### 3) 정책 삭제 및 차단 설정
- __deleteAllPolicy(String mail)__
  - 인증 정책 위반 또는 인증 성공 시 모든 정책 삭제  
  - 데이터 오염 방지를 위해 차단 전 또는 인증 성공 전 호출 필수

- __setBlockPolicy(String mail)__
  - `AUTH_BLOCK` 값을 `true`로 설정하여 차단
 
# 추가 사항

## `EmailResponse`
- 이메일 인증 정책 관련 `enum` 추가

## `TooManyRequestException`
- 이메일 인증 횟수 제한 초과 시 발생하는 `CustomException` 추가

## `GlobalExceptionHandler`
- `TooManyRequestException`을 처리할 `handler method` 추가

---

# 향후 계획

## 남은 인증 횟수 조회 API
남아있는 `검증`, `발급` 횟수를 인증 정책 위반 시 클라이언트에게 전달하려 했으나,  
코드 로직상 가독성이 저하될 우려가 있어 **별도의 조회 API**를 분류하여 명세서를 작성한 후 구현할 예정입니다.

---

# 1차 수정

* `EmailVerificationService`의 `setVerifiedEmail()` 메소드 `public -> private`으로 수정
* `EmailVerificationType`의 멤버 변수, 메소드 리네이밍
  * `key` -> `purpose`
    * **인증 목적**임을 강조
  * `minState`, `maxState` -> `minStandard`, `maxStandard`
    * **기준**을 강조
  *  'getByKey()`에서 `getTypeByPurpose()`
    * 멤버 변수 값이 아닌 열거형의 `Type`을 반환함을 강조
 * `EmailVerificationPolicyManager` 메소드 재배치

# 2차 수정
* `EmailVerificationType` 변수, 메소드 리네이밍
  * `getKey()` -> `getRedisKey()`
  * `KEY_PATTERN` -> `REDIS_KEY_PATTERN` 
 
# 💬 리뷰 요청 사항 (선택)

- `EmailVerificationType` 메소드명 적절성
- `minState`, `maxState` 변수명 가독성 및 의미 전달력
- 이메일 인증 목적 변수 `purpose`를 `key`와 비교하여 `enum`을 구하는 로직  
  - `enum` 필드 `key`를 `purpose`로 변경하는 것이 타당한가?
- 기타 코드 컨벤션, 변수명 및 메소드명 적절성

---

## 📸 스크린샷 (선택)
(필요시 스크린샷을 추가하세요)
