### PR TITLE
[#83] 비밀번호 변경 API

### DIFF
--- a/src/main/java/com/poortorich/user/constants/UserResponseMessages.java
+++ b/src/main/java/com/poortorich/user/constants/UserResponseMessages.java
@@ -31,12 +31,15 @@ public class UserResponseMessages {
     public static final String PASSWORD_LENGTH_INVALID = "비밀번호는 8 ~ 15자리로 작성해야 합니다.";
     public static final String PASSWORD_DO_NOT_MATCH = "비밀번호와 비밀번호 재입력이 일치하지 않습니다.";
     public static final String PASSWORD_CONFIRM_REQUIRED = "비밀번호 재입력칸을 입력해주세요.";
+
     public static final String PASSWORD_UPDATE_SUCCESS = "비밀번호 변경 성공";
     public static final String CURRENT_PASSWORD_REQUIRED = "현재 비밀번호를 입력해주세요.";
     public static final String NEW_PASSWORD_REQUIRED = "새 비밀번호를 입력해주세요.";
+    public static final String CURRENT_PASSWORD_IS_WRONG = "비밀번호가 틀렸습니다. 다시 입력해주세요.";
+    public static final String NEW_PASSWORD_IS_DO_NOT_MATCH = "새 비밀번호가 일치하지 않습니다.";
     
     public static final String BIRTHDAY_REQUIRED = "생년월일을 입력해주세요.";
-    public static final String BIRTHDAY_FORMAT_INVALID = "yyyy.mm.dd 형식이어야 합니다.";
+    public static final String BIRTHDAY_FORMAT_INVALID = "yyyy-mm-dd 형식이어야 합니다.";
     public static final String BIRTHDAY_IN_FUTURE = "생년월일은 오늘 이전 날짜여야 합니다.";
 
     public static final String EMAIL_REQUIRED = "이메일을 입력해주세요.";

--- a/src/main/java/com/poortorich/user/constants/UserResponseMessages.java
+++ b/src/main/java/com/poortorich/user/constants/UserResponseMessages.java
@@ -31,7 +31,10 @@ public class UserResponseMessages {
     public static final String PASSWORD_LENGTH_INVALID = "비밀번호는 8 ~ 15자리로 작성해야 합니다.";
     public static final String PASSWORD_DO_NOT_MATCH = "비밀번호와 비밀번호 재입력이 일치하지 않습니다.";
     public static final String PASSWORD_CONFIRM_REQUIRED = "비밀번호 재입력칸을 입력해주세요.";
-
+    public static final String PASSWORD_UPDATE_SUCCESS = "비밀번호 변경 성공";
+    public static final String CURRENT_PASSWORD_REQUIRED = "현재 비밀번호를 입력해주세요.";
+    public static final String NEW_PASSWORD_REQUIRED = "새 비밀번호를 입력해주세요.";
+    
     public static final String BIRTHDAY_REQUIRED = "생년월일을 입력해주세요.";
     public static final String BIRTHDAY_FORMAT_INVALID = "yyyy.mm.dd 형식이어야 합니다.";
     public static final String BIRTHDAY_IN_FUTURE = "생년월일은 오늘 이전 날짜여야 합니다.";

--- a/src/main/java/com/poortorich/user/controller/UserController.java
+++ b/src/main/java/com/poortorich/user/controller/UserController.java
@@ -2,9 +2,11 @@ package com.poortorich.user.controller;
 
 import com.poortorich.global.response.BaseResponse;
 import com.poortorich.global.response.DataResponse;
+import com.poortorich.global.response.Response;
 import com.poortorich.user.constants.UserResponseMessages;
 import com.poortorich.user.facade.UserFacade;
 import com.poortorich.user.request.NicknameCheckRequest;
+import com.poortorich.user.request.PasswordUpdateRequest;
 import com.poortorich.user.request.ProfileUpdateRequest;
 import com.poortorich.user.request.UserRegistrationRequest;
 import com.poortorich.user.request.UsernameCheckRequest;
@@ -72,5 +74,14 @@ public class UserController {
                 UserResponse.USER_EMAIL_FIND_SUCCESS,
                 userFacade.getUserEmail(userDetails.getUsername())
         );
+    }
+
+    @PutMapping("/password")
+    public ResponseEntity<BaseResponse> updateUserPassword(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid PasswordUpdateRequest passwordUpdateRequest
+    ) {
+        Response response = userFacade.updateUserPassword(userDetails.getUsername(), passwordUpdateRequest);
+        return BaseResponse.toResponseEntity(response);
     }
 }

--- a/src/main/java/com/poortorich/user/entity/User.java
+++ b/src/main/java/com/poortorich/user/entity/User.java
@@ -111,4 +111,8 @@ public class User implements UserDetails {
                 DateTimeFormatter.ofPattern(UserValidationRules.BIRTHDAY_DATE_FORMAT));
         this.job = userProfile.getJob();
     }
