### PR TITLE
[#30] 카테고리 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/PoorToRichApplication.java
+++ b/src/main/java/com/poortorich/PoorToRichApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
-@EntityScan(basePackages = {"PoorToRich.PoorToRich.category.entity"})
+@EntityScan(basePackages = {"com.poortorich.category.entity"})
 public class PoorToRichApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/poortorich/category/controller/CategoryController.java
+++ b/src/main/java/com/poortorich/category/controller/CategoryController.java
@@ -1,7 +1,8 @@
 package com.poortorich.category.controller;
 
 import com.poortorich.category.entity.CategoryType;
-import com.poortorich.category.request.CustomCategoryRequest;
+import com.poortorich.category.request.CategoryInfoRequest;
+import com.poortorich.category.response.CategoryInfoResponse;
 import com.poortorich.category.response.CustomCategoriesResponse;
 import com.poortorich.category.response.CustomCategoryResponse;
 import com.poortorich.category.response.DefaultCategoriesResponse;
@@ -12,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,12 +57,17 @@ public class CategoryController {
     }
 
     @PostMapping("/expense")
-    public ResponseEntity<BaseResponse> createExpenseCategory(@RequestBody @Valid CustomCategoryRequest categoryRequest) {
+    public ResponseEntity<BaseResponse> createExpenseCategory(@RequestBody @Valid CategoryInfoRequest categoryRequest) {
         return BaseResponse.toResponseEntity(categoryService.createCategory(categoryRequest, CategoryType.CUSTOM_EXPENSE));
     }
 
     @PostMapping("/income")
-    public ResponseEntity<BaseResponse> createIncomeCategory(@RequestBody @Valid CustomCategoryRequest categoryRequest) {
+    public ResponseEntity<BaseResponse> createIncomeCategory(@RequestBody @Valid CategoryInfoRequest categoryRequest) {
         return BaseResponse.toResponseEntity(categoryService.createCategory(categoryRequest, CategoryType.CUSTOM_INCOME));
+    }
+
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<CategoryInfoResponse> getCategory(@PathVariable Long categoryId) {
+        return ResponseEntity.ok(categoryService.getCategory(categoryId));
     }
 }

--- a/src/main/java/com/poortorich/category/repository/CategoryRepository.java
+++ b/src/main/java/com/poortorich/category/repository/CategoryRepository.java
@@ -4,8 +4,6 @@ import com.poortorich.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigInteger;
-
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 

--- a/src/main/java/com/poortorich/category/repository/CategoryRepository.java
+++ b/src/main/java/com/poortorich/category/repository/CategoryRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.math.BigInteger;
 
 @Repository
-public interface CategoryRepository extends JpaRepository<Category, BigInteger> {
+public interface CategoryRepository extends JpaRepository<Category, Long> {
 
 }

--- a/src/main/java/com/poortorich/category/request/CategoryInfoRequest.java
+++ b/src/main/java/com/poortorich/category/request/CategoryInfoRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CustomCategoryRequest {
+public class CategoryInfoRequest {
 
     @NotBlank
     private String name;

--- a/src/main/java/com/poortorich/category/response/CategoryInfoResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoryInfoResponse.java
@@ -1,0 +1,16 @@
+package com.poortorich.category.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryInfoResponse {
+
+    private String name;
+    private String color;
+}

--- a/src/main/java/com/poortorich/category/response/CategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoryResponse.java
@@ -9,6 +9,7 @@ public enum CategoryResponse implements Response {
     SUCCESS_CREATE_CATEGORY(HttpStatus.CREATED, "카테고리를 성공적으로 등록하였습니다."),
 
     DUPLICATION_CATEGORY_NAME(HttpStatus.CONFLICT, "이미 사용중인 카테고리 이름입니다."),
+    NON_EXISTENT_ID(HttpStatus.NOT_FOUND, "존재하지 않는 아이디 입니다."),
 
     DEFAULT(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러 발생");
 

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -14,9 +14,7 @@ import com.poortorich.global.response.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.math.BigInteger;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -3,16 +3,20 @@ package com.poortorich.category.service;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.entity.CategoryType;
 import com.poortorich.category.repository.CategoryRepository;
-import com.poortorich.category.request.CustomCategoryRequest;
+import com.poortorich.category.request.CategoryInfoRequest;
+import com.poortorich.category.response.CategoryInfoResponse;
 import com.poortorich.category.response.CategoryResponse;
 import com.poortorich.category.response.CustomCategoryResponse;
 import com.poortorich.category.response.DefaultCategoryResponse;
 import com.poortorich.category.validator.CategoryValidator;
+import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.global.response.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -44,7 +48,7 @@ public class CategoryService {
                 .collect(Collectors.toList());
     }
 
-    public Response createCategory(CustomCategoryRequest customCategory, CategoryType type) {
+    public Response createCategory(CategoryInfoRequest customCategory, CategoryType type) {
         if (categoryValidator.isNameUsed(customCategory.getName())) {
             return CategoryResponse.DUPLICATION_CATEGORY_NAME;
         }
@@ -53,12 +57,21 @@ public class CategoryService {
         return CategoryResponse.SUCCESS_CREATE_CATEGORY;
     }
 
-    private Category buildCategory(CustomCategoryRequest customCategory, CategoryType type) {
+    private Category buildCategory(CategoryInfoRequest customCategory, CategoryType type) {
         return Category.builder()
                 .type(type)
                 .name(customCategory.getName())
                 .color(customCategory.getColor())
                 .visibility(true)
                 .build();
+    }
+
+    public CategoryInfoResponse getCategory(Long id) {
+        return categoryRepository.findById(id).stream()
+                .map(category -> CategoryInfoResponse.builder()
+                        .name(category.getName())
+                        .color(category.getColor())
+                        .build())
+                .findAny().orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_ID));
     }
 }


### PR DESCRIPTION
## #️⃣30
 
 ## 📝작업 내용

## 1. `CategoryInfoResponse` DTO

- 카테고리의 정보를 반환하기 위한 DTO 생성

## 2. `CategoryResponse`

- 예외 처리를 위한 필드를 추가

상수명 | HttpStatus | 설명
--|--|--
`NON_EXISTENT_ID` | NOT_FOUND (404) | 조회된 값이 존재하지 않는 경우

## 3. `CategoryService`

- 매개변수로 들어온 `Id` 값으로 카테고리 조회
- 만약 조회된 값이 없는 경우 `NotFoundException` 예외를 던지도록 구현

## 4. `CategoryController`

- `@PathVariable` 로 `categoryId` 값을 받아옴
---

### 추가 수정

- 전체적인 패키지명 변경으로 인한 오류 발생으로 인한 `PoorToRichApplication` Entity 경로 수정
- `CategoryRepository` Id 값의 형식 변경 
`BigInteger` > `Long` 변경
- 객체 이름의 통일성을 위한 이름 변경 
`CustomeCategoryRequest` > `CategoryInfoRequest`
 
 ### 스크린샷 

> 조회에 성공한 경우

![image](https://github.com/user-attachments/assets/7d718a68-9239-4cc7-b0fa-6c6f5afa5720)

> 조회에 실패한 경우

![image](https://github.com/user-attachments/assets/39a17556-e35d-4816-838b-e8ee671c0694)

