### PR TITLE
[#36] 활성화된 카테고리 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/category/controller/CategoryController.java
+++ b/src/main/java/com/poortorich/category/controller/CategoryController.java
@@ -2,7 +2,7 @@ package com.poortorich.category.controller;
 
 import com.poortorich.category.entity.CategoryType;
 import com.poortorich.category.request.CategoryInfoRequest;
-import com.poortorich.category.response.CategoriesResponse;
+import com.poortorich.category.response.ActiveCategoriesResponse;
 import com.poortorich.category.response.CategoryInfoResponse;
 import com.poortorich.category.response.CustomCategoriesResponse;
 import com.poortorich.category.response.CustomCategoryResponse;
@@ -61,7 +61,7 @@ public class CategoryController {
     }
 
     @GetMapping("/active")
-    public ResponseEntity<CategoriesResponse> getActiveCategories(@RequestParam String type) {
+    public ResponseEntity<ActiveCategoriesResponse> getActiveCategories(@RequestParam String type) {
         return ResponseEntity.ok(categoryService.getActiveCategories(type));
     }
 

--- a/src/main/java/com/poortorich/category/controller/CategoryController.java
+++ b/src/main/java/com/poortorich/category/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.poortorich.category.controller;
 
 import com.poortorich.category.entity.CategoryType;
 import com.poortorich.category.request.CategoryInfoRequest;
+import com.poortorich.category.response.CategoriesResponse;
 import com.poortorich.category.response.CategoryInfoResponse;
 import com.poortorich.category.response.CustomCategoriesResponse;
 import com.poortorich.category.response.CustomCategoryResponse;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -56,6 +58,11 @@ public class CategoryController {
         List<CustomCategoryResponse> incomeCategories = categoryService.getCustomCategories(CategoryType.CUSTOM_INCOME);
         CustomCategoriesResponse response = new CustomCategoriesResponse(incomeCategories);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/active")
+    public ResponseEntity<CategoriesResponse> getActiveCategories(@RequestParam String type) {
+        return ResponseEntity.ok(categoryService.getActiveCategories(type));
     }
 
     @PostMapping("/expense")

--- a/src/main/java/com/poortorich/category/entity/CategoryType.java
+++ b/src/main/java/com/poortorich/category/entity/CategoryType.java
@@ -1,8 +1,26 @@
 package com.poortorich.category.entity;
 
+import com.poortorich.category.response.CategoryResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+
+import java.util.Map;
+
 public enum CategoryType {
     DEFAULT_EXPENSE,
     DEFAULT_INCOME,
     CUSTOM_EXPENSE,
     CUSTOM_INCOME;
+
+    public static final Map<String, CategoryType> TYPE_MAP = Map.of(
+            "income", DEFAULT_INCOME,
+            "expense", DEFAULT_EXPENSE
+    );
+
+    public static CategoryType from(String type) {
+        if (!TYPE_MAP.containsKey(type)) {
+            throw new BadRequestException(CategoryResponse.INVALID_CATEGORY_TYPE);
+        }
+
+        return TYPE_MAP.get(type);
+    }
 }

--- a/src/main/java/com/poortorich/category/response/ActiveCategoriesResponse.java
+++ b/src/main/java/com/poortorich/category/response/ActiveCategoriesResponse.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CategoriesResponse {
-    private List<String> categories;
+public class ActiveCategoriesResponse {
+    private List<String> activeCategories;
 }

--- a/src/main/java/com/poortorich/category/response/CategoriesResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoriesResponse.java
@@ -1,0 +1,16 @@
+package com.poortorich.category.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoriesResponse {
+    private List<String> categories;
+}

--- a/src/main/java/com/poortorich/category/response/CategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoryResponse.java
@@ -12,6 +12,7 @@ public enum CategoryResponse implements Response {
 
     DUPLICATION_CATEGORY_NAME(HttpStatus.CONFLICT, "이미 사용중인 카테고리 이름입니다."),
     NON_EXISTENT_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
+    INVALID_CATEGORY_TYPE(HttpStatus.BAD_REQUEST,"카테고리의 타입이 적절하지 않습니다."),
 
     DEFAULT(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러 발생");
 

--- a/src/main/java/com/poortorich/category/response/DefaultCategoriesResponse.java
+++ b/src/main/java/com/poortorich/category/response/DefaultCategoriesResponse.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 
 import java.util.List;
 
-
 @Data
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.poortorich.category.entity.Category;
 import com.poortorich.category.entity.CategoryType;
 import com.poortorich.category.repository.CategoryRepository;
 import com.poortorich.category.request.CategoryInfoRequest;
+import com.poortorich.category.response.CategoriesResponse;
 import com.poortorich.category.response.CategoryInfoResponse;
 import com.poortorich.category.response.CategoryResponse;
 import com.poortorich.category.response.CustomCategoryResponse;
@@ -25,6 +26,10 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final CategoryValidator categoryValidator;
 
+    private void addCategory() {
+        categoryRepository.save(new Category());
+    }
+
     public List<DefaultCategoryResponse> getDefaultCategories(CategoryType type) {
         return categoryRepository.findAll().stream()
                 .filter(category -> category.getType() == type)
@@ -33,7 +38,7 @@ public class CategoryService {
                         .color(category.getColor())
                         .visibility(category.getVisibility())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<CustomCategoryResponse> getCustomCategories(CategoryType type) {
@@ -44,7 +49,18 @@ public class CategoryService {
                         .color(category.getColor())
                         .name(category.getName())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    public CategoriesResponse getActiveCategories(String type) {
+        List<String> categories = categoryRepository.findAll().stream()
+                .filter(category -> category.getType() == CategoryType.from(type) && category.getVisibility())
+                .map(Category::getName)
+                .toList();
+
+        return CategoriesResponse.builder()
+                .categories(categories)
+                .build();
     }
 
     public Response createCategory(CategoryInfoRequest customCategory, CategoryType type) {

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -4,7 +4,7 @@ import com.poortorich.category.entity.Category;
 import com.poortorich.category.entity.CategoryType;
 import com.poortorich.category.repository.CategoryRepository;
 import com.poortorich.category.request.CategoryInfoRequest;
-import com.poortorich.category.response.CategoriesResponse;
+import com.poortorich.category.response.ActiveCategoriesResponse;
 import com.poortorich.category.response.CategoryInfoResponse;
 import com.poortorich.category.response.CategoryResponse;
 import com.poortorich.category.response.CustomCategoryResponse;
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,10 +24,6 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
     private final CategoryValidator categoryValidator;
-
-    private void addCategory() {
-        categoryRepository.save(new Category());
-    }
 
     public List<DefaultCategoryResponse> getDefaultCategories(CategoryType type) {
         return categoryRepository.findAll().stream()
@@ -52,14 +47,14 @@ public class CategoryService {
                 .toList();
     }
 
-    public CategoriesResponse getActiveCategories(String type) {
+    public ActiveCategoriesResponse getActiveCategories(String type) {
         List<String> categories = categoryRepository.findAll().stream()
                 .filter(category -> category.getType() == CategoryType.from(type) && category.getVisibility())
                 .map(Category::getName)
                 .toList();
 
-        return CategoriesResponse.builder()
-                .categories(categories)
+        return ActiveCategoriesResponse.builder()
+                .activeCategories(categories)
                 .build();
     }
 

--- a/src/main/java/com/poortorich/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/poortorich/global/handler/GlobalExceptionHandler.java
@@ -41,7 +41,6 @@ public class GlobalExceptionHandler {
         return BaseResponse.toResponseEntity(HttpStatus.BAD_REQUEST, MISSING_PARAMETER);
     }
 
-
     @ExceptionHandler(AuthorizationException.class)
     public ResponseEntity<BaseResponse> handleAuthorizationException(AuthorizationException exception) {
         return BaseResponse.toResponseEntity(exception.getResponse());

--- a/src/main/java/com/poortorich/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/poortorich/global/handler/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     private static final String DEFAULT_ERROR_MESSAGE = "잘못된 요청입니다.";
+    private static final String MISSING_PARAMETER = "요청 파라미터가 존재하지 않습니다.";
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse> handleMethodArgumentNotValidException(
@@ -32,6 +34,13 @@ public class GlobalExceptionHandler {
 
         return BaseResponse.toResponseEntity(HttpStatus.BAD_REQUEST, errorMessage);
     }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<BaseResponse> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException exception) {
+        return BaseResponse.toResponseEntity(HttpStatus.BAD_REQUEST, MISSING_PARAMETER);
+    }
+
 
     @ExceptionHandler(AuthorizationException.class)
     public ResponseEntity<BaseResponse> handleAuthorizationException(AuthorizationException exception) {


### PR DESCRIPTION
## #️⃣36

## 📝작업 내용

## `GlobalExceptionHandler`

### 문제 발생

- `@RequestParam` 값이 비어있을 경우 `MissingServletRequestParameterException` 예외가 발생

### 해결

- `GlobalExceptionHandler` 에 해당 예외 핸들러를 추가
상수 `MISSING_PARAMETER` 를 사용하여 에러 메세지를 반환하도록 구현

## `CategoryResponse`

- 예외 처리에 필요한 필드 추가

상수명 | HttpStatus | 설명
--|--|--
`INVALID_CATEGORY_TYPE` | BAD REQUEST (400) | 카테고리 타입 값이 적절하지 않은 경우

## `CategoryType`

- Map을 사용하여 입력으로 들어오는 `type` 값과 `CategoryType` 값을 매핑
- `from` 메소드를 사용하여 매개변수로 들어온 `type` 값에 맞는 `CategoryType` 값을 반환
**적절한 키 값이 없는 경우 `BadRequestException` 예외를 던짐**

## `CategoryService`

- `type` 값이 일치하고, `visbility` 값이 _true_인 **category entity의 name**을 반환

- List로 변경하는 코드 변경
> `collect(Collectors.toList())` 에서 반환되는 List는 수정이 가능하기 때문에 문제가 발생할 수 있다고 판단했습니다. 따라서 수정이 불가능한 List을 반환하는 `toList()` 로 변경하였습니다.

## 추가 수정 사항

- `Controller` `Service` 메소드 순서 변경
> /category/{categoryId} 에 매핑될 수 있는 가능성이 있기 때문에 코드의 순서를 변경하여 /category/active end point를 먼저 처리할 수 있도록 작성했습니다.
- `CategoriesResponse` DTO 추가

---

### 스크린샷 
 
> 카테고리 타입이 비었거나 적절한 값이 아닌 경우 

![image](https://github.com/user-attachments/assets/c740fa45-b299-44bf-b137-30d732635675)

> Request parameter가 없는 경우

![image](https://github.com/user-attachments/assets/be5252b4-9134-493d-99e7-054962484424)

 ## 💬리뷰 요구사항

- 예외 핸들러 로직