### PR TITLE
feat: 인증 코드 재발급 횟수 조회 API

### DIFF
--- a/src/main/java/PoorToRich/PoorToRich/email/controller/MailController.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/controller/MailController.java
@@ -3,15 +3,20 @@ package PoorToRich.PoorToRich.email.controller;
 import PoorToRich.PoorToRich.email.facade.EmailFacade;
 import PoorToRich.PoorToRich.email.request.EmailVerificationRequest;
 import PoorToRich.PoorToRich.email.request.VerifyEmailCodeRequest;
+import PoorToRich.PoorToRich.email.response.VerificationResendCodeStatusResponse;
 import PoorToRich.PoorToRich.global.response.BaseResponse;
 import PoorToRich.PoorToRich.global.response.Response;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -36,5 +41,17 @@ public class MailController {
     ) {
         Response response = emailFacade.verifyEmailCode(verifyEmailCodeRequest);
         return BaseResponse.toResponseEntity(response);
+    }
+
+    @GetMapping("/send")
+    public ResponseEntity<VerificationResendCodeStatusResponse> getResendStatus(
+            @RequestParam
+            @Valid
+            @Email(message = "invalid_mail")
+            @NotBlank(message = "invalid_mail")
+            String email
+    ) {
+        VerificationResendCodeStatusResponse verificationCodeStatus = emailFacade.getResendStatus(email);
+        return ResponseEntity.ok(verificationCodeStatus);
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/enums/EmailResponse.java
@@ -15,7 +15,7 @@ public enum EmailResponse implements Response {
     VERIFICATION_CODE_REQUIRED("verification_code_required", HttpStatus.BAD_REQUEST, "인증 코드를 먼저 발급받으세요."),
 
     EMAIL_VERIFICATION_SUCCESS("email_verification_success", HttpStatus.OK, "이메일 인증 성공"),
-    INVALID_EMAIL("invalid_email", HttpStatus.BAD_REQUEST, "유효하지 않은 이메일입니다."),
+    INVALID_EMAIL("invalid_email", HttpStatus.BAD_REQUEST, "잘못된 이메일 형식입니다."),
     EMAIL_SEND_FAILURE("mail_send_failure", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
     EMAIL_NOT_FOUND("mail_not_found", HttpStatus.NOT_FOUND, "존재하지 않는 이메일 주소입니다."),
     TOO_MANY_REQUEST_MAIL("too_many_request_mail", HttpStatus.TOO_MANY_REQUESTS, "인증 요청 횟수를 초과하였습니다. 30분 후에 다시 시도하세요."),

--- a/src/main/java/PoorToRich/PoorToRich/email/facade/EmailFacade.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/facade/EmailFacade.java
@@ -1,8 +1,10 @@
 package PoorToRich.PoorToRich.email.facade;
 
 import PoorToRich.PoorToRich.email.enums.EmailResponse;
+import PoorToRich.PoorToRich.email.enums.EmailVerificationType;
 import PoorToRich.PoorToRich.email.request.EmailVerificationRequest;
 import PoorToRich.PoorToRich.email.request.VerifyEmailCodeRequest;
+import PoorToRich.PoorToRich.email.response.VerificationResendCodeStatusResponse;
 import PoorToRich.PoorToRich.email.service.EmailVerificationService;
 import PoorToRich.PoorToRich.email.service.MailService;
 import PoorToRich.PoorToRich.email.util.VerificationCodeGenerator;
@@ -42,5 +44,11 @@ public class EmailFacade {
             return EmailResponse.INVALID_VERIFICATION_CODE;
         }
         return EmailResponse.EMAIL_VERIFICATION_SUCCESS;
+    }
+
+    public VerificationResendCodeStatusResponse getResendStatus(String mail) {
+        Integer remainAttempts = verificationService
+                .getRemainingAttemptsByVerificationType(mail, EmailVerificationType.CODE_RESEND);
+        return new VerificationResendCodeStatusResponse(remainAttempts);
     }
 }

--- a/src/main/java/PoorToRich/PoorToRich/email/response/VerificationResendCodeStatusResponse.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/response/VerificationResendCodeStatusResponse.java
@@ -1,0 +1,17 @@
+package PoorToRich.PoorToRich.email.response;
+
+import lombok.Data;
+
+@Data
+public class VerificationResendCodeStatusResponse {
+
+    public static final String messageForm = "인증 코드 재발급 횟수 %d회 남았습니다.";
+
+    private final Integer remainAttempts;
+    private final String message;
+
+    public VerificationResendCodeStatusResponse(Integer remainAttempts) {
+        this.remainAttempts = remainAttempts;
+        this.message = String.format(messageForm, remainAttempts);
+    }
+}

--- a/src/main/java/PoorToRich/PoorToRich/email/response/VerificationResendCodeStatusResponse.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/response/VerificationResendCodeStatusResponse.java
@@ -10,7 +10,7 @@ public class VerificationResendCodeStatusResponse {
     private final Integer remainAttempts;
     private final String message;
 
-    public VerificationResendCodeStatusResponse(Integer remainAttempts) {
+    public VerificationResendCodeStatusResponse(int remainAttempts) {
         this.remainAttempts = remainAttempts;
         this.message = String.format(messageForm, remainAttempts);
     }

--- a/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
@@ -64,7 +64,7 @@ public class EmailVerificationService {
         return valueOps.get(type.getRedisKey(mail));
     }
 
-    public Integer getRemainingAttemptsByVerificationType(String mail, EmailVerificationType verificationType) {
+    public int getRemainingAttemptsByVerificationType(String mail, EmailVerificationType verificationType) {
         int attemptCount = Integer.parseInt(
                 Optional.ofNullable(valueOps.get(verificationType.getRedisKey(mail)))
                         .orElse(verificationType.getMinStandard())

--- a/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
+++ b/src/main/java/PoorToRich/PoorToRich/email/service/EmailVerificationService.java
@@ -4,6 +4,7 @@ import PoorToRich.PoorToRich.email.enums.EmailVerificationType;
 import PoorToRich.PoorToRich.email.util.EmailVerificationPolicyManager;
 import jakarta.annotation.PostConstruct;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -63,4 +64,12 @@ public class EmailVerificationService {
         return valueOps.get(type.getRedisKey(mail));
     }
 
+    public Integer getRemainingAttemptsByVerificationType(String mail, EmailVerificationType verificationType) {
+        int attemptCount = Integer.parseInt(
+                Optional.ofNullable(valueOps.get(verificationType.getRedisKey(mail)))
+                        .orElse(verificationType.getMinStandard())
+        );
+
+        return Integer.parseInt(verificationType.getMaxStandard()) - attemptCount;
+    }
 }


### PR DESCRIPTION
남은 인증 코드 재발급 횟수를 조회 API

## #️⃣23

 ## 📝작업 내용
 
## 작업 내용

### 1. 인증 코드 재발급 횟수 조회 기능 추가
- `email`을 통해 남은 인증 코드 재발급 횟수를 조회하는 기능을 추가하였습니다.
  - 만약 인증 코드를 **발급받지 않았다면** 최대 횟수를 반환하고,
  - 발급받았다면 **최대 횟수에서 차감된 횟수**를 반환합니다.

---

## 발견된 문제

### 1. `ConstraintViolationException` 발생 문제
- `@RequestParam`을 사용하여 `email`을 받아오고, 해당 값을 검증하기 위해 `@Valid` 애너테이션을 사용했으나, 예상했던 `MethodArgumentNotValidException` 대신 `ConstraintViolationException`이 발생했습니다.
- **원인**: `@RequestParam`과 `@PathVariable`에서 발생하는 검증 오류는 `ConstraintViolationException`을 발생시키므로, 이를 처리하기 위한 **`ExceptionHandler` 추가**가 필요합니다.

### 2. `@Email` 검증의 정확성 문제
- `@Email` 애너테이션의 검증이 일부 이메일 형식에서 제대로 동작하지 않는 문제가 발생했습니다.
  - **예시**:
    - `[O] example@ex.com`
    - `[O] example@dsad`
    - `[X] example@`
    - `[X] example`
- `@Email` 검증이 `example@dsad`와 같은 이메일을 **허용**하는 문제 발견.  
  → `@Email`의 기본 검증 규칙이 너무 느슨하여 예상하지 못한 이메일을 허용함.

발견된 문제의 경우 차후 해결 예정

 ### 스크린샷 (선택)
 
![codeResendStatusSuccess](https://github.com/user-attachments/assets/abc01383-a321-4546-b09f-01136a04f39e)

 ## 💬리뷰 요구사항(선택)
 