+
+    public void updatePasswrod(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/poortorich/user/entity/User.java
+++ b/src/main/java/com/poortorich/user/entity/User.java
@@ -112,7 +112,7 @@ public class User implements UserDetails {
         this.job = userProfile.getJob();
     }
 
-    public void updatePasswrod(String password) {
+    public void updatePassword(String password) {
         this.password = password;
     }
 }

--- a/src/main/java/com/poortorich/user/facade/UserFacade.java
+++ b/src/main/java/com/poortorich/user/facade/UserFacade.java
@@ -3,6 +3,7 @@ package com.poortorich.user.facade;
 import com.poortorich.global.response.Response;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.user.request.NicknameCheckRequest;
+import com.poortorich.user.request.PasswordUpdateRequest;
 import com.poortorich.user.request.ProfileUpdateRequest;
 import com.poortorich.user.request.UserRegistrationRequest;
 import com.poortorich.user.request.UsernameCheckRequest;
@@ -65,5 +66,12 @@ public class UserFacade {
 
     public UserEmailResponse getUserEmail(String username) {
         return userService.getUserEmail(username);
+    }
+
+    @Transactional
+    public Response updateUserPassword(String username, PasswordUpdateRequest passwordUpdateRequest) {
+        userValidationService.validateUpdateUserPassword(username, passwordUpdateRequest);
+        userService.updatePassword(username, passwordUpdateRequest.getNewPassword());
+        return UserResponse.PASSWORD_UPDATE_SUCCESS;
     }
 }

--- a/src/main/java/com/poortorich/user/request/PasswordUpdateRequest.java
+++ b/src/main/java/com/poortorich/user/request/PasswordUpdateRequest.java
@@ -1,0 +1,40 @@
+package com.poortorich.user.request;
+
+import com.poortorich.user.constants.UserResponseMessages;
+import com.poortorich.user.constants.UserValidationRules;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PasswordUpdateRequest {
+
+    @NotBlank(message = UserResponseMessages.CURRENT_PASSWORD_REQUIRED)
+    private final String currentPassword;
+
+    @NotBlank(message = UserResponseMessages.NEW_PASSWORD_REQUIRED)
+    @Size(
+            max = UserValidationRules.PASSWORD_MAX_LENGTH,
+            min = UserValidationRules.PASSWORD_MIN_LENGTH,
+            message = UserResponseMessages.PASSWORD_LENGTH_INVALID
+    )
+    @Pattern(
+            regexp = UserValidationRules.NO_BLANK_PATTERN,
+            message = UserResponseMessages.PASSWORD_CONTAINS_BLANK
+    )
+    @Pattern(
+            regexp = UserValidationRules.PASSWORD_NO_KOREAN_PATTERN,
+            message = UserResponseMessages.PASSWORD_CONTAINS_KOREAN
+    )
+    @Pattern(
+            regexp = UserValidationRules.PASSWORD_PATTERN,
+            message = UserResponseMessages.PASSWORD_INVALID
+    )
+    private final String newPassword;
+
+    @NotBlank(message = UserResponseMessages.PASSWORD_CONFIRM_REQUIRED)
+    private final String confirmNewPassword;
+}

--- a/src/main/java/com/poortorich/user/response/enums/UserResponse.java
+++ b/src/main/java/com/poortorich/user/response/enums/UserResponse.java
@@ -25,7 +25,9 @@ public enum UserResponse implements Response {
     GENDER_INVALID(HttpStatus.BAD_REQUEST, UserResponseMessages.GENDER_INVALID, "gender"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, UserResponseMessages.USER_NOT_FOUND, null),
     USER_DETAIL_FIND_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_DETAIL_FIND_SUCCESS, null),
-    USER_EMAIL_FIND_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_EMAIL_FIND_SUCCESS, null);
+    USER_EMAIL_FIND_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_EMAIL_FIND_SUCCESS, null),
+    PASSWORD_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.PASSWORD_UPDATE_SUCCESS, null),
+    USER_PROFILE_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/user/response/enums/UserResponse.java
+++ b/src/main/java/com/poortorich/user/response/enums/UserResponse.java
@@ -39,7 +39,6 @@ public enum UserResponse implements Response {
     USER_EMAIL_FIND_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_EMAIL_FIND_SUCCESS, null),
     USER_PROFILE_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS, null);
 
-
     private final HttpStatus httpStatus;
     private final String message;
     private final String field;

--- a/src/main/java/com/poortorich/user/response/enums/UserResponse.java
+++ b/src/main/java/com/poortorich/user/response/enums/UserResponse.java
@@ -11,23 +11,34 @@ import org.springframework.http.HttpStatus;
 public enum UserResponse implements Response {
 
     REGISTRATION_SUCCESS(HttpStatus.CREATED, UserResponseMessages.REGISTRATION_SUCCESS, null),
+
     USERNAME_DUPLICATE(HttpStatus.CONFLICT, UserResponseMessages.USERNAME_DUPLICATE, "username"),
     USERNAME_AVAILABLE(HttpStatus.OK, UserResponseMessages.USERNAME_AVAILABLE, null),
     USERNAME_RESERVE_CHECK_REQUIRED(HttpStatus.BAD_REQUEST, UserResponseMessages.USERNAME_RESERVE_CHECK_REQUIRED,
             "username"),
+
     NICKNAME_DUPLICATE(HttpStatus.CONFLICT, UserResponseMessages.NICKNAME_DUPLICATE, "nickname"),
     NICKNAME_AVAILABLE(HttpStatus.OK, UserResponseMessages.NICKNAME_AVAILABLE, null),
     NICKNAME_RESERVE_CHECK_REQUIRED(HttpStatus.BAD_REQUEST, UserResponseMessages.NICKNAME_RESERVE_CHECK_REQUIRED,
             "nickname"),
+
     EMAIL_DUPLICATE(HttpStatus.CONFLICT, UserResponseMessages.EMAIL_DUPLICATE, "email"),
+
     PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, UserResponseMessages.PASSWORD_DO_NOT_MATCH, "password"),
