### PR TITLE
[#41] 지출 가계부 추가 API 구현

### DIFF
--- a/src/main/java/com/poortorich/PoorToRichApplication.java
+++ b/src/main/java/com/poortorich/PoorToRichApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
-@EntityScan(basePackages = {"com.poortorich.category.entity", "com.poortorich.user.entity"})
+@EntityScan(basePackages = {"com.poortorich.category.entity", "com.poortorich.user.entity", "com.poortorich.expense.entity"})
 public class PoorToRichApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/poortorich/category/repository/CategoryRepository.java
+++ b/src/main/java/com/poortorich/category/repository/CategoryRepository.java
@@ -4,7 +4,10 @@ import com.poortorich.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
+    Optional<Category> findByName(String name);
 }

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -108,4 +108,9 @@ public class CategoryService {
         return categoryRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_CATEGORY));
     }
+
+    public Category findCategoryByName(String name) {
+        return categoryRepository.findByName(name)
+                .orElseThrow(() -> new NotFoundException(CategoryResponse.NON_EXISTENT_CATEGORY));
+    }
 }

--- a/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
+++ b/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
@@ -8,7 +8,7 @@ public class ExpenseResponseMessages {
 
     public static final String COST_REQUIRED = "금액은 필수로 입력해야 합니다.";
     public static final String COST_NEGATIVE = "금액은 0보다 커야합니다.";
-    public static final String COST_TOO_BIG = "금액은 " + ExpenseValidationConstraints.COST_MAX_SIZE + "보다 작아야 합니다.";
+    public static final String COST_TOO_BIG = "금액은 " + ExpenseValidationConstraints.COST_LIMIT + "보다 작아야 합니다.";
 
     public static final String TITLE_TOO_SHORT = "지출명은 1자 이상 작성해야 합니다.";
     public static final String TITLE_TOO_LONG = "지출명은 " + ExpenseValidationConstraints.TITLE_MAX_SIZE + "자 이하로 작성해야 합니다.";

--- a/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
+++ b/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
@@ -8,10 +8,11 @@ public class ExpenseResponseMessages {
 
     public static final String COST_REQUIRED = "금액은 필수로 입력해야 합니다.";
     public static final String COST_NEGATIVE = "금액은 0보다 커야합니다.";
+    public static final String COST_TOO_BIG = "금액은 " + ExpenseValidationConstraints.COST_MAX_SIZE + "보다 작아야 합니다.";
 
     public static final String TITLE_TOO_SHORT = "지출명은 1자 이상 작성해야 합니다.";
-    public static final String TITLE_TOO_LONG = "지출명은 {max}자 이하로 작성해야 합니다.";
-    public static final String MEMO_TOO_LONG = "메모는 {max}자 이하로 작성해야 합니다.";
+    public static final String TITLE_TOO_LONG = "지출명은 " + ExpenseValidationConstraints.TITLE_MAX_SIZE + "자 이하로 작성해야 합니다.";
+    public static final String MEMO_TOO_LONG = "메모는 " + ExpenseValidationConstraints.MEMO_MAX_SIZE + "자 이하로 작성해야 합니다.";
 
     public static final String PAYMENT_METHOD_REQUIRED = "지출수단은 필수로 선택해야 합니다.";
     public static final String PAYMENT_METHOD_INVALID = "지출수단이 적절하지 않습니다.";

--- a/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
+++ b/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
@@ -1,0 +1,24 @@
+package com.poortorich.expense.constants;
+
+public class ExpenseResponseMessages {
+
+    public static final String DATE_REQUIRED = "날짜는 필수로 입력해야 합니다.";
+
+    public static final String CATEGORY_NAME_REQUIRED = "카테고리는 필수로 선택해야 합니다.";
+
+    public static final String COST_REQUIRED = "금액은 필수로 입력해야 합니다.";
+    public static final String COST_NEGATIVE = "금액은 0보다 커야합니다.";
+
+    public static final String TITLE_TOO_SHORT = "지출명은 1자 이상 작성해야 합니다.";
+    public static final String TITLE_TOO_LONG = "지출명은 {max}자 이하로 작성해야 합니다.";
+    public static final String MEMO_TOO_LONG = "메모는 {max}자 이하로 작성해야 합니다.";
+
+    public static final String PAYMENT_METHOD_REQUIRED = "지출수단은 필수로 선택해야 합니다.";
+    public static final String PAYMENT_METHOD_INVALID = "지출수단이 적절하지 않습니다.";
+
+    public static final String ITERATION_TYPE_INVALID = "반복 데이터 유형이 적절하지 않습니다.";
+
+    public static final String CREATE_EXPENSE_SUCCESS = "가계부를 성공적으로 등록하였습니다.";
+
+    private ExpenseResponseMessages() {}
+}

--- a/src/main/java/com/poortorich/expense/constants/ExpenseValidationConstraints.java
+++ b/src/main/java/com/poortorich/expense/constants/ExpenseValidationConstraints.java
@@ -4,7 +4,7 @@ public class ExpenseValidationConstraints {
 
     public static final int TITLE_MAX_SIZE = 15;
 
-    public static final int COST_MAX_SIZE = 100000000;
+    public static final int COST_LIMIT = 100000000;
 
     public static final int MEMO_MAX_SIZE = 100;
 

--- a/src/main/java/com/poortorich/expense/constants/ExpenseValidationConstraints.java
+++ b/src/main/java/com/poortorich/expense/constants/ExpenseValidationConstraints.java
@@ -4,6 +4,8 @@ public class ExpenseValidationConstraints {
 
     public static final int TITLE_MAX_SIZE = 15;
 
+    public static final int COST_MAX_SIZE = 100000000;
+
     public static final int MEMO_MAX_SIZE = 100;
 
     private ExpenseValidationConstraints() {}

--- a/src/main/java/com/poortorich/expense/constants/ExpenseValidationConstraints.java
+++ b/src/main/java/com/poortorich/expense/constants/ExpenseValidationConstraints.java
@@ -1,0 +1,10 @@
+package com.poortorich.expense.constants;
+
+public class ExpenseValidationConstraints {
+
+    public static final int TITLE_MAX_SIZE = 15;
+
+    public static final int MEMO_MAX_SIZE = 100;
+
+    private ExpenseValidationConstraints() {}
+}

--- a/src/main/java/com/poortorich/expense/controller/ExpenseController.java
+++ b/src/main/java/com/poortorich/expense/controller/ExpenseController.java
@@ -1,0 +1,25 @@
+package com.poortorich.expense.controller;
+
+import com.poortorich.expense.facade.ExpenseFacade;
+import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.global.response.BaseResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/expense")
+@RequiredArgsConstructor
+public class ExpenseController {
+
+    private final ExpenseFacade expenseFacade;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse> createExpense(@RequestBody @Valid ExpenseRequest expenseRequest) {
+        return BaseResponse.toResponseEntity(expenseFacade.createExpense(expenseRequest));
+    }
+}

--- a/src/main/java/com/poortorich/expense/entity/Expense.java
+++ b/src/main/java/com/poortorich/expense/entity/Expense.java
@@ -1,0 +1,79 @@
+package com.poortorich.expense.entity;
+
+import com.poortorich.category.entity.Category;
+import com.poortorich.expense.entity.enums.IterationType;
+import com.poortorich.expense.entity.enums.PaymentMethod;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "expense")
+public class Expense {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @NotNull
+    @Column(name = "expenseDate", nullable = false)
+    private Date expenseDate;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "cost", nullable = false)
+    private Long cost;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "paymentMethod", nullable = false)
+    private PaymentMethod paymentMethod;
+
+    @Column(name = "memo")
+    private String memo;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "iterationType", nullable = false)
+    private IterationType iterationType;
+
+    @CreationTimestamp
+    @Column(name = "createdDate")
+    private Timestamp createdDate;
+
+    @UpdateTimestamp
+    @Column(name = "updateDate")
+    private Timestamp updatedDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "categoryId")
+    private Category category;
+
+    // User 외래키
+}

--- a/src/main/java/com/poortorich/expense/entity/Expense.java
+++ b/src/main/java/com/poortorich/expense/entity/Expense.java
@@ -23,8 +23,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import java.sql.Timestamp;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -42,7 +42,7 @@ public class Expense {
 
     @NotNull
     @Column(name = "expenseDate", nullable = false)
-    private Date expenseDate;
+    private LocalDate expenseDate;
 
     @Column(name = "title")
     private String title;
@@ -65,11 +65,11 @@ public class Expense {
 
     @CreationTimestamp
     @Column(name = "createdDate")
-    private Timestamp createdDate;
+    private LocalDateTime createdDate;
 
     @UpdateTimestamp
     @Column(name = "updateDate")
-    private Timestamp updatedDate;
+    private LocalDateTime updatedDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "categoryId")

--- a/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
+++ b/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
@@ -1,0 +1,36 @@
+package com.poortorich.expense.entity.enums;
+
+import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Objects;
+
+@RequiredArgsConstructor
+public enum IterationType {
+
+    DEFAULT("반복없음"),
+    EVERY_DAY("매일"),
+    EVERY_DAY_OF_THE_WEEK("주중 매일"),
+    EVERY_WEEK("매주"),
+    EVERY_SECOND_WEEK("2주마다"),
+    EVERY_MONTH("매달"),
+    LAST_DAY_OF_EVERY_MONTH("매달 말일"),
+    EVERY_YEAR("매년");
+
+    public final String type;
+
+    public static IterationType from(String type) {
+        if (type == null || type.trim().isEmpty()) {
+            return DEFAULT;
+        }
+
+        for (IterationType iteration : IterationType.values()) {
+            if (Objects.equals(iteration.type, type)) {
+                return iteration;
+            }
+        }
+
+        throw new BadRequestException(ExpenseResponse.ITERATION_TYPE_INVALID);
+    }
+}

--- a/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
+++ b/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
@@ -9,13 +9,13 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public enum IterationType {
 
-    DEFAULT("반복 없음"),
-    EVERY_DAY("매일"),
-    EVERY_WEEK("매주"),
-    EVERY_MONTH("매달"),
-    EVERY_YEAR("매년"),
-    EVERY_WEEKDAYS("주중 매일"),
-    USER_FRIENDLY("사용자화");
+    DEFAULT("none"),
+    DAILY("daily"),
+    WEEKLY("weekly"),
+    MONTHLY("monthly"),
+    YEARLY("yearly"),
+    WEEKDAY("weekday"),
+    CUSTOM("custom");
 
     public final String type;
 

--- a/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
+++ b/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
@@ -9,14 +9,13 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public enum IterationType {
 
-    DEFAULT("반복없음"),
+    DEFAULT("반복 없음"),
     EVERY_DAY("매일"),
-    EVERY_DAY_OF_THE_WEEK("주중 매일"),
     EVERY_WEEK("매주"),
-    EVERY_SECOND_WEEK("2주마다"),
     EVERY_MONTH("매달"),
-    LAST_DAY_OF_EVERY_MONTH("매달 말일"),
-    EVERY_YEAR("매년");
+    EVERY_YEAR("매년"),
+    EVERY_WEEKDAYS("주중 매일"),
+    USER_FRIENDLY("사용자화");
 
     public final String type;
 

--- a/src/main/java/com/poortorich/expense/entity/enums/PaymentMethod.java
+++ b/src/main/java/com/poortorich/expense/entity/enums/PaymentMethod.java
@@ -1,0 +1,28 @@
+package com.poortorich.expense.entity.enums;
+
+import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Objects;
+
+@RequiredArgsConstructor
+public enum PaymentMethod {
+
+    CASH("현금"),
+    CREDIT_CARD("신용카드"),
+    CHECK_CARD("체크카드"),
+    BANK_TRANSFER("계좌이체");
+
+    public final String type;
+
+    public static PaymentMethod from(String type) {
+        for (PaymentMethod payment : PaymentMethod.values()) {
+            if (Objects.equals(payment.type, type)) {
+                return payment;
+            }
+        }
+
+        throw new BadRequestException(ExpenseResponse.PAYMENT_METHOD_INVALID);
+    }
+}

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -1,0 +1,27 @@
+package com.poortorich.expense.facade;
+
+import com.poortorich.category.entity.Category;
+import com.poortorich.category.service.CategoryService;
+import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.expense.service.ExpenseService;
+import com.poortorich.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ExpenseFacade {
+
+    private final ExpenseService expenseService;
+    private final CategoryService categoryService;
+
+    @Transactional
+    public Response createExpense(ExpenseRequest expenseRequest) {
+        Category category = categoryService.findCategoryByName(expenseRequest.getCategoryName());
+        expenseService.createExpense(expenseRequest, category);
+
+        return ExpenseResponse.CREATE_EXPENSE_SUCCESS;
+    }
+}

--- a/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
@@ -1,0 +1,10 @@
+package com.poortorich.expense.repository;
+
+import com.poortorich.expense.entity.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+
+}

--- a/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
+++ b/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
@@ -35,7 +35,7 @@ public class ExpenseRequest {
 
     @NotNull(message = ExpenseResponseMessages.COST_REQUIRED)
     @Positive(message = ExpenseResponseMessages.COST_NEGATIVE)
-    @Max(value = ExpenseValidationConstraints.COST_MAX_SIZE,
+    @Max(value = ExpenseValidationConstraints.COST_LIMIT,
             message = ExpenseResponseMessages.COST_TOO_BIG)
     private Long cost;
 

--- a/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
+++ b/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
@@ -5,22 +5,26 @@ import com.poortorich.expense.constants.ExpenseValidationConstraints;
 import com.poortorich.expense.entity.enums.IterationType;
 import com.poortorich.expense.entity.enums.PaymentMethod;
 import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.global.constants.DatePattern;
 import com.poortorich.global.exceptions.BadRequestException;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
 public class ExpenseRequest {
 
+    @DateTimeFormat(pattern = DatePattern.BASIC_PATTERN)
     @NotNull(message = ExpenseResponseMessages.DATE_REQUIRED)
-    private Date date;
+    private LocalDate date;
 
     @NotBlank(message = ExpenseResponseMessages.CATEGORY_NAME_REQUIRED)
     private String categoryName;
@@ -31,6 +35,8 @@ public class ExpenseRequest {
 
     @NotNull(message = ExpenseResponseMessages.COST_REQUIRED)
     @Positive(message = ExpenseResponseMessages.COST_NEGATIVE)
+    @Max(value = ExpenseValidationConstraints.COST_MAX_SIZE,
+            message = ExpenseResponseMessages.COST_TOO_BIG)
     private Long cost;
 
     @NotBlank(message = ExpenseResponseMessages.PAYMENT_METHOD_REQUIRED)

--- a/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
+++ b/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
@@ -1,0 +1,65 @@
+package com.poortorich.expense.request;
+
+import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.expense.constants.ExpenseValidationConstraints;
+import com.poortorich.expense.entity.enums.IterationType;
+import com.poortorich.expense.entity.enums.PaymentMethod;
+import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+public class ExpenseRequest {
+
+    @NotNull(message = ExpenseResponseMessages.DATE_REQUIRED)
+    private Date date;
+
+    @NotBlank(message = ExpenseResponseMessages.CATEGORY_NAME_REQUIRED)
+    private String categoryName;
+
+    @Size(max = ExpenseValidationConstraints.TITLE_MAX_SIZE,
+            message = ExpenseResponseMessages.TITLE_TOO_LONG)
+    private String title;
+
+    @NotNull(message = ExpenseResponseMessages.COST_REQUIRED)
+    @Positive(message = ExpenseResponseMessages.COST_NEGATIVE)
+    private Long cost;
+
+    @NotBlank(message = ExpenseResponseMessages.PAYMENT_METHOD_REQUIRED)
+    private String paymentMethod;
+
+    @Size(max = ExpenseValidationConstraints.MEMO_MAX_SIZE,
+            message = ExpenseResponseMessages.MEMO_TOO_LONG)
+    private String memo;
+
+    private String iterationType;
+
+    public PaymentMethod parsePaymentMethod() {
+        return PaymentMethod.from(paymentMethod);
+    }
+
+    public String trimTitle() {
+        if (title == null) {
+            return null;
+        }
+
+        String trimTitle = title.trim();
+        if (!trimTitle.isEmpty()) {
+            return trimTitle;
+        }
+
+        throw new BadRequestException(ExpenseResponse.TITLE_TOO_SHORT);
+    }
+
+    public IterationType parseIterationType() {
+        return IterationType.from(iterationType);
+    }
+}

--- a/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
+++ b/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
@@ -1,0 +1,29 @@
+package com.poortorich.expense.response;
+
+import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.global.response.Response;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum ExpenseResponse implements Response {
+
+    CREATE_EXPENSE_SUCCESS(HttpStatus.CREATED, ExpenseResponseMessages.CREATE_EXPENSE_SUCCESS),
+
+    TITLE_TOO_SHORT(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.TITLE_TOO_SHORT),
+    PAYMENT_METHOD_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.PAYMENT_METHOD_INVALID),
+    ITERATION_TYPE_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.ITERATION_TYPE_INVALID);
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/poortorich/expense/service/ExpenseService.java
+++ b/src/main/java/com/poortorich/expense/service/ExpenseService.java
@@ -1,0 +1,31 @@
+package com.poortorich.expense.service;
+
+import com.poortorich.category.entity.Category;
+import com.poortorich.expense.entity.Expense;
+import com.poortorich.expense.repository.ExpenseRepository;
+import com.poortorich.expense.request.ExpenseRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExpenseService {
+
+    private final ExpenseRepository expenseRepository;
+
+    public void createExpense(ExpenseRequest expenseRequest, Category category) {
+        expenseRepository.save(buildExpense(expenseRequest, category));
+    }
+
+    private Expense buildExpense(ExpenseRequest expenseRequest, Category category) {
+        return Expense.builder()
+                .expenseDate(expenseRequest.getDate())
+                .category(category)
+                .title(expenseRequest.trimTitle())
+                .cost(expenseRequest.getCost())
+                .paymentMethod(expenseRequest.parsePaymentMethod())
+                .memo(expenseRequest.getMemo())
+                .iterationType(expenseRequest.parseIterationType())
+                .build();
+    }
+}

--- a/src/main/java/com/poortorich/global/constants/DatePattern.java
+++ b/src/main/java/com/poortorich/global/constants/DatePattern.java
@@ -1,0 +1,7 @@
+package com.poortorich.global.constants;
+
+public class DatePattern {
+    public static final String BASIC_PATTERN = "yyyy-MM-dd";
+
+    private DatePattern() {}
+}

--- a/src/main/java/com/poortorich/security/config/SecurityConfig.java
+++ b/src/main/java/com/poortorich/security/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                                 "user/register/username/exists",
                                 "/email/send",
                                 "/email/verify",
-                                "/email/block"
+                                "/email/block",
+                                "/expense"
                         ).permitAll()
                         .anyRequest().denyAll()
                 );

--- a/src/test/java/com/poortorich/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/com/poortorich/expense/controller/ExpenseControllerTest.java
@@ -1,0 +1,72 @@
+package com.poortorich.expense.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.poortorich.expense.facade.ExpenseFacade;
+import com.poortorich.expense.fixture.ExpenseApiFixture;
+import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.expense.util.ExpenseRequestTestBuilder;
+import com.poortorich.security.config.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ExpenseController.class)
+@Import(SecurityConfig.class)
+@ExtendWith(MockitoExtension.class)
+class ExpenseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ExpenseFacade expenseFacade;
+
+    private ExpenseRequest expenseRequest;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        expenseRequest = new ExpenseRequestTestBuilder().build();
+        objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    }
+
+    @Test
+    @DisplayName("유효한 지출 가계부 데이터로 createExpense 호출 시 기대했던 응답이 반환된다.")
+    void createExpense_whenValidInput_thenNoException() throws Exception {
+        String requestJson = objectMapper.writeValueAsString(expenseRequest);
+
+        when(expenseFacade.createExpense(any(ExpenseRequest.class)))
+                .thenReturn(ExpenseResponse.CREATE_EXPENSE_SUCCESS);
+
+        mockMvc.perform(post(ExpenseApiFixture.CREATE_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                        .with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.resultMessage").value(ExpenseResponse.CREATE_EXPENSE_SUCCESS.getMessage()));
+
+        verify(expenseFacade, times(1)).createExpense(any(ExpenseRequest.class));
+    }
+}

--- a/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
+++ b/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
@@ -1,0 +1,52 @@
+package com.poortorich.expense.facade;
+
+import com.poortorich.category.entity.Category;
+import com.poortorich.category.service.CategoryService;
+import com.poortorich.expense.fixture.ExpenseFixture;
+import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.service.ExpenseService;
+import com.poortorich.expense.util.ExpenseRequestTestBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenseFacadeTest {
+
+    @Mock
+    private ExpenseService expenseService;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @InjectMocks
+    private ExpenseFacade expenseFacade;
+
+    private ExpenseRequest expenseRequest;
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        expenseRequest = new ExpenseRequestTestBuilder().build();
+        category = Category.builder()
+                .name(ExpenseFixture.VALID_CATEGORY_NAME)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Category, Expense 서비스가 적절히 호출된다.")
+    void createExpense_shouldCallServiceMethods() {
+        when(categoryService.findCategoryByName(expenseRequest.getCategoryName())).thenReturn(category);
+
+        expenseFacade.createExpense(expenseRequest);
+        verify(expenseService).createExpense(expenseRequest, category);
+        verify(categoryService).findCategoryByName(expenseRequest.getCategoryName());
+    }
+}

--- a/src/test/java/com/poortorich/expense/fixture/ExpenseApiFixture.java
+++ b/src/test/java/com/poortorich/expense/fixture/ExpenseApiFixture.java
@@ -1,0 +1,6 @@
+package com.poortorich.expense.fixture;
+
+public class ExpenseApiFixture {
+
+    public static final String CREATE_PATH = "/expense";
+}

--- a/src/test/java/com/poortorich/expense/fixture/ExpenseFixture.java
+++ b/src/test/java/com/poortorich/expense/fixture/ExpenseFixture.java
@@ -1,0 +1,23 @@
+package com.poortorich.expense.fixture;
+
+import java.time.LocalDate;
+
+public class ExpenseFixture {
+
+    public static final LocalDate VALID_DATE = LocalDate.of(2025, 1, 1);
+
+    public static final String VALID_CATEGORY_NAME = "주거비";
+
+    public static final String VALID_TITLE = "월세";
+    public static final String SPACED_TITLE = "  월세 ";
+
+    public static final Long VALID_COST = 700000L;
+
+    public static final String VALID_PAYMENT_METHOD_STRING = "계좌이체";
+
+    public static final String VALID_MEMO = "월세 너무 비싸다";
+
+    public static final String VALID_ITERATION_TYPE_STRING = "매달";
+
+    private ExpenseFixture() {}
+}

--- a/src/test/java/com/poortorich/expense/fixture/ExpenseFixture.java
+++ b/src/test/java/com/poortorich/expense/fixture/ExpenseFixture.java
@@ -17,7 +17,7 @@ public class ExpenseFixture {
 
     public static final String VALID_MEMO = "월세 너무 비싸다";
 
-    public static final String VALID_ITERATION_TYPE_STRING = "매달";
+    public static final String VALID_ITERATION_TYPE_STRING = "monthly";
 
     private ExpenseFixture() {}
 }

--- a/src/test/java/com/poortorich/expense/fixture/enums/CategoryNameValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/CategoryNameValidationCase.java
@@ -1,0 +1,26 @@
+package com.poortorich.expense.fixture.enums;
+
+import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.global.testcases.TestCase;
+
+public enum CategoryNameValidationCase implements TestCase<String, String> {
+    NULL(null, ExpenseResponseMessages.CATEGORY_NAME_REQUIRED);
+
+    private final String categoryName;
+    private final String expectedErrorMessage;
+
+    CategoryNameValidationCase(String categoryName, String expectedErrorMessage) {
+        this.categoryName = categoryName;
+        this.expectedErrorMessage = expectedErrorMessage;
+    }
+
+    @Override
+    public String getTestData() {
+        return categoryName;
+    }
+
+    @Override
+    public String getExpectedData() {
+        return expectedErrorMessage;
+    }
+}

--- a/src/test/java/com/poortorich/expense/fixture/enums/CostValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/CostValidationCase.java
@@ -1,0 +1,29 @@
+package com.poortorich.expense.fixture.enums;
+
+import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.global.testcases.TestCase;
+
+public enum CostValidationCase implements TestCase<Long, String> {
+    NULL(null,ExpenseResponseMessages.COST_REQUIRED),
+    ZERO(0L, ExpenseResponseMessages.COST_NEGATIVE),
+    MINUS(-1L, ExpenseResponseMessages.COST_NEGATIVE),
+    TOO_BIG(100000001L, ExpenseResponseMessages.COST_TOO_BIG);
+
+    private final Long cost;
+    private final String expectedErrorMessage;
+
+    CostValidationCase(Long cost, String expectedErrorMessage) {
+        this.cost = cost;
+        this.expectedErrorMessage = expectedErrorMessage;
+    }
+
+    @Override
+    public Long getTestData() {
+        return cost;
+    }
+
+    @Override
+    public String getExpectedData() {
+        return expectedErrorMessage;
+    }
+}

--- a/src/test/java/com/poortorich/expense/fixture/enums/DateValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/DateValidationCase.java
@@ -1,0 +1,28 @@
+package com.poortorich.expense.fixture.enums;
+
+import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.global.testcases.TestCase;
+
+import java.time.LocalDate;
+
+public enum DateValidationCase implements TestCase<LocalDate, String> {
+    NULL(null, ExpenseResponseMessages.DATE_REQUIRED);
+
+    private final LocalDate date;
+    private final String expectedErrorMessage;
+
+    DateValidationCase(LocalDate date, String expectedErrorMessage) {
+        this.date = date;
+        this.expectedErrorMessage = expectedErrorMessage;
+    }
+
+    @Override
+    public LocalDate getTestData() {
+        return date;
+    }
+
+    @Override
+    public String getExpectedData() {
+        return expectedErrorMessage;
+    }
+}

--- a/src/test/java/com/poortorich/expense/fixture/enums/MemoValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/MemoValidationCase.java
@@ -1,0 +1,27 @@
+package com.poortorich.expense.fixture.enums;
+
+import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.global.testcases.TestCase;
+
+public enum MemoValidationCase implements TestCase<String, String> {
+    TOO_LONG("아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청긴메모를작성해야하는데아직도100자가넘지않았지만이제막넘",
+            ExpenseResponseMessages.MEMO_TOO_LONG);
+
+    private final String memo;
+    private final String expectedErrorMessage;
+
+    MemoValidationCase(String memo, String expectedErrorMessage) {
+        this.memo = memo;
+        this.expectedErrorMessage = expectedErrorMessage;
+    }
+
+    @Override
+    public String getTestData() {
+        return memo;
+    }
+
+    @Override
+    public String getExpectedData() {
+        return expectedErrorMessage;
+    }
+}

--- a/src/test/java/com/poortorich/expense/fixture/enums/TitleValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/TitleValidationCase.java
@@ -1,0 +1,26 @@
+package com.poortorich.expense.fixture.enums;
+
+import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.global.testcases.TestCase;
+
+public enum TitleValidationCase implements TestCase<String, String> {
+    TOO_LONG("아주아주아주아주아주아주긴지출제목", ExpenseResponseMessages.TITLE_TOO_LONG);
+
+    private final String title;
+    private final String expectedErrorMessage;
+
+    TitleValidationCase(String title, String expectedErrorMessage) {
+        this.title = title;
+        this.expectedErrorMessage = expectedErrorMessage;
+    }
+
+    @Override
+    public String getTestData() {
+        return title;
+    }
+
+    @Override
+    public String getExpectedData() {
+        return expectedErrorMessage;
+    }
+}

--- a/src/test/java/com/poortorich/expense/request/ExpenseConverterTest.java
+++ b/src/test/java/com/poortorich/expense/request/ExpenseConverterTest.java
@@ -1,0 +1,115 @@
+package com.poortorich.expense.request;
+
+import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.expense.entity.enums.IterationType;
+import com.poortorich.expense.fixture.ExpenseFixture;
+import com.poortorich.expense.util.ExpenseRequestTestBuilder;
+import com.poortorich.global.exceptions.BadRequestException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ExpenseConverterTest {
+
+    private ExpenseRequestTestBuilder requestTestBuilder;
+
+    @BeforeEach
+    void setUp() {
+        requestTestBuilder = new ExpenseRequestTestBuilder();
+    }
+
+    @Nested
+    @DisplayName("지출 제목 예외 처리 테스트")
+    class TrimTitle {
+
+        @Test
+        @DisplayName("지출 제목이 null 인 경우 null 을 반환한다.")
+        void trimTitle_whenNull_returnsNull() {
+            ExpenseRequest request = requestTestBuilder
+                    .title(null)
+                    .build();
+
+            assertThat(request.trimTitle()).isNull();
+        }
+
+        @Test
+        @DisplayName("지출 제목의 앞 뒤 공백은 제거되어 저장된다.")
+        void trimTitle_whenSpacedTitle_returnsTrimmedTitle() {
+            ExpenseRequest request = requestTestBuilder
+                    .title(ExpenseFixture.SPACED_TITLE)
+                    .build();
+
+            assertThat(request.trimTitle()).isEqualTo(ExpenseFixture.VALID_TITLE);
+        }
+
+        @Test
+        @DisplayName("지출 제목이 빈 문자열일 경우 예외가 발생한다.")
+        void trimTitle_whenEmptyString_throwsException() {
+            ExpenseRequest request = requestTestBuilder
+                    .title("")
+                    .build();
+
+            assertThatThrownBy(request::trimTitle)
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(ExpenseResponseMessages.TITLE_TOO_SHORT);
+        }
+    }
+
+    @Nested
+    @DisplayName("지출 수단 예외 처리 테스트")
+    class ExceptionPaymentMethod {
+
+        @Test
+        @DisplayName("유효하지 않은 지출수단 입력 시 예외가 발생한다.")
+        void whenInvalidPaymentMethod_throwsException() {
+            ExpenseRequest request = requestTestBuilder
+                    .paymentMethod("유효하지않은지출수단")
+                    .build();
+
+            assertThatThrownBy(request::parsePaymentMethod)
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(ExpenseResponseMessages.PAYMENT_METHOD_INVALID);
+        }
+    }
+
+    @Nested
+    @DisplayName("반복 데이터 예외 처리 테스트")
+    class ExceptionIterationType {
+
+        @Test
+        @DisplayName("반복 데이터가 null 인 경우 DEFAULT 값으로 설정된다.")
+        void whenNullIterationType_returnsDEFAULT() {
+            ExpenseRequest request = requestTestBuilder
+                    .iterationType(null)
+                    .build();
+
+            assertThat(request.parseIterationType()).isEqualTo(IterationType.DEFAULT);
+        }
+
+        @Test
+        @DisplayName("반복 데이터가 공백인 경우 DEFAULT 값으로 설정된다.")
+        void whenEmptyIterationType_returnsDEFAULT() {
+            ExpenseRequest request = requestTestBuilder
+                    .iterationType("")
+                    .build();
+
+            assertThat(request.parseIterationType()).isEqualTo(IterationType.DEFAULT);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 반복 데이터 입력 시 예외가 발생한다.")
+        void whenInvalidIterationType_throwsException() {
+            ExpenseRequest request = requestTestBuilder
+                    .iterationType("유효하지않은반복데이터")
+                    .build();
+
+            assertThatThrownBy(request::parseIterationType)
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(ExpenseResponseMessages.ITERATION_TYPE_INVALID);
+        }
+    }
+}

--- a/src/test/java/com/poortorich/expense/request/ExpenseRequestValidTest.java
+++ b/src/test/java/com/poortorich/expense/request/ExpenseRequestValidTest.java
@@ -1,0 +1,117 @@
+package com.poortorich.expense.request;
+
+import com.poortorich.expense.fixture.enums.CategoryNameValidationCase;
+import com.poortorich.expense.fixture.enums.CostValidationCase;
+import com.poortorich.expense.fixture.enums.DateValidationCase;
+import com.poortorich.expense.fixture.enums.MemoValidationCase;
+import com.poortorich.expense.fixture.enums.TitleValidationCase;
+import com.poortorich.expense.util.ExpenseRequestTestBuilder;
+import com.poortorich.global.testcases.TestCase;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExpenseRequestValidTest {
+
+    private Validator validator;
+    private ExpenseRequestTestBuilder expenseRequestTestBuilder;
+
+    static Stream<Arguments> dateValidationCases() {
+        return TestCase.getAllTestCases(DateValidationCase.class);
+    }
+
+    static Stream<Arguments> categoryNameValidationCases() {
+        return TestCase.getAllTestCases(CategoryNameValidationCase.class);
+    }
+
+    static Stream<Arguments> titleValidationCases() {
+        return TestCase.getAllTestCases(TitleValidationCase.class);
+    }
+
+    static Stream<Arguments> costValidationCases() {
+        return TestCase.getAllTestCases(CostValidationCase.class);
+    }
+
+    static Stream<Arguments> memoValidationCases() {
+        return TestCase.getAllTestCases(MemoValidationCase.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            validator = validatorFactory.getValidator();
+        }
+        expenseRequestTestBuilder = new ExpenseRequestTestBuilder();
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateValidationCases")
+    void invalidDate_shouldFailValidation(LocalDate date, String expectedErrorMessage) {
+        ExpenseRequest request = expenseRequestTestBuilder.date(date).build();
+
+        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+    }
+
+    @ParameterizedTest
+    @MethodSource("categoryNameValidationCases")
+    void invalidCategoryName_shouldFailValidation(String categoryName, String expectedErrorMessage) {
+        ExpenseRequest request = expenseRequestTestBuilder.categoryName(categoryName).build();
+
+        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+    }
+
+    @ParameterizedTest
+    @MethodSource("titleValidationCases")
+    void invalidTitle_shouldFailValidation(String title, String expectedErrorMessage) {
+        ExpenseRequest request = expenseRequestTestBuilder.title(title).build();
+
+        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+    }
+
+    @ParameterizedTest
+    @MethodSource("costValidationCases")
+    void invalidCost_shouldFailValidation(Long cost, String expectedErrorMessage) {
+        ExpenseRequest request = expenseRequestTestBuilder.cost(cost).build();
+
+        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+    }
+
+    @ParameterizedTest
+    @MethodSource("memoValidationCases")
+    void invalidMemo_shouldFailValidation(String memo, String expectedErrorMessage) {
+        ExpenseRequest request = expenseRequestTestBuilder.memo(memo).build();
+
+        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
+
+        violations.forEach(v -> {
+            System.out.println(v.getMessage());
+            System.out.println(v.getMessageTemplate());
+        });
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+    }
+}

--- a/src/test/java/com/poortorich/expense/request/ExpenseRequestValidTest.java
+++ b/src/test/java/com/poortorich/expense/request/ExpenseRequestValidTest.java
@@ -7,10 +7,6 @@ import com.poortorich.expense.fixture.enums.MemoValidationCase;
 import com.poortorich.expense.fixture.enums.TitleValidationCase;
 import com.poortorich.expense.util.ExpenseRequestTestBuilder;
 import com.poortorich.global.testcases.TestCase;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validation;
-import jakarta.validation.Validator;
-import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,14 +14,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.LocalDate;
-import java.util.Set;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.poortorich.global.util.RequestValidTestHelper.assertValidationMessage;
 
 public class ExpenseRequestValidTest {
 
-    private Validator validator;
     private ExpenseRequestTestBuilder expenseRequestTestBuilder;
 
     static Stream<Arguments> dateValidationCases() {
@@ -50,9 +44,6 @@ public class ExpenseRequestValidTest {
 
     @BeforeEach
     void setUp() {
-        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
-            validator = validatorFactory.getValidator();
-        }
         expenseRequestTestBuilder = new ExpenseRequestTestBuilder();
     }
 
@@ -60,64 +51,49 @@ public class ExpenseRequestValidTest {
     @MethodSource("dateValidationCases")
     @DisplayName("Valid date")
     void invalidDate_shouldFailValidation(LocalDate date, String expectedErrorMessage) {
-        ExpenseRequest request = expenseRequestTestBuilder.date(date).build();
-
-        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
-
-        assertThat(violations)
-                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+        assertValidationMessage(
+                expenseRequestTestBuilder.date(date).build(),
+                expectedErrorMessage
+        );
     }
 
     @ParameterizedTest
     @MethodSource("categoryNameValidationCases")
     @DisplayName("Valid categoryName")
     void invalidCategoryName_shouldFailValidation(String categoryName, String expectedErrorMessage) {
-        ExpenseRequest request = expenseRequestTestBuilder.categoryName(categoryName).build();
-
-        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
-
-        assertThat(violations)
-                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+        assertValidationMessage(
+                expenseRequestTestBuilder.categoryName(categoryName).build(),
+                expectedErrorMessage
+        );
     }
 
     @ParameterizedTest
     @MethodSource("titleValidationCases")
     @DisplayName("Valid title")
     void invalidTitle_shouldFailValidation(String title, String expectedErrorMessage) {
-        ExpenseRequest request = expenseRequestTestBuilder.title(title).build();
-
-        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
-
-        assertThat(violations)
-                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+        assertValidationMessage(
+                expenseRequestTestBuilder.title(title).build(),
+                expectedErrorMessage
+        );
     }
 
     @ParameterizedTest
     @MethodSource("costValidationCases")
     @DisplayName("Valid cost")
     void invalidCost_shouldFailValidation(Long cost, String expectedErrorMessage) {
-        ExpenseRequest request = expenseRequestTestBuilder.cost(cost).build();
-
-        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
-
-        assertThat(violations)
-                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+        assertValidationMessage(
+                expenseRequestTestBuilder.cost(cost).build(),
+                expectedErrorMessage
+        );
     }
 
     @ParameterizedTest
     @MethodSource("memoValidationCases")
     @DisplayName("Valid memo")
     void invalidMemo_shouldFailValidation(String memo, String expectedErrorMessage) {
-        ExpenseRequest request = expenseRequestTestBuilder.memo(memo).build();
-
-        Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);
-
-        violations.forEach(v -> {
-            System.out.println(v.getMessage());
-            System.out.println(v.getMessageTemplate());
-        });
-
-        assertThat(violations)
-                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+        assertValidationMessage(
+                expenseRequestTestBuilder.memo(memo).build(),
+                expectedErrorMessage
+        );
     }
 }

--- a/src/test/java/com/poortorich/expense/request/ExpenseRequestValidTest.java
+++ b/src/test/java/com/poortorich/expense/request/ExpenseRequestValidTest.java
@@ -12,6 +12,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -57,6 +58,7 @@ public class ExpenseRequestValidTest {
 
     @ParameterizedTest
     @MethodSource("dateValidationCases")
+    @DisplayName("Valid date")
     void invalidDate_shouldFailValidation(LocalDate date, String expectedErrorMessage) {
         ExpenseRequest request = expenseRequestTestBuilder.date(date).build();
 
@@ -68,6 +70,7 @@ public class ExpenseRequestValidTest {
 
     @ParameterizedTest
     @MethodSource("categoryNameValidationCases")
+    @DisplayName("Valid categoryName")
     void invalidCategoryName_shouldFailValidation(String categoryName, String expectedErrorMessage) {
         ExpenseRequest request = expenseRequestTestBuilder.categoryName(categoryName).build();
 
@@ -79,6 +82,7 @@ public class ExpenseRequestValidTest {
 
     @ParameterizedTest
     @MethodSource("titleValidationCases")
+    @DisplayName("Valid title")
     void invalidTitle_shouldFailValidation(String title, String expectedErrorMessage) {
         ExpenseRequest request = expenseRequestTestBuilder.title(title).build();
 
@@ -90,6 +94,7 @@ public class ExpenseRequestValidTest {
 
     @ParameterizedTest
     @MethodSource("costValidationCases")
+    @DisplayName("Valid cost")
     void invalidCost_shouldFailValidation(Long cost, String expectedErrorMessage) {
         ExpenseRequest request = expenseRequestTestBuilder.cost(cost).build();
 
@@ -101,6 +106,7 @@ public class ExpenseRequestValidTest {
 
     @ParameterizedTest
     @MethodSource("memoValidationCases")
+    @DisplayName("Valid memo")
     void invalidMemo_shouldFailValidation(String memo, String expectedErrorMessage) {
         ExpenseRequest request = expenseRequestTestBuilder.memo(memo).build();
 

--- a/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
@@ -1,0 +1,63 @@
+package com.poortorich.expense.service;
+
+import com.poortorich.category.entity.Category;
+import com.poortorich.expense.entity.Expense;
+import com.poortorich.expense.fixture.ExpenseFixture;
+import com.poortorich.expense.repository.ExpenseRepository;
+import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.util.ExpenseRequestTestBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class ExpenseServiceTest {
+
+    @Mock
+    private ExpenseRepository expenseRepository;
+
+    @InjectMocks
+    private ExpenseService expenseService;
+
+    @Captor
+    private ArgumentCaptor<Expense> expenseCaptor;
+
+    private ExpenseRequest expenseRequest;
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        expenseRequest = new ExpenseRequestTestBuilder().build();
+        category = Category.builder()
+                .name(ExpenseFixture.VALID_CATEGORY_NAME)
+                .build();
+    }
+
+    @Test
+    @DisplayName("유효한 지출 정보가 성공적으로 저장된다.")
+    void createValidExpense() {
+        expenseService.createExpense(expenseRequest, category);
+
+        verify(expenseRepository).save(expenseCaptor.capture());
+        Expense savedExpense = expenseCaptor.getValue();
+        assertAll(
+                () -> assertThat(savedExpense.getExpenseDate()).isEqualTo(expenseRequest.getDate()),
+                () -> assertThat(savedExpense.getCategory()).isEqualTo(category),
+                () -> assertThat(savedExpense.getTitle()).isEqualTo(expenseRequest.getTitle()),
+                () -> assertThat(savedExpense.getCost()).isEqualTo(expenseRequest.getCost()),
+                () -> assertThat(savedExpense.getPaymentMethod()).isEqualTo(expenseRequest.parsePaymentMethod()),
+                () -> assertThat(savedExpense.getMemo()).isEqualTo(expenseRequest.getMemo()),
+                () -> assertThat(savedExpense.getIterationType()).isEqualTo(expenseRequest.parseIterationType())
+        );
+    }
+}

--- a/src/test/java/com/poortorich/expense/util/ExpenseRequestTestBuilder.java
+++ b/src/test/java/com/poortorich/expense/util/ExpenseRequestTestBuilder.java
@@ -1,0 +1,64 @@
+package com.poortorich.expense.util;
+
+import com.poortorich.expense.fixture.ExpenseFixture;
+import com.poortorich.expense.request.ExpenseRequest;
+
+import java.time.LocalDate;
+
+public class ExpenseRequestTestBuilder {
+
+    private LocalDate date = ExpenseFixture.VALID_DATE;
+    private String categoryName = ExpenseFixture.VALID_CATEGORY_NAME;
+    private String title = ExpenseFixture.VALID_TITLE;
+    private Long cost = ExpenseFixture.VALID_COST;
+    private String paymentMethod = ExpenseFixture.VALID_PAYMENT_METHOD_STRING;
+    private String memo = ExpenseFixture.VALID_MEMO;
+    private String iterationType = ExpenseFixture.VALID_ITERATION_TYPE_STRING;
+
+    public ExpenseRequestTestBuilder date(LocalDate date) {
+        this.date = date;
+        return this;
+    }
+
+    public ExpenseRequestTestBuilder categoryName(String categoryName) {
+        this.categoryName = categoryName;
+        return this;
+    }
+
+    public ExpenseRequestTestBuilder title(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public ExpenseRequestTestBuilder cost(Long cost) {
+        this.cost = cost;
+        return this;
+    }
+
+    public ExpenseRequestTestBuilder paymentMethod(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+        return this;
+    }
+
+    public ExpenseRequestTestBuilder memo(String memo) {
+        this.memo = memo;
+        return this;
+    }
+
+    public ExpenseRequestTestBuilder iterationType(String iterationType) {
+        this.iterationType = iterationType;
+        return this;
+    }
+
+    public ExpenseRequest build() {
+        return new ExpenseRequest(
+                date,
+                categoryName,
+                title,
+                cost,
+                paymentMethod,
+                memo,
+                iterationType
+        );
+    }
+}

--- a/src/test/java/com/poortorich/global/util/RequestValidTestHelper.java
+++ b/src/test/java/com/poortorich/global/util/RequestValidTestHelper.java
@@ -1,0 +1,25 @@
+package com.poortorich.global.util;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RequestValidTestHelper {
+
+    public static <T> void assertValidationMessage(T request, String expectedErrorMessage) {
+        Validator validator;
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            validator = validatorFactory.getValidator();
+        }
+
+        Set<ConstraintViolation<T>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
+    }
+}


### PR DESCRIPTION
## #️⃣41

## 📝작업 내용

## `Expense`
### Entity 클래스

- Category Entity와 `ManyToOne` 연관관계 설정
- `iterationType`을 Enum 타입으로 설정

> 로그인이 구현된 후 User 연관관계를 설정하기 위해, 현재는 주석처리를 해두었습니다.

## `ExpenseResponse`

- 성공 및 예외 처리에 필요한 필드 추가

> title, paymentMethod, iterationType 관련 필드는 `@Valid`로 처리하지 못하는 예외 처리를 위해 선언하였습니다.

- `title`의 경우, null 값을 허용하기 때문에 `@Size(min = 1)` 을 사용하는 경우 null 값까지 예외처리가 되어 따로 예외 처리를 진행하였습니다. 

상수명 | HttpStatus | 설명
-- | -- | --
CREATE_EXPENSE_SUCCESS | CREATED (201) | 지출 가계부를 성공적으로 등록
TITLE_TOO_SHORT | BAD REQUEST (400) | 지출 제목의 길이가 1 이하일 경우 (null 제외)
PAYMENT_METHOD_INVALID | BAD REQUEST (400) | 지출수단이 유효하지 않은 경우
ITERATION_TYPE_INVALID | BAD REQUEST (400) | 반복데이터가 유효하지 않은 경우

## `ExpenseRequest`

- `@Valid` 검증을 위한 어노테이션을 적절히 선언
API 명세서를 기반으로 작성하였습니다.

- Enum 값 `PaymentMethod` `IterationType` 의 parse 메서드 작성
- `title`의 **1자 이하 문자열 예외처리**를 위해 `trimTitle` 메서드 작성

## `ExpenseFacade`

- `Category`와 `Expense`는 서로 연관관계이기 때문에 Service 계층에서의 불필요한 의존성을 피하고자 Facade 패턴 사용

### `CategoryService`

- **`findCategoryByName`**
이름으로 카테고리를 찾아오고 만약 존재하지 않는다면 예외를 던지도록 구현
_로그인 구현 후 User 관련 코드 추가 예정_
> 이 과정에서 `CategoryRepository`에 `findByName` 코드를 추가하였습니다.

### `ExpenseService`
- **`createExpense`**
`ExpenseRequest` 값과 `findCategoryByName`에서 반환된 category를 이용하여 `Expense` Entity로 변환 후 `ExpenseRepository`로 저장

**성공적으로 저장된 경우 `CREATE_EXPENSE_SUCCESS` 반환**

---
## Test
> 간략하게 소개하겠습니다!

## `ExpenseRequestValidTest`

- `ExpenseRequest`에서 `@Valid` 관련 예외 처리 테스트 담당

## `ExpenseConverterTest`

- `ExpenseRequest`에서 `@Valid`로 처리하지 않는 예외 처리 메소드 `parsePaymentMethod()`, `trimTitle()`, `parseIterationType()` 테스트를 담당하고 있습니다.

## `ExpenseService`

- 유효한 데이터가 들어왔을 때 성공적으로 저장되는지 확인

## `ExpenseFacade`

- `CategoryService`와 `ExpenseService`가 적절하게 호출되는지 확인

## `ExpenseController`

- 유효한 데이터가 들어왔을 때 성공 response를 반환하는지 확인
> 유효하지 않은 데이터는 이미 `ExpenseRequest` 테스트에서 확인하였기 때문에 작성하지 않았습니다.

---
### 스크린샷

> 정상 실행
<img width="650" src="https://github.com/user-attachments/assets/af1eb8d9-3d0a-4c13-84a7-668074ac2503" />

> 작성한 테스트 모두 통과
![image](https://github.com/user-attachments/assets/2fe1dbde-0b95-4c1f-beed-a86b668c54cf)

 ## 💬리뷰 요구사항
 
- 전체적인 코드 컨벤션 및 변수명
- 테스트 코드
---
- `@Valid` 관련 테스트에서 아래 코드가 자꾸 반복되는데, 이 코드를 분리하여 관리하는 것에 대한 논의를 하고 싶습니다 🥸
``` java
Set<ConstraintViolation<ExpenseRequest>> violations = validator.validate(request);  

assertThat(violations)  
        .anyMatch(v -> v.getMessage().equals(expectedErrorMessage));
```