### PR TITLE
[#67] 지출 가계부 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
+++ b/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
@@ -20,7 +20,10 @@ public class ExpenseResponseMessages {
 
     public static final String ITERATION_TYPE_INVALID = "반복 데이터 유형이 적절하지 않습니다.";
 
-    public static final String CREATE_EXPENSE_SUCCESS = "가계부를 성공적으로 등록하였습니다.";
+    public static final String CREATE_EXPENSE_SUCCESS = "지출 가계부를 성공적으로 등록하였습니다.";
+    public static final String GET_EXPENSE_SUCCESS = "지출 가계부를 성공적으로 조회하였습니다.";
+
+    public static final String EXPENSE_NON_EXISTENT = "존재하지 않는 지출입니다.";
 
     private ExpenseResponseMessages() {}
 }

--- a/src/main/java/com/poortorich/expense/controller/ExpenseController.java
+++ b/src/main/java/com/poortorich/expense/controller/ExpenseController.java
@@ -2,12 +2,16 @@ package com.poortorich.expense.controller;
 
 import com.poortorich.expense.facade.ExpenseFacade;
 import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.response.BaseResponse;
+import com.poortorich.global.response.DataResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +29,15 @@ public class ExpenseController {
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody @Valid ExpenseRequest expenseRequest) {
         return BaseResponse.toResponseEntity(expenseFacade.createExpense(expenseRequest, userDetails.getUsername()));
+    }
+
+    @GetMapping("/{expenseId}")
+    public ResponseEntity<BaseResponse> getExpense(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long expenseId) {
+        return DataResponse.toResponseEntity(
+                ExpenseResponse.GET_EXPENSE_SUCCESS,
+                expenseFacade.getExpense(expenseId, userDetails.getUsername())
+        );
     }
 }

--- a/src/main/java/com/poortorich/expense/entity/Expense.java
+++ b/src/main/java/com/poortorich/expense/entity/Expense.java
@@ -3,6 +3,7 @@ package com.poortorich.expense.entity;
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.enums.IterationType;
 import com.poortorich.expense.entity.enums.PaymentMethod;
+import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,6 +15,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -64,14 +66,6 @@ public class Expense {
     @Column(name = "iterationType", nullable = false)
     private IterationType iterationType;
 
-    @CreationTimestamp
-    @Column(name = "createdDate")
-    private LocalDateTime createdDate;
-
-    @UpdateTimestamp
-    @Column(name = "updatedDate")
-    private LocalDateTime updatedDate;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "categoryId")
     private Category category;
@@ -79,4 +73,15 @@ public class Expense {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")
     private User user;
+
+    @OneToOne(mappedBy = "generatedExpense")
+    private IterationExpenses generatedIterationExpenses;
+
+    @CreationTimestamp
+    @Column(name = "createdDate")
+    private LocalDateTime createdDate;
+
+    @UpdateTimestamp
+    @Column(name = "updatedDate")
+    private LocalDateTime updatedDate;
 }

--- a/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
+++ b/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
@@ -31,4 +31,9 @@ public enum IterationType {
                 .findFirst()
                 .orElseThrow(() -> new BadRequestException(ExpenseResponse.ITERATION_TYPE_INVALID));
     }
+
+    @Override
+    public String toString() {
+        return type;
+    }
 }

--- a/src/main/java/com/poortorich/expense/entity/enums/PaymentMethod.java
+++ b/src/main/java/com/poortorich/expense/entity/enums/PaymentMethod.java
@@ -23,4 +23,9 @@ public enum PaymentMethod {
                 .findFirst()
                 .orElseThrow(() -> new BadRequestException(ExpenseResponse.PAYMENT_METHOD_INVALID));
     }
+
+    @Override
+    public String toString() {
+        return type;
+    }
 }

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -5,9 +5,12 @@ import com.poortorich.category.service.CategoryService;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.entity.enums.IterationType;
 import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.response.ExpenseInfoResponse;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.expense.service.ExpenseService;
 import com.poortorich.global.response.Response;