+    PASSWORD_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.PASSWORD_UPDATE_SUCCESS, null),
+    CURRENT_PASSWORD_IS_WRONG(HttpStatus.BAD_REQUEST, UserResponseMessages.CURRENT_PASSWORD_IS_WRONG,
+            "currentPassword"),
+    NEW_PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, UserResponseMessages.NEW_PASSWORD_IS_DO_NOT_MATCH, "newPassword"),
+
     BIRTHDAY_IN_FUTURE(HttpStatus.BAD_REQUEST, UserResponseMessages.BIRTHDAY_IN_FUTURE, "birth"),
+
     GENDER_INVALID(HttpStatus.BAD_REQUEST, UserResponseMessages.GENDER_INVALID, "gender"),
+
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, UserResponseMessages.USER_NOT_FOUND, null),
     USER_DETAIL_FIND_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_DETAIL_FIND_SUCCESS, null),
     USER_EMAIL_FIND_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_EMAIL_FIND_SUCCESS, null),
-    PASSWORD_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.PASSWORD_UPDATE_SUCCESS, null),
     USER_PROFILE_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS, null);
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -70,4 +70,10 @@ public class UserService {
                 .email(userEmail)
                 .build();
     }
+
+    public void updatePassword(String username, String newPassword) {
+        userRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND))
+                .updatePasswrod(passwordEncoder.encode(newPassword));
+    }
 }

--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -74,6 +74,6 @@ public class UserService {
     public void updatePassword(String username, String newPassword) {
         userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND))
-                .updatePasswrod(passwordEncoder.encode(newPassword));
+                .updatePassword(passwordEncoder.encode(newPassword));
     }
 }

