### PR TITLE
[#32] 카테고리 편집 API 구현

### DIFF
--- a/src/main/java/com/poortorich/category/controller/CategoryController.java
+++ b/src/main/java/com/poortorich/category/controller/CategoryController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -69,5 +70,12 @@ public class CategoryController {
     @GetMapping("/{categoryId}")
     public ResponseEntity<CategoryInfoResponse> getCategory(@PathVariable Long categoryId) {
         return ResponseEntity.ok(categoryService.getCategory(categoryId));
+    }
+
+    @PutMapping("/{categoryId}")
+    public ResponseEntity<BaseResponse> modifyCategory(
+            @PathVariable Long categoryId,
+            @RequestBody @Valid CategoryInfoRequest categoryRequest) {
+        return BaseResponse.toResponseEntity(categoryService.modifyCategory(categoryId, categoryRequest));
     }
 }

--- a/src/main/java/com/poortorich/category/entity/Category.java
+++ b/src/main/java/com/poortorich/category/entity/Category.java
@@ -15,11 +15,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "category")

--- a/src/main/java/com/poortorich/category/entity/Category.java
+++ b/src/main/java/com/poortorich/category/entity/Category.java
@@ -49,4 +49,9 @@ public class Category {
     private Timestamp updatedDate;
 
     // User 외래키
+
+    public void updateCategory(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
 }

--- a/src/main/java/com/poortorich/category/response/CategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoryResponse.java
@@ -7,9 +7,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum CategoryResponse implements Response {
     SUCCESS_CREATE_CATEGORY(HttpStatus.CREATED, "카테고리를 성공적으로 등록하였습니다."),
+    SUCCESS_MODIFY_CATEGORY(HttpStatus.CREATED, "카테고리를 성공적으로 편집하였습니다."),
 
     DUPLICATION_CATEGORY_NAME(HttpStatus.CONFLICT, "이미 사용중인 카테고리 이름입니다."),
-    NON_EXISTENT_ID(HttpStatus.NOT_FOUND, "존재하지 않는 아이디 입니다."),
+    NON_EXISTENT_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
 
     DEFAULT(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러 발생");
 

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -70,6 +70,20 @@ public class CategoryService {
                         .name(category.getName())
                         .color(category.getColor())
                         .build())
-                .findAny().orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_ID));
+                .findAny().orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_CATEGORY));
+    }
+
+    public Response modifyCategory(Long id, CategoryInfoRequest categoryRequest) {
+        if (categoryValidator.isNameUsed(categoryRequest.getName(), id)) {
+            return CategoryResponse.DUPLICATION_CATEGORY_NAME;
+        }
+
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_CATEGORY));
+
+        category.updateCategory(categoryRequest.getName(), categoryRequest.getColor());
+        categoryRepository.save(category);
+
+        return CategoryResponse.SUCCESS_MODIFY_CATEGORY;
     }
 }

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -11,6 +11,7 @@ import com.poortorich.category.response.DefaultCategoryResponse;
 import com.poortorich.category.validator.CategoryValidator;
 import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.global.response.Response;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -73,6 +74,7 @@ public class CategoryService {
                 .findAny().orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_CATEGORY));
     }
 
+    @Transactional
     public Response modifyCategory(Long id, CategoryInfoRequest categoryRequest) {
         if (categoryValidator.isNameUsed(categoryRequest.getName(), id)) {
             return CategoryResponse.DUPLICATION_CATEGORY_NAME;
@@ -80,9 +82,7 @@ public class CategoryService {
 
         Category category = categoryRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_CATEGORY));
-
         category.updateCategory(categoryRequest.getName(), categoryRequest.getColor());
-        categoryRepository.save(category);
 
         return CategoryResponse.SUCCESS_MODIFY_CATEGORY;
     }

--- a/src/main/java/com/poortorich/category/validator/CategoryValidator.java
+++ b/src/main/java/com/poortorich/category/validator/CategoryValidator.java
@@ -15,4 +15,10 @@ public class CategoryValidator {
                 .stream()
                 .anyMatch(category -> category.getName().equals(name));
     }
+
+    public Boolean isNameUsed(String name, Long id) {
+        return categoryRepository.findAll()
+                .stream()
+                .anyMatch(category -> category.getName().equals(name) && !category.getId().equals(id));
+    }
 }


### PR DESCRIPTION
## #️⃣32
 
 ## 📝작업 내용

## 1. `Category` entity

- entity 변경을 위한 값 수정 메소드 추가
`updateCategory`

> setter 를 사용하지 않고 메소드의 목적을 알 수 있도록 명시적인 이름을 작성하여 구현하였습니다. 

## 2. `CategoryResponse`

- 예외처리를 위한 필드 추가

상수명 | HttpStatus | 설명
--|--|--
`SUCCESS_MODIFY_CATEGORY` | CREATED (201) | 카테고리 편집 성공

- 필드 이름 및 메세지 수정
`NON_EXISTENT_ID` > `NON_EXISTENT_CATEGORY`

## 3. `CategoryService`

- 같은 이름이 있는 경우, id 값을 찾을 수 없는 경우 예외 처리를 진행
- 성공적으로 업데이트가 됐다면, entity 값을 변경하고 `categoryRepository` 에 저장

> `@Transactional` 어노테이션을 사용하는 게 맞는지 고민중입니다 ,,

## 4. `CategoryValidator`

- 카테고리를 편집할 때 이름을 변경하지 않는 경우, **기존의 중복 이름 검증 로직**에서 예외를 발생
⇒ **중복 이름 검증 로직**을 **오버로딩**하여 id 값이 같은 경우는 검사하지 않도록 추가 구현
 
 ### 스크린샷 

> 편집 성공

![image](https://github.com/user-attachments/assets/9c1c14c8-7797-4bf5-8c1b-ae774c01f442)


> 중복된 카테고리 이름으로 변경 시

![image](https://github.com/user-attachments/assets/6677dd4e-4e30-47fa-9fd5-800726bed4d6)

> 존재하지 않는 아이디 값 전달 시

![image](https://github.com/user-attachments/assets/173d5b20-a0d4-494c-93a3-13d104087f3f)
 
 ## 💬리뷰 요구사항
 
- service 로직에 `@Transactional` 어노테이션 사용 고려

---
## 추가 구현

- `@Transactional` 어노테이션 추가
- Entity `@DynamicUpdate` 어노테이션 추가 
변경된 값만 업데이트