+import com.poortorich.iteration.entity.IterationExpenses;
+import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.iteration.service.IterationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,5 +44,17 @@ public class ExpenseFacade {
         if (expense.getIterationType() == IterationType.CUSTOM) {
             iterationService.createIterationInfo(expenseRequest.getCustomIteration(), expense, savedExpenses, username);
         }
+    }
+
+    @Transactional
+    public ExpenseInfoResponse getExpense(Long id, String username) {
+        IterationExpenses iterationExpenses = expenseService.getIterationExpenses(id, username);
+
+        CustomIterationInfoResponse customIteration = null;
+        if (iterationExpenses != null) {
+            customIteration = iterationService.getCustomIteration(iterationExpenses);
+        }
+
+        return expenseService.getExpenseInfoResponse(id, username, customIteration);
     }
 }

--- a/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
@@ -1,10 +1,14 @@
 package com.poortorich.expense.repository;
 
 import com.poortorich.expense.entity.Expense;
+import com.poortorich.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
+    Optional<Expense> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/com/poortorich/expense/response/ExpenseInfoResponse.java
+++ b/src/main/java/com/poortorich/expense/response/ExpenseInfoResponse.java
@@ -1,5 +1,6 @@
 package com.poortorich.expense.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExpenseInfoResponse {
 
     private LocalDate date;

--- a/src/main/java/com/poortorich/expense/response/ExpenseInfoResponse.java
+++ b/src/main/java/com/poortorich/expense/response/ExpenseInfoResponse.java
@@ -1,0 +1,25 @@
+package com.poortorich.expense.response;
+
+import com.poortorich.iteration.response.CustomIterationInfoResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpenseInfoResponse {
+
+    private LocalDate date;
+    private String categoryName;
+    private String title;
+    private Long cost;
+    private String paymentMethod;
+    private String memo;
+    private String iterationType;
+    private CustomIterationInfoResponse customIteration;
+}

--- a/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
+++ b/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
@@ -11,7 +11,6 @@ public enum ExpenseResponse implements Response {
     CREATE_EXPENSE_SUCCESS(HttpStatus.CREATED, ExpenseResponseMessages.CREATE_EXPENSE_SUCCESS),
     GET_EXPENSE_SUCCESS(HttpStatus.OK, ExpenseResponseMessages.GET_EXPENSE_SUCCESS),
 
-
     TITLE_TOO_SHORT(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.TITLE_TOO_SHORT),
     PAYMENT_METHOD_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.PAYMENT_METHOD_INVALID),
     ITERATION_TYPE_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.ITERATION_TYPE_INVALID),

--- a/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
+++ b/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
@@ -9,11 +9,15 @@ import org.springframework.http.HttpStatus;
 public enum ExpenseResponse implements Response {
 
     CREATE_EXPENSE_SUCCESS(HttpStatus.CREATED, ExpenseResponseMessages.CREATE_EXPENSE_SUCCESS),
+    GET_EXPENSE_SUCCESS(HttpStatus.OK, ExpenseResponseMessages.GET_EXPENSE_SUCCESS),
+
 
     TITLE_TOO_SHORT(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.TITLE_TOO_SHORT),
     PAYMENT_METHOD_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.PAYMENT_METHOD_INVALID),
     ITERATION_TYPE_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.ITERATION_TYPE_INVALID),
-    DATE_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.DATE_INVALID);
+    DATE_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.DATE_INVALID),
+
+    EXPENSE_NON_EXISTENT(HttpStatus.NOT_FOUND, ExpenseResponseMessages.EXPENSE_NON_EXISTENT);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/expense/service/ExpenseService.java
+++ b/src/main/java/com/poortorich/expense/service/ExpenseService.java
@@ -4,10 +4,14 @@ import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.repository.ExpenseRepository;
 import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.response.ExpenseInfoResponse;
 import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.repository.UserRepository;
 import com.poortorich.user.response.enums.UserResponse;
+import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.iteration.entity.IterationExpenses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -43,8 +47,32 @@ public class ExpenseService {
                 .build();
     }
 
+    public IterationExpenses getIterationExpenses(Long id, String username) {
+        Expense expense = getExpense(id, username);
+        return expense.getGeneratedIterationExpenses();
+    }
+
     private User findUserByUsername(String username) {
         return userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
+    }
+
+    public ExpenseInfoResponse getExpenseInfoResponse(Long id, String username, CustomIterationInfoResponse customIteration) {
+        Expense expense = getExpense(id, username);
+        return ExpenseInfoResponse.builder()
+                .date(expense.getExpenseDate())
+                .categoryName(expense.getCategory().getName())
+                .title(expense.getTitle())
+                .cost(expense.getCost())
+                .paymentMethod(expense.getPaymentMethod().toString())
+                .memo(expense.getMemo())
+                .iterationType(expense.getIterationType().toString())
+                .customIteration(customIteration)
+                .build();
+    }
+
+    private Expense getExpense(Long id, String username) {
+        return expenseRepository.findByIdAndUser(id, findUserByUsername(username))
+                .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
     }
 }