--- a/src/main/java/com/poortorich/user/service/UserValidationService.java
+++ b/src/main/java/com/poortorich/user/service/UserValidationService.java
@@ -69,7 +69,7 @@ public class UserValidationService {
     }
 
     public void validateUpdateUserPassword(String username, PasswordUpdateRequest passwordUpdateRequest) {
-        userValidator.validatePasswordCorrect(username, passwordUpdateRequest.getCurrentPassword());
+        userValidator.validatePassword(username, passwordUpdateRequest.getCurrentPassword());
         userValidator.validatePasswordMatch(
                 passwordUpdateRequest.getNewPassword(),
                 passwordUpdateRequest.getConfirmNewPassword()

--- a/src/main/java/com/poortorich/user/service/UserValidationService.java
+++ b/src/main/java/com/poortorich/user/service/UserValidationService.java
@@ -24,10 +24,12 @@ public class UserValidationService {
     public void validateRegistration(UserRegistrationRequest userRegistrationRequest) {
         userValidator.validateUsernameDuplicate(userRegistrationRequest.getUsername());
         userValidator.validateNicknameDuplicate(userRegistrationRequest.getNickname());
-        userValidator.validatePasswordMatch(
+        if (!userValidator.isPasswordMatch(
                 userRegistrationRequest.getPassword(),
-                userRegistrationRequest.getPasswordConfirm()
-        );
+                userRegistrationRequest.getPasswordConfirm())
+        ) {
+            throw new BadRequestException(UserResponse.PASSWORD_DO_NOT_MATCH);
+        }
         userValidator.validateEmailDuplicate(userRegistrationRequest.getEmail());
         userValidator.validateBirthIsInFuture(userRegistrationRequest.parseBirthday());
 
@@ -70,9 +72,11 @@ public class UserValidationService {
 
     public void validateUpdateUserPassword(String username, PasswordUpdateRequest passwordUpdateRequest) {
         userValidator.validatePassword(username, passwordUpdateRequest.getCurrentPassword());
-        userValidator.validatePasswordMatch(
+        if (!userValidator.isPasswordMatch(
                 passwordUpdateRequest.getNewPassword(),
-                passwordUpdateRequest.getConfirmNewPassword()
-        );
+                passwordUpdateRequest.getConfirmNewPassword())
+        ) {
+            throw new BadRequestException(UserResponse.NEW_PASSWORD_DO_NOT_MATCH);
+        }
     }
 }

--- a/src/main/java/com/poortorich/user/service/UserValidationService.java
+++ b/src/main/java/com/poortorich/user/service/UserValidationService.java
@@ -5,6 +5,7 @@ import com.poortorich.email.util.EmailVerificationPolicyManager;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.ConflictException;
 import com.poortorich.global.exceptions.ForbiddenException;
+import com.poortorich.user.request.PasswordUpdateRequest;
 import com.poortorich.user.request.ProfileUpdateRequest;
 import com.poortorich.user.request.UserRegistrationRequest;
 import com.poortorich.user.response.enums.UserResponse;
@@ -60,10 +61,18 @@ public class UserValidationService {
     public void validateUpdateUserProfile(String username, ProfileUpdateRequest userProfile) {
         if (userValidator.isNicknameChanged(username, userProfile.getNickname())) {
             userValidator.validateNicknameDuplicate(userProfile.getNickname());
-            
+
             if (!userReservationService.existsByNickname(userProfile.getNickname())) {
                 throw new BadRequestException(UserResponse.NICKNAME_RESERVE_CHECK_REQUIRED);
             }
         }
+    }
+
+    public void validateUpdateUserPassword(String username, PasswordUpdateRequest passwordUpdateRequest) {
+        userValidator.validatePasswordCorrect(username, passwordUpdateRequest.getCurrentPassword());
+        userValidator.validatePasswordMatch(
+                passwordUpdateRequest.getNewPassword(),
+                passwordUpdateRequest.getConfirmNewPassword()
+        );
     }
 }

--- a/src/main/java/com/poortorich/user/validator/UserValidator.java
+++ b/src/main/java/com/poortorich/user/validator/UserValidator.java
@@ -1,6 +1,5 @@
 package com.poortorich.user.validator;
 
-import com.poortorich.auth.response.enums.AuthResponse;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.ConflictException;
 import com.poortorich.global.exceptions.NotFoundException;
@@ -37,10 +36,8 @@ public class UserValidator {
         }
     }
 
-    public void validatePasswordMatch(String password, String passwordConfirm) {
-        if (!password.equals(passwordConfirm)) {
-            throw new BadRequestException(UserResponse.PASSWORD_DO_NOT_MATCH);
-        }
+    public boolean isPasswordMatch(String password, String passwordConfirm) {
+        return password.equals(passwordConfirm);
     }
 
     public void validateBirthIsInFuture(LocalDate birthday) {
@@ -63,7 +60,7 @@ public class UserValidator {
                 .getPassword();
 
         if (!passwordEncoder.matches(password, userPassword)) {
-            throw new BadRequestException(AuthResponse.CREDENTIALS_INVALID);
+            throw new BadRequestException(UserResponse.CURRENT_PASSWORD_IS_WRONG);
         }
     }
 }

--- a/src/main/java/com/poortorich/user/validator/UserValidator.java
+++ b/src/main/java/com/poortorich/user/validator/UserValidator.java
@@ -57,12 +57,12 @@ public class UserValidator {
         return !Objects.equals(currentNickname, nickname);
     }
 
-    public void validatePasswordCorrect(String username, String currentPassword) {
-        String password = userRepository.findByUsername(username)
+    public void validatePassword(String username, String password) {
+        String userPassword = userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND))
                 .getPassword();
 
-        if (!passwordEncoder.matches(currentPassword, password)) {
+        if (!passwordEncoder.matches(password, userPassword)) {
             throw new BadRequestException(AuthResponse.CREDENTIALS_INVALID);
         }
     }

--- a/src/test/java/com/poortorich/user/controller/UserControllerTest.java
+++ b/src/test/java/com/poortorich/user/controller/UserControllerTest.java
@@ -21,13 +21,14 @@ import com.poortorich.user.facade.UserFacade;
 import com.poortorich.user.fixture.UserFixture;
 import com.poortorich.user.fixture.UserRegisterApiFixture;
 import com.poortorich.user.request.NicknameCheckRequest;
+import com.poortorich.user.request.PasswordUpdateRequest;
 import com.poortorich.user.request.ProfileUpdateRequest;
 import com.poortorich.user.request.UserRegistrationRequest;
 import com.poortorich.user.request.UsernameCheckRequest;
 import com.poortorich.user.response.UserDetailResponse;
 import com.poortorich.user.response.UserEmailResponse;
 import com.poortorich.user.response.enums.UserResponse;
-import com.poortorich.user.util.UserRegistrationRequestTestBuilder;
+import com.poortorich.user.util.PasswordUpdateRequestTestBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -275,7 +276,27 @@ class UserControllerTest extends BaseSecurityTest {
         verify(userFacade, times(1)).getUserEmail(anyString());
     }
 
-    private String getUserRegistrationRequestJson() throws JsonProcessingException {
-        return objectMapper.writeValueAsString(new UserRegistrationRequestTestBuilder().build());
+    @Test
+    @DisplayName("유효한 데이터로 비밀번호 변경 api 호출 - 성공")
+    @WithMockUser(username = UserFixture.VALID_USERNAME_SAMPLE_1)
+    void updateUserPassword_whenValidInput_thenNoException() throws Exception {
+        User mockUser = UserFixture.createDefaultUser();
+        PasswordUpdateRequest request = PasswordUpdateRequestTestBuilder.builder().build();
+
+        when(userFacade.updateUserPassword(anyString(), any(PasswordUpdateRequest.class)))
+                .thenReturn(UserResponse.PASSWORD_UPDATE_SUCCESS);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/user/password")
+                        .with(SecurityMockMvcRequestPostProcessors.user(mockUser))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(getRequestJson(request)))
+                .andExpect(jsonPath("$.resultCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.resultMessage").value(UserResponseMessages.PASSWORD_UPDATE_SUCCESS));
+
+        verify(userFacade).updateUserPassword(anyString(), any(PasswordUpdateRequest.class));
+    }
+
+    private String getRequestJson(Object request) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(request);
     }
 }

--- a/src/test/java/com/poortorich/user/facade/UserFacadeTest.java
+++ b/src/test/java/com/poortorich/user/facade/UserFacadeTest.java
@@ -16,6 +16,7 @@ import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.fixture.UserFixture;
 import com.poortorich.user.request.NicknameCheckRequest;
+import com.poortorich.user.request.PasswordUpdateRequest;
 import com.poortorich.user.request.ProfileUpdateRequest;
 import com.poortorich.user.request.UserRegistrationRequest;
 import com.poortorich.user.request.UsernameCheckRequest;
@@ -25,6 +26,7 @@ import com.poortorich.user.response.enums.UserResponse;
 import com.poortorich.user.service.RedisUserReservationService;
 import com.poortorich.user.service.UserService;
 import com.poortorich.user.service.UserValidationService;
+import com.poortorich.user.util.PasswordUpdateRequestTestBuilder;
 import com.poortorich.user.util.ProfileUpdateRequestTestBuilder;
 import com.poortorich.user.util.UserRegistrationRequestTestBuilder;
 import org.junit.jupiter.api.BeforeEach;
@@ -179,5 +181,23 @@ public class UserFacadeTest {
         userFacade.getUserEmail(mockUser.getUsername());
 
         verify(userService, times(1)).getUserEmail(anyString());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 요청 시 서비스들이 적절히 호출되는지 확인한다.")
+    void updateUserPassword_shouldCallServiceMethods() {
+        String username = UserFixture.VALID_USERNAME_SAMPLE_1;
+        PasswordUpdateRequest passwordUpdateRequest = PasswordUpdateRequestTestBuilder.builder().build();
+
+        doNothing().when(userValidationService)
+                .validateUpdateUserPassword(anyString(), any(PasswordUpdateRequest.class));
+
+        doNothing().when(userService)
+                .updatePassword(username, passwordUpdateRequest.getNewPassword());
+
+        userFacade.updateUserPassword(username, passwordUpdateRequest);
+
+        verify(userValidationService, times(1)).validateUpdateUserPassword(username, passwordUpdateRequest);
+        verify(userService, times(1)).updatePassword(username, passwordUpdateRequest.getNewPassword());
     }
 }

--- a/src/test/java/com/poortorich/user/service/UserServiceTest.java
+++ b/src/test/java/com/poortorich/user/service/UserServiceTest.java
@@ -158,6 +158,22 @@ public class UserServiceTest {
         assertThat(userEmail.getEmail()).isEqualTo(mockUser.getEmail());
 
         verify(userRepository, times(1)).findByUsername(anyString());
+    }
 
+    @Test
+    @DisplayName("회원이 존재할 때 비밀번호를 변경한다.")
+    void updateUserPassword_whenUserExists_thenUpdatePassword() {
+        User mockUser = UserFixture.createDefaultUser();
+        String newPassword = UserFixture.VALID_PASSWORD_SAMPLE_2;
+        String encodedNewPassword = UserFixture.TEST_ENCODED_PASSWORD;
+
+        when(userRepository.findByUsername(anyString())).thenReturn(Optional.of(mockUser));
+        when(passwordEncoder.encode(anyString())).thenReturn(encodedNewPassword);
+
+        userService.updatePassword(mockUser.getUsername(), newPassword);
+
+        assertThat(mockUser.getPassword()).isEqualTo(encodedNewPassword);
+
+        verify(userRepository, times(1)).findByUsername(anyString());
     }
 }

--- a/src/test/java/com/poortorich/user/service/UserValidationServiceTest.java
+++ b/src/test/java/com/poortorich/user/service/UserValidationServiceTest.java
@@ -65,12 +65,12 @@ public class UserValidationServiceTest {
         when(emailVerificationPolicyManager.isEmailVerified(Mockito.anyString())).thenReturn(true);
         when(userReservationService.existsByUsername(request.getUsername())).thenReturn(true);
         when(userReservationService.existsByNickname(request.getNickname())).thenReturn(true);
-
+        when(userValidator.isPasswordMatch(anyString(), anyString())).thenReturn(true);
         userValidationService.validateRegistration(request);
 
         verify(userValidator).validateUsernameDuplicate(request.getUsername());
         verify(userValidator).validateNicknameDuplicate(request.getNickname());
-        verify(userValidator).validatePasswordMatch(request.getPassword(), request.getPasswordConfirm());
+        verify(userValidator).isPasswordMatch(request.getPassword(), request.getPasswordConfirm());
         verify(userValidator).validateEmailDuplicate(request.getEmail());
         verify(userValidator).validateBirthIsInFuture(request.parseBirthday());
         verify(userReservationService).existsByUsername(request.getUsername());
@@ -86,6 +86,7 @@ public class UserValidationServiceTest {
         when(emailVerificationPolicyManager.isEmailVerified(any())).thenReturn(false);
         when(userReservationService.existsByUsername(request.getUsername())).thenReturn(true);
         when(userReservationService.existsByNickname(request.getNickname())).thenReturn(true);
+        when(userValidator.isPasswordMatch(anyString(), anyString())).thenReturn(true);
 
         assertThatThrownBy(() -> userValidationService.validateRegistration(request))
                 .isInstanceOf(ForbiddenException.class)
@@ -93,7 +94,7 @@ public class UserValidationServiceTest {
 
         verify(userValidator).validateUsernameDuplicate(request.getUsername());
         verify(userValidator).validateNicknameDuplicate(request.getNickname());
-        verify(userValidator).validatePasswordMatch(request.getPassword(), request.getPasswordConfirm());
+        verify(userValidator).isPasswordMatch(request.getPassword(), request.getPasswordConfirm());
         verify(userValidator).validateEmailDuplicate(request.getEmail());
         verify(userValidator).validateBirthIsInFuture(request.parseBirthday());
         verify(userReservationService).existsByUsername(request.getUsername());
@@ -116,7 +117,7 @@ public class UserValidationServiceTest {
 
         verify(userValidator).validateUsernameDuplicate(request.getUsername());
         verify(userValidator, never()).validateNicknameDuplicate(any());
-        verify(userValidator, never()).validatePasswordMatch(any(), any());
+        verify(userValidator, never()).isPasswordMatch(any(), any());
         verify(userValidator, never()).validateEmailDuplicate(any());
         verify(userValidator, never()).validateBirthIsInFuture(any());
         verify(userReservationService, never()).existsByUsername(any());
@@ -139,7 +140,7 @@ public class UserValidationServiceTest {
 
         verify(userValidator).validateUsernameDuplicate(request.getUsername());
         verify(userValidator).validateNicknameDuplicate(request.getNickname());
-        verify(userValidator, never()).validatePasswordMatch(any(), any());
+        verify(userValidator, never()).isPasswordMatch(any(), any());
         verify(userValidator, never()).validateEmailDuplicate(any());
         verify(userValidator, never()).validateBirthIsInFuture(any());
         verify(userReservationService, never()).existsByUsername(any());
@@ -154,9 +155,7 @@ public class UserValidationServiceTest {
                 .passwordConfirm(UserFixture.MISMATCH_PASSWORD_CONFIRM)
                 .build();
 
-        doThrow(new BadRequestException(UserResponse.PASSWORD_DO_NOT_MATCH))
-                .when(userValidator)
-                .validatePasswordMatch(request.getPassword(), request.getPasswordConfirm());
+        when(userValidator.isPasswordMatch(anyString(), anyString())).thenReturn(false);
 
         assertThatThrownBy(() -> userValidationService.validateRegistration(request))
                 .isInstanceOf(BadRequestException.class)
@@ -164,7 +163,7 @@ public class UserValidationServiceTest {
 
         verify(userValidator).validateUsernameDuplicate(request.getUsername());
         verify(userValidator).validateNicknameDuplicate(request.getNickname());
-        verify(userValidator).validatePasswordMatch(request.getPassword(), request.getPasswordConfirm());
+        verify(userValidator).isPasswordMatch(request.getPassword(), request.getPasswordConfirm());
         verify(userValidator, never()).validateEmailDuplicate(any());
         verify(userValidator, never()).validateBirthIsInFuture(any());
         verify(userReservationService, never()).existsByUsername(any());
@@ -177,6 +176,7 @@ public class UserValidationServiceTest {
     void validateRegistration_whenEmailDuplicate_thenThrowConflictException() {
         UserRegistrationRequest request = userRegistrationBuilder.build();
 
+        when(userValidator.isPasswordMatch(anyString(), anyString())).thenReturn(true);
         doThrow(new ConflictException(UserResponse.EMAIL_DUPLICATE))
                 .when(userValidator)
                 .validateEmailDuplicate(request.getEmail());
@@ -187,7 +187,7 @@ public class UserValidationServiceTest {
 
         verify(userValidator).validateUsernameDuplicate(request.getUsername());
         verify(userValidator).validateNicknameDuplicate(request.getNickname());
-        verify(userValidator).validatePasswordMatch(request.getPassword(), request.getPasswordConfirm());
+        verify(userValidator).isPasswordMatch(request.getPassword(), request.getPasswordConfirm());
         verify(userValidator).validateEmailDuplicate(request.getEmail());
         verify(userValidator, never()).validateBirthIsInFuture(any());
         verify(userReservationService, never()).existsByUsername(any());
@@ -202,6 +202,7 @@ public class UserValidationServiceTest {
                 .email(UserFixture.FUTURE_BIRTH)
                 .build();
 
+        when(userValidator.isPasswordMatch(anyString(), anyString())).thenReturn(true);
         doThrow(new BadRequestException(UserResponse.BIRTHDAY_IN_FUTURE))
                 .when(userValidator)
                 .validateBirthIsInFuture(request.parseBirthday());
@@ -212,7 +213,7 @@ public class UserValidationServiceTest {
 
         verify(userValidator).validateUsernameDuplicate(request.getUsername());
         verify(userValidator).validateNicknameDuplicate(request.getNickname());
-        verify(userValidator).validatePasswordMatch(request.getPassword(), request.getPasswordConfirm());
+        verify(userValidator).isPasswordMatch(request.getPassword(), request.getPasswordConfirm());
         verify(userValidator).validateEmailDuplicate(request.getEmail());
         verify(userValidator).validateBirthIsInFuture(request.parseBirthday());
         verify(userReservationService, never()).existsByUsername(any());
@@ -225,6 +226,7 @@ public class UserValidationServiceTest {
     void validateRegistration_whenUsernameIsNotReserved_thenThrowBadRequestException() {
         UserRegistrationRequest request = userRegistrationBuilder.build();
 
+        when(userValidator.isPasswordMatch(anyString(), anyString())).thenReturn(true);
         when(userReservationService.existsByUsername(any())).thenReturn(false);
 
         assertThatThrownBy(() -> userValidationService.validateRegistration(request))
@@ -233,7 +235,7 @@ public class UserValidationServiceTest {
 
         verify(userValidator).validateUsernameDuplicate(request.getUsername());
         verify(userValidator).validateNicknameDuplicate(request.getNickname());
-        verify(userValidator).validatePasswordMatch(request.getPassword(), request.getPasswordConfirm());
+        verify(userValidator).isPasswordMatch(request.getPassword(), request.getPasswordConfirm());
         verify(userValidator).validateEmailDuplicate(request.getEmail());
         verify(userValidator).validateBirthIsInFuture(request.parseBirthday());
         verify(userReservationService).existsByUsername(request.getUsername());
@@ -248,6 +250,7 @@ public class UserValidationServiceTest {
 
         when(userReservationService.existsByUsername(any())).thenReturn(true);
         when(userReservationService.existsByNickname(any())).thenReturn(false);
+        when(userValidator.isPasswordMatch(anyString(), anyString())).thenReturn(true);
 
         assertThatThrownBy(() -> userValidationService.validateRegistration(request))
                 .isInstanceOf(BadRequestException.class)
@@ -255,7 +258,7 @@ public class UserValidationServiceTest {
 
         verify(userValidator).validateUsernameDuplicate(request.getUsername());
         verify(userValidator).validateNicknameDuplicate(request.getNickname());
-        verify(userValidator).validatePasswordMatch(request.getPassword(), request.getPasswordConfirm());
+        verify(userValidator).isPasswordMatch(request.getPassword(), request.getPasswordConfirm());
         verify(userValidator).validateEmailDuplicate(request.getEmail());
         verify(userValidator).validateBirthIsInFuture(request.parseBirthday());
         verify(userReservationService).existsByUsername(request.getUsername());
@@ -427,13 +430,14 @@ public class UserValidationServiceTest {
         String username = UserFixture.VALID_USERNAME_SAMPLE_1;
         PasswordUpdateRequest passwordUpdateRequest = PasswordUpdateRequestTestBuilder.builder().build();
 
+        when(userValidator.isPasswordMatch(anyString(), anyString())).thenReturn(true);
         doNothing().when(userValidator).validatePassword(anyString(), anyString());
 
         userValidationService.validateUpdateUserPassword(username, passwordUpdateRequest);
 
         verify(userValidator, times(1)).validatePassword(username, passwordUpdateRequest.getCurrentPassword());
         verify(userValidator, times(1))
-                .validatePasswordMatch(
+                .isPasswordMatch(
                         passwordUpdateRequest.getNewPassword(),
                         passwordUpdateRequest.getConfirmNewPassword()
                 );

--- a/src/test/java/com/poortorich/user/service/UserValidationServiceTest.java
+++ b/src/test/java/com/poortorich/user/service/UserValidationServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,9 +18,11 @@ import com.poortorich.global.exceptions.ForbiddenException;
 import com.poortorich.user.constants.UserResponseMessages;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.fixture.UserFixture;
+import com.poortorich.user.request.PasswordUpdateRequest;
 import com.poortorich.user.request.ProfileUpdateRequest;
 import com.poortorich.user.request.UserRegistrationRequest;
 import com.poortorich.user.response.enums.UserResponse;
+import com.poortorich.user.util.PasswordUpdateRequestTestBuilder;
 import com.poortorich.user.util.ProfileUpdateRequestTestBuilder;
 import com.poortorich.user.util.UserRegistrationRequestTestBuilder;
 import com.poortorich.user.validator.UserValidator;
@@ -416,5 +419,23 @@ public class UserValidationServiceTest {
         verify(userValidator).isNicknameChanged(UserFixture.VALID_USERNAME_SAMPLE_1, profile.getNickname());
         verify(userValidator).validateNicknameDuplicate(profile.getNickname());
         verify(userReservationService).existsByNickname(profile.getNickname());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 검증 - 유효한 데이터인 경우 예외가 발생하지 않는다.")
+    public void validateUpdateUserPassword_whenValidRequest_thenDoNothing() {
+        String username = UserFixture.VALID_USERNAME_SAMPLE_1;
+        PasswordUpdateRequest passwordUpdateRequest = PasswordUpdateRequestTestBuilder.builder().build();
+
+        doNothing().when(userValidator).validatePassword(anyString(), anyString());
+
+        userValidationService.validateUpdateUserPassword(username, passwordUpdateRequest);
+
+        verify(userValidator, times(1)).validatePassword(username, passwordUpdateRequest.getCurrentPassword());
+        verify(userValidator, times(1))
+                .validatePasswordMatch(
+                        passwordUpdateRequest.getNewPassword(),
+                        passwordUpdateRequest.getConfirmNewPassword()
+                );
     }
 }

--- a/src/test/java/com/poortorich/user/util/PasswordUpdateRequestTestBuilder.java
+++ b/src/test/java/com/poortorich/user/util/PasswordUpdateRequestTestBuilder.java
@@ -1,4 +1,34 @@
 package com.poortorich.user.util;
 
+import com.poortorich.user.fixture.UserFixture;
+import com.poortorich.user.request.PasswordUpdateRequest;
+
 public class PasswordUpdateRequestTestBuilder {
+
+    private String currentPassword = UserFixture.VALID_PASSWORD_SAMPLE_1;
+    private String newPassword = UserFixture.VALID_PASSWORD_SAMPLE_2;
+    private String confirmNewPassword = UserFixture.VALID_PASSWORD_SAMPLE_2;
+
+    public static PasswordUpdateRequestTestBuilder builder() {
+        return new PasswordUpdateRequestTestBuilder();
+    }
+
+    public PasswordUpdateRequestTestBuilder currentPassword(String currentPassword) {
+        this.currentPassword = currentPassword;
+        return this;
+    }
+
+    public PasswordUpdateRequestTestBuilder newPassword(String newPassword) {
+        this.newPassword = newPassword;
+        return this;
+    }
+
+    public PasswordUpdateRequestTestBuilder confirmNewPassword(String confirmNewPassword) {
+        this.confirmNewPassword = confirmNewPassword;
+        return this;
+    }
+
+    public PasswordUpdateRequest build() {
+        return new PasswordUpdateRequest(currentPassword, newPassword, confirmNewPassword);
+    }
 }

--- a/src/test/java/com/poortorich/user/util/PasswordUpdateRequestTestBuilder.java
+++ b/src/test/java/com/poortorich/user/util/PasswordUpdateRequestTestBuilder.java
@@ -1,0 +1,4 @@
+package com.poortorich.user.util;
+
+public class PasswordUpdateRequestTestBuilder {
+}

--- a/src/test/java/com/poortorich/user/validator/UserValidatorTest.java
+++ b/src/test/java/com/poortorich/user/validator/UserValidatorTest.java
@@ -162,7 +162,7 @@ class UserValidatorTest {
             String password = UserFixture.VALID_PASSWORD_SAMPLE_1;
             String differentPasswordConfirm = UserFixture.MISMATCH_PASSWORD_CONFIRM;
 
-            Assertions.assertThatThrownBy(() -> userValidator.validatePasswordMatch(password, differentPasswordConfirm))
+            Assertions.assertThatThrownBy(() -> userValidator.isPasswordMatch(password, differentPasswordConfirm))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage(UserResponseMessages.PASSWORD_DO_NOT_MATCH);
         }
@@ -173,7 +173,7 @@ class UserValidatorTest {
             String password = UserFixture.VALID_PASSWORD_SAMPLE_1;
             String passwordConfirm = UserFixture.VALID_PASSWORD_SAMPLE_1;
 
-            userValidator.validatePasswordMatch(password, passwordConfirm);
+            userValidator.isPasswordMatch(password, passwordConfirm);
         }
 
         @Test

--- a/src/test/java/com/poortorich/user/validator/UserValidatorTest.java
+++ b/src/test/java/com/poortorich/user/validator/UserValidatorTest.java
@@ -3,8 +3,12 @@ package com.poortorich.user.validator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.poortorich.auth.constants.AuthResponseMessage;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.ConflictException;
 import com.poortorich.global.exceptions.NotFoundException;
@@ -12,6 +16,7 @@ import com.poortorich.user.constants.UserResponseMessages;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.fixture.UserFixture;
 import com.poortorich.user.repository.UserRepository;
+import com.poortorich.user.response.enums.UserResponse;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -22,12 +27,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 class UserValidatorTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private UserValidator userValidator;
@@ -165,6 +174,56 @@ class UserValidatorTest {
             String passwordConfirm = UserFixture.VALID_PASSWORD_SAMPLE_1;
 
             userValidator.validatePasswordMatch(password, passwordConfirm);
+        }
+
+        @Test
+        @DisplayName("평문 비밀번호가 DB 내 인코딩된 비밀번호와 일치할 때 예외를 던지지 않는다.")
+        void validatePassword_whenCurrentPasswordIsCorrect_thenNoException() {
+            User mockUser = UserFixture.createDefaultUser();
+            String username = UserFixture.VALID_USERNAME_SAMPLE_1;
+            String currentPassword = UserFixture.VALID_PASSWORD_SAMPLE_1;
+
+            when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockUser));
+            when(passwordEncoder.matches(currentPassword, mockUser.getPassword())).thenReturn(true);
+
+            userValidator.validatePassword(username, currentPassword);
+
+            verify(userRepository, times(1)).findByUsername(username);
+            verify(passwordEncoder, times(1)).matches(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("평문 비밀번호가 DB 내 인코딩된 비밀번호와 일치하지 않아 예외를 던진다.")
+        void validatePassword_whenCurrentPasswordIsIncorrect_thenThrowException() {
+            User mockUser = UserFixture.createDefaultUser();
+            String username = UserFixture.VALID_USERNAME_SAMPLE_1;
+            String currentPassword = UserFixture.VALID_PASSWORD_SAMPLE_1;
+
+            when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockUser));
+            when(passwordEncoder.matches(currentPassword, mockUser.getPassword())).thenReturn(false);
+
+            assertThatThrownBy(() -> userValidator.validatePassword(username, currentPassword))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(AuthResponseMessage.CREDENTIALS_INVALID);
+
+            verify(userRepository, times(1)).findByUsername(username);
+            verify(passwordEncoder, times(1)).matches(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("DB 내 유저를 찾을 수 없어 예외를 던진다.")
+        void validatePassword_whenUserNotFound_thenThrowException() {
+            String username = UserFixture.VALID_USERNAME_SAMPLE_1;
+            String currentPassword = UserFixture.VALID_PASSWORD_SAMPLE_1;
+
+            when(userRepository.findByUsername(username)).thenThrow(new NotFoundException(UserResponse.USER_NOT_FOUND));
+
+            assertThatThrownBy(() -> userValidator.validatePassword(username, currentPassword))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(UserResponseMessages.USER_NOT_FOUND);
+
+            verify(userRepository, times(1)).findByUsername(username);
+            verify(passwordEncoder, never()).matches(anyString(), anyString());
         }
     }
 


### PR DESCRIPTION
## #️⃣83
 
 ## 📝작업 내용
 비밀번호 변경 API를 추가했습니다.

# 주요 추가/수정 로직
## UserController
### __updateUserPassword()__ __`New`__

## UserFacade
### __updateUserPassword()__ __`New`__
- `Request Body`가 유효한지 검증합니다.
- 비밀번호를 갱신합니다.

## UserValidationService
### __validateUpdateUserPassword()__ __`New`__
- 현재 비밀번호가 일치하는지 검증합니다.
- 새 비밀번호와 새비밀번호 확인 필드가 서로 같은지 검증합니다.
 
## UserValidator
### __validatePassword()__ __`New`__
- 현재 비밀번호가 요청한 회원의 비밀번호가 일치하는지 비교합니다.
  - 틀렸다면 예외를 던집니다.
 
## UserService
### __updatePassword()__ __`New`__
- 새로운 비밀번호로 갱신합니다.

 ### 스크린샷 (선택) 
![image](https://github.com/user-attachments/assets/106bcbc6-6a47-4d83-8c5e-ce3586cf4a77)

 ## 💬리뷰 요구사항(선택)
컨벤션 위배 


### `New Issue`
`newPassword`와 `confirmNewPassword`가 서로 같은지 비교하는 로직에서 서로 틀리다면 `UserResponse.PASSWORD_DO_NOT_MATH` 예외를 던지도록 구현되어있습니다.

이는 회원가입을 구현할 때 구현하였는데 서로 다른 경우 field 데이터가 `password`로 클라이언트에게 전달되는 문제를 발견했습니다.
(__해당 API에서 문제가 되는 필드명은 `confirmNewPassword`입니다__ )

이를 회피하기 위해서는 다른 로직을 구성해서 구현할 필요가 있어보입니다.

