### PR TITLE
[#34] 카테고리 삭제 API 구현

### DIFF
--- a/src/main/java/com/poortorich/category/controller/CategoryController.java
+++ b/src/main/java/com/poortorich/category/controller/CategoryController.java
@@ -12,6 +12,7 @@ import com.poortorich.global.response.BaseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -77,5 +78,10 @@ public class CategoryController {
             @PathVariable Long categoryId,
             @RequestBody @Valid CategoryInfoRequest categoryRequest) {
         return BaseResponse.toResponseEntity(categoryService.modifyCategory(categoryId, categoryRequest));
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<BaseResponse> deleteCategory(@PathVariable Long categoryId) {
+        return BaseResponse.toResponseEntity(categoryService.deleteCategory(categoryId));
     }
 }

--- a/src/main/java/com/poortorich/category/response/CategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoryResponse.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum CategoryResponse implements Response {
     SUCCESS_CREATE_CATEGORY(HttpStatus.CREATED, "카테고리를 성공적으로 등록하였습니다."),
     SUCCESS_MODIFY_CATEGORY(HttpStatus.CREATED, "카테고리를 성공적으로 편집하였습니다."),
+    SUCCESS_DELETE_CATEGORY(HttpStatus.OK, "카테고리를 성공적으로 삭제하였습니다."),
 
     DUPLICATION_CATEGORY_NAME(HttpStatus.CONFLICT, "이미 사용중인 카테고리 이름입니다."),
     NON_EXISTENT_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -67,7 +67,7 @@ public class CategoryService {
 
     public CategoryInfoResponse getCategory(Long id) {
         Category category = getCategoryOrThrow(id);
-        
+
         return CategoryInfoResponse.builder()
                 .name(category.getName())
                 .color(category.getColor())
@@ -84,6 +84,13 @@ public class CategoryService {
         category.updateCategory(categoryRequest.getName(), categoryRequest.getColor());
 
         return CategoryResponse.SUCCESS_MODIFY_CATEGORY;
+    }
+
+    public Response deleteCategory(Long id) {
+        Category category = getCategoryOrThrow(id);
+        categoryRepository.delete(category);
+
+        return CategoryResponse.SUCCESS_DELETE_CATEGORY;
     }
 
     private Category getCategoryOrThrow(Long id) {

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -66,12 +66,12 @@ public class CategoryService {
     }
 
     public CategoryInfoResponse getCategory(Long id) {
-        return categoryRepository.findById(id).stream()
-                .map(category -> CategoryInfoResponse.builder()
-                        .name(category.getName())
-                        .color(category.getColor())
-                        .build())
-                .findAny().orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_CATEGORY));
+        Category category = getCategoryOrThrow(id);
+        
+        return CategoryInfoResponse.builder()
+                .name(category.getName())
+                .color(category.getColor())
+                .build();
     }
 
     @Transactional
@@ -80,10 +80,14 @@ public class CategoryService {
             return CategoryResponse.DUPLICATION_CATEGORY_NAME;
         }
 
-        Category category = categoryRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_CATEGORY));
+        Category category = getCategoryOrThrow(id);
         category.updateCategory(categoryRequest.getName(), categoryRequest.getColor());
 
         return CategoryResponse.SUCCESS_MODIFY_CATEGORY;
+    }
+
+    private Category getCategoryOrThrow(Long id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_CATEGORY));
     }
 }


### PR DESCRIPTION
## #️⃣34
 
## 📝작업 내용

## `CategoryService`

- `deleteCategory` 구현
- 중복되는 카테고리 조회 코드 분리
> 조회, 수정, 삭제에 걸쳐 id 값으로 카테고리를 조회하고, 존재하지 않으면 예외를 던지는 코드가 반복됐습니다. `getCategoryOrThrow` 메소드를 만들어 코드를 분리했습니다.

## `CategoryResponse`

- 카테고리 삭제 성공 필드 추가

상수명 | HttpStatus | 설명
--|--|--
`SUCCESS_DELETE_CATEGORY` | OK (200) | 성공적으로 카테고리를 삭제
 
 ### 스크린샷

> 삭제에 성공한 경우

![image](https://github.com/user-attachments/assets/8b9f0f78-f882-4069-b610-5cba208e1746)

> 존재하지 않는 카테고리인 경우

![image](https://github.com/user-attachments/assets/63d8a6da-fb31-454c-ab22-cb527e932ad6)