--- a/src/main/java/com/poortorich/iteration/entity/IterationExpenses.java
+++ b/src/main/java/com/poortorich/iteration/entity/IterationExpenses.java
@@ -58,6 +58,6 @@ public class IterationExpenses {
     private LocalDateTime createdDate;
 
     @UpdateTimestamp
-    @Column(name = "updateDate")
+    @Column(name = "updatedDate")
     private LocalDateTime updatedDate;
 }

--- a/src/main/java/com/poortorich/iteration/entity/enums/EndType.java
+++ b/src/main/java/com/poortorich/iteration/entity/enums/EndType.java
@@ -22,4 +22,9 @@ public enum EndType {
                 .findFirst()
                 .orElseThrow(() -> new BadRequestException(IterationResponse.END_TYPE_INVALID));
     }
+
+    @Override
+    public String toString() {
+        return type;
+    }
 }

--- a/src/main/java/com/poortorich/iteration/entity/enums/IterationRuleType.java
+++ b/src/main/java/com/poortorich/iteration/entity/enums/IterationRuleType.java
@@ -24,4 +24,9 @@ public enum IterationRuleType {
                 .findFirst()
                 .orElseThrow(() -> new BadRequestException(IterationResponse.ITERATION_RULE_TYPE_INVALID));
     }
+
+    @Override
+    public String toString() {
+        return type;
+    }
 }

--- a/src/main/java/com/poortorich/iteration/entity/enums/MonthlyMode.java
+++ b/src/main/java/com/poortorich/iteration/entity/enums/MonthlyMode.java
@@ -22,4 +22,9 @@ public enum MonthlyMode {
                 .findFirst()
                 .orElseThrow(() -> new BadRequestException(IterationResponse.MONTHLY_MODE_INVALID));
     }
+
+    @Override
+    public String toString() {
+        return mode;
+    }
 }

--- a/src/main/java/com/poortorich/iteration/entity/enums/Weekday.java
+++ b/src/main/java/com/poortorich/iteration/entity/enums/Weekday.java
@@ -43,4 +43,9 @@ public enum Weekday {
     public static Weekday fromDayOfWeek(DayOfWeek dayOfWeek) {
         return Weekday.values()[dayOfWeek.getValue() % 7];
     }
+
+    @Override
+    public String toString() {
+        return type;
+    }
 }

