### PR TITLE
[#54] 응답 형식 리팩터링

### DIFF
--- a/src/main/java/com/poortorich/global/response/BaseResponse.java
+++ b/src/main/java/com/poortorich/global/response/BaseResponse.java
@@ -1,11 +1,11 @@
 package com.poortorich.global.response;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-@Builder
+@SuperBuilder
 @Getter
 public class BaseResponse {
 

--- a/src/main/java/com/poortorich/global/response/DataResponse.java
+++ b/src/main/java/com/poortorich/global/response/DataResponse.java
@@ -1,0 +1,31 @@
+package com.poortorich.global.response;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SuperBuilder
+@Getter
+public class DataResponse extends BaseResponse {
+
+    private final Object data;
+
+    public static ResponseEntity<DataResponse> toResponseEntity(Response response, Object data) {
+        return ResponseEntity.status(response.getHttpStatus())
+                .body(DataResponse.builder()
+                        .resultCode(response.getHttpStatus().value())
+                        .resultMessage(response.getMessage())
+                        .data(data)
+                        .build());
+    }
+
+    public static ResponseEntity<DataResponse> toResponseEntity(HttpStatus httpStatus, String message, Object data) {
+        return ResponseEntity.status(httpStatus)
+                .body(DataResponse.builder()
+                        .resultCode(httpStatus.value())
+                        .resultMessage(message)
+                        .data(data)
+                        .build());
+    }
+}


### PR DESCRIPTION
 ## #️⃣54
 ## 📝작업 내용
 
data 필드를 가지는 기본 응답 형식을 추가하였음.
BaseResponse를 상속하며 SuperBuilder를 통해 부모-자식간 필드 빌드 가능

< Trouble Shooting >
 DataResponse를 제너릭 타입을 사용해 선언하였으나 Builder 사용 시 타입을 찾지 못하는 문제가 발생하였음. data 필드의 타입을 Object로 수정하여 해결함.
 