--- a/src/main/java/com/poortorich/iteration/entity/info/IterationInfo.java
+++ b/src/main/java/com/poortorich/iteration/entity/info/IterationInfo.java
@@ -61,7 +61,7 @@ public class IterationInfo {
     private LocalDateTime createdDate;
 
     @UpdateTimestamp
-    @Column(name = "updateDate")
+    @Column(name = "updatedDate")
     private LocalDateTime updatedDate;
 
     public String getIterationTypeLowerCase() {

--- a/src/main/java/com/poortorich/iteration/entity/info/IterationInfo.java
+++ b/src/main/java/com/poortorich/iteration/entity/info/IterationInfo.java
@@ -40,6 +40,9 @@ public class IterationInfo {
     @Column(name = "id")
     private Long id;
 
+    @Column(name = "iterationType", insertable = false, updatable = false)
+    private String iterationType;
+
     @Column(name = "cycle")
     private Integer cycle;
 
@@ -60,4 +63,8 @@ public class IterationInfo {
     @UpdateTimestamp
     @Column(name = "updateDate")
     private LocalDateTime updatedDate;
+
+    public String getIterationTypeLowerCase() {
+        return iterationType.toLowerCase();
+    }
 }

--- a/src/main/java/com/poortorich/iteration/entity/info/WeeklyIterationRule.java
+++ b/src/main/java/com/poortorich/iteration/entity/info/WeeklyIterationRule.java
@@ -1,13 +1,18 @@
 package com.poortorich.iteration.entity.info;
 
+import com.poortorich.iteration.entity.enums.Weekday;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Entity
 @Getter
@@ -20,4 +25,16 @@ public class WeeklyIterationRule extends IterationInfo {
 
     @Column(name = "daysOfWeek")
     private String daysOfWeek;
+
+    @Transient
+    public List<String> getDaysOfWeekList() {
+        if (daysOfWeek == null || daysOfWeek.isBlank()) {
+            return List.of();
+        }
+
+        return Arrays.stream(daysOfWeek.split(","))
+                .map(Weekday::valueOf)
+                .map(Weekday::toString)
+                .toList();
+    }
 }

--- a/src/main/java/com/poortorich/iteration/response/CustomIterationInfoResponse.java
+++ b/src/main/java/com/poortorich/iteration/response/CustomIterationInfoResponse.java
@@ -1,0 +1,17 @@
+package com.poortorich.iteration.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomIterationInfoResponse {
+
+    private IterationRuleInfoResponse iterationRule;
+    private Integer cycle;
+    private EndInfoResponse end;
+}

--- a/src/main/java/com/poortorich/iteration/response/EndInfoResponse.java
+++ b/src/main/java/com/poortorich/iteration/response/EndInfoResponse.java
@@ -1,0 +1,21 @@
+package com.poortorich.iteration.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EndInfoResponse {
+
+    private String type;
+    private Integer count;
+    private LocalDate date;
+}

--- a/src/main/java/com/poortorich/iteration/response/IterationRuleInfoResponse.java
+++ b/src/main/java/com/poortorich/iteration/response/IterationRuleInfoResponse.java
@@ -1,0 +1,21 @@
+package com.poortorich.iteration.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IterationRuleInfoResponse {
+
+    private String type;
+    private List<String> daysOfWeek;
+    private MonthlyOptionInfoResponse monthlyOption;
+}

--- a/src/main/java/com/poortorich/iteration/response/MonthlyOptionInfoResponse.java
+++ b/src/main/java/com/poortorich/iteration/response/MonthlyOptionInfoResponse.java
@@ -1,0 +1,20 @@
+package com.poortorich.iteration.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MonthlyOptionInfoResponse {
+
+    private String mode;
+    private Integer day;
+    private Integer week;
+    private String dayOfWeek;
+}

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -317,14 +317,10 @@ public class IterationService {
 
     public CustomIterationInfoResponse getCustomIteration(IterationExpenses iterationExpenses) {
         IterationInfo iterationInfo = iterationExpenses.getIterationInfo();
-        return buildCustomIterationInfo(iterationInfo);
-    }
-
-    private CustomIterationInfoResponse buildCustomIterationInfo(IterationInfo info) {
         return CustomIterationInfoResponse.builder()
-                .iterationRule(buildIterationRuleByRuleType(info))
-                .cycle(info.getCycle())
-                .end(buildEndInfoResponseByEndType(info))
+                .iterationRule(buildIterationRuleByRuleType(iterationInfo))
+                .cycle(iterationInfo.getCycle())
+                .end(buildEndInfoResponseByEndType(iterationInfo))
                 .build();
     }
 

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -237,6 +237,11 @@ public class IterationService {
         }
     }
 
+    private User findUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
+    }
+
     private IterationInfo getIterationInfo(CustomIteration customIteration) {
         IterationRuleType ruleType = customIteration.getIterationRule().parseIterationType();
 
@@ -308,11 +313,6 @@ public class IterationService {
                 .iterationInfo(iterationInfo)
                 .user(user)
                 .build();
-    }
-
-    private User findUserByUsername(String username) {
-        return userRepository.findByUsername(username)
-                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
     }
 
     public CustomIterationInfoResponse getCustomIteration(IterationExpenses iterationExpenses) {

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -20,12 +20,17 @@ import com.poortorich.iteration.request.CustomIteration;
 import com.poortorich.iteration.request.End;
 import com.poortorich.iteration.request.IterationRule;
 import com.poortorich.iteration.request.MonthlyOption;
+import com.poortorich.iteration.response.CustomIterationInfoResponse;
+import com.poortorich.iteration.response.EndInfoResponse;
 import com.poortorich.iteration.response.IterationResponse;
+import com.poortorich.iteration.response.IterationRuleInfoResponse;
+import com.poortorich.iteration.response.MonthlyOptionInfoResponse;
 import com.poortorich.iteration.util.IterationDateCalculator;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.repository.UserRepository;
 import com.poortorich.user.response.enums.UserResponse;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -62,6 +67,7 @@ public class IterationService {
         int maxIterations = 0;
         int allowedIterations = getAllowedIterations(expense.getIterationType(), customIteration);
 
+        iterationExpenses.add(expense);
         while (!date.isAfter(endDate)) {
             if (maxIterations > allowedIterations) {
                 throw new BadRequestException(IterationResponse.ITERATIONS_TOO_LONG);
@@ -307,5 +313,81 @@ public class IterationService {
     private User findUserByUsername(String username) {
         return userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
+    }
+
+    public CustomIterationInfoResponse getCustomIteration(IterationExpenses iterationExpenses) {
+        IterationInfo iterationInfo = iterationExpenses.getIterationInfo();
+        return buildCustomIterationInfo(iterationInfo);
+    }
+
+    private CustomIterationInfoResponse buildCustomIterationInfo(IterationInfo info) {
+        return CustomIterationInfoResponse.builder()
+                .iterationRule(buildIterationRuleByRuleType(info))
+                .cycle(info.getCycle())
+                .end(buildEndInfoResponseByEndType(info))
+                .build();
+    }
+
+    private IterationRuleInfoResponse buildIterationRuleByRuleType(IterationInfo info) {
+        IterationInfo unproxiedInfo = (IterationInfo) Hibernate.unproxy(info);
+
+        if (unproxiedInfo instanceof WeeklyIterationRule weekly) {
+            return IterationRuleInfoResponse.builder()
+                    .type(weekly.getIterationTypeLowerCase())
+                    .daysOfWeek(weekly.getDaysOfWeekList())
+                    .build();
+        }
+
+        if (unproxiedInfo instanceof MonthlyIterationRule monthly) {
+            return IterationRuleInfoResponse.builder()
+                    .type(monthly.getIterationTypeLowerCase())
+                    .monthlyOption(buildMonthlyOptionInfoResponseByMonthlyMode(monthly))
+                    .build();
+        }
+
+        return IterationRuleInfoResponse.builder()
+                .type(info.getIterationTypeLowerCase())
+                .build();
+    }
+
+    private MonthlyOptionInfoResponse buildMonthlyOptionInfoResponseByMonthlyMode(MonthlyIterationRule monthly) {
+        if (monthly.getMonthlyMode() == MonthlyMode.DAY) {
+            return MonthlyOptionInfoResponse.builder()
+                    .mode(monthly.getMonthlyMode().toString())
+                    .day(monthly.getMonthlyDay())
+                    .week(monthly.getMonthlyWeek())
+                    .build();
+        }
+
+        if (monthly.getMonthlyMode() == MonthlyMode.WEEKDAY) {
+            return MonthlyOptionInfoResponse.builder()
+                    .mode(monthly.getMonthlyMode().toString())
+                    .dayOfWeek(monthly.getMonthlyDayOfWeek().toString())
+                    .build();
+        }
+
+        return MonthlyOptionInfoResponse.builder()
+                .mode(monthly.getMonthlyMode().toString())
+                .build();
+    }
+
+    private EndInfoResponse buildEndInfoResponseByEndType(IterationInfo info) {
+        if (info.getEndType() == EndType.AFTER) {
+            return EndInfoResponse.builder()
+                    .type(info.getEndType().toString())
+                    .count(info.getEndCount())
+                    .build();
+        }
+
+        if (info.getEndType() == EndType.UNTIL) {
+            return EndInfoResponse.builder()
+                    .type(info.getEndType().toString())
+                    .date(info.getEndDate())
+                    .build();
+        }
+
+        return EndInfoResponse.builder()
+                .type(info.getEndType().toString())
+                .build();
     }
 }

--- a/src/test/java/com/poortorich/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/com/poortorich/expense/controller/ExpenseControllerTest.java
@@ -33,8 +33,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-
 @WebMvcTest(ExpenseController.class)
 @Import(SecurityConfig.class)
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#67 
 
 ## 📝작업 내용
 
## `Entity`

### `Expense`

- `IterationInfo` 정보를 얻기 위해 `IterationExpenses`와 양방향 매핑 관계를 맺도록 설정
   - 연관관계의 주인은 `generatedExpense` 필드로 설정

### `IterationInfo`

- 반복 타입 조회를 하기 위해 `@DiscriminatorColumn`의 `iterationType` 필드에 접근할 수 있도록 추가
- `getIterationTypeLowerCase()`
   : `iterationType`을 소문자 형태로 반환하는 메서드
   > 모든 Type 관련 필드들이 enum String 형태로 저장되기 때문에 다른 테이블의 형식에 맞춰 `iterationType`을 대문자로 저장했습니다. (`@DiscirminatorColumn`은 enum 지정 불가) 
   > 출력시 소문자 형태로 전달해줘야 하는데, 문자열이 짧고 변환하는 데에 드는 비용이 별로 크지 않다고 생각하여 `toLowerCase()`를 사용하게 되었습니다.

## `entity.enums`

- 각 enum 타입마다 value 값 출력이 필요하기 때문에 **toString 재정의**

## `Response`

### `ExpenseResponse`

- 지출 조회시 필요한 Reseponse 값을 추가

상수명 | HttpStatus | 설명
-- | -- | --
GET_EXPENSE_SUCCESS | OK (200) | 지출 가계부 조회 성공
EXPENSE_NON_EXISTENT | NOT_FOUND (404) | 지출 가계부 조회 실패

### `ExpenseInfoResponse`

- 지출 가계부 정보를 담는 responseDTO

### `CustomIterationInfoResponse`

- 사용자화 반복 데이터 정보를 담는 responseDTO

### `IterationRuleInfoResponse` `MonthlyOptionInfoResponse` `EndInfoResponse`

- 사용자화 반복 데이터에서 각 타입 별로 필요한 값만 전달될 수 있도록 `@JsonInclude(JsonInclude.Include.NON_NULL)
` 어노테이션을 사용
   필드 값이 null인 경우 그 필드는 전송이 되지 않음

## `IterationService`

#### `getCustomIteration()`
: `CustomIterationInfoResponse`를 반환하는 메서드

#### `buildIterationRuleByRuleType()`
: `IterationRuleInfoResponse`를 반환하는 메서드
   `IterationInfo` 타입에 따라 return 값이 다르기 때문에 instanceof 를 사용
> 지연로딩을 한 경우 Hibernate는 위해 프록시 객체를 사용하게 되는데, 부모 클래스인 `IterationInfo`를 기준으로 프록시 객체를 생성하기 때문에 `instanceof`에서 실패하는 문제가 발생하였습니다. (자식 클래스의 메서드나 타입 정보를 직접적으로 담고 있지 않음) 
> 이를 해결하기 위해 `Hibernate.unproxy(info)`를 사용하여 프록시 객체를 실제 객체로 변환해주었습니다.

#### `buildMonthlyOptionInfoResponseByMonthlyMode()`
: `IterationRuleType`이 `MONTHLY`인 경우 필요한 `MonthlyOption` 필드 정보를 받아오기 위한 메서드
`MonthlyMode`에 따라 반환하는 값이 다름

#### `buildEndInfoResponseByEndType()`
: `EndType`에 따라 `EndInfoResponse`를 반환하는 메서드

## `ExpenseService`

#### `getIterationExpenses()`
: `Expense`에 매핑된 `IterationExpenses`를 반환해주는 메서드

#### `getExpenseInfoResponse()`
: `ExpenseInfoResponse`를 build 후 반환해주는 메서드

#### `getExpense()`
: Id와 User 정보에 맞는 `Expense`를 반환하는 메서드
맞는 정보가 없다면 예외 처리

## `ExpenseFacade`

#### `getExpense()`
: `Expense`와 `IterationExpenses`를 바탕으로 데이터를 뽑아낸 뒤, `ExpenseInfoResponse`를 반환하는 메서드

## `ExpenseController`

#### `getExpense()`
: `expenseId` 값을 바탕으로 지출 가계부를 조회하는 메서드

 ### 스크린샷

> 기본 지출 가계부 조회에 성공한 경우
![image](https://github.com/user-attachments/assets/027acbc6-06ab-4cac-98c3-12515126c639)

> 사용자화 반복데이터를 설정한 지출 가계부 조회에 성공한 경우 
![image](https://github.com/user-attachments/assets/12b7b543-7881-45c7-9103-c1cc6d427977)

> 지출 가계부 조회에 실패한 경우
![image](https://github.com/user-attachments/assets/4a6aded8-aa8a-4cd8-be1d-2020aff77624)

 ## 💬리뷰 요구사항(선택)
