### PR TITLE
[#86] 지출 가계부 삭제 API 구현

### DIFF
--- a/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
+++ b/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
@@ -20,8 +20,11 @@ public class ExpenseResponseMessages {
 
     public static final String ITERATION_TYPE_INVALID = "반복 데이터 유형이 적절하지 않습니다.";
 
+    public static final String ITERATION_ACTION_INVALID = "반복 데이터 편집/삭제 유형이 적절하지 않습니다.";
+
     public static final String CREATE_EXPENSE_SUCCESS = "지출 가계부를 성공적으로 등록하였습니다.";
     public static final String GET_EXPENSE_SUCCESS = "지출 가계부를 성공적으로 조회하였습니다.";
+    public static final String DELETE_EXPENSE_SUCCESS = "지출 가계부를 성공적으로 삭제하였습니다.";
 
     public static final String EXPENSE_NON_EXISTENT = "존재하지 않는 지출입니다.";
 

--- a/src/main/java/com/poortorich/expense/controller/ExpenseController.java
+++ b/src/main/java/com/poortorich/expense/controller/ExpenseController.java
@@ -1,6 +1,7 @@
 package com.poortorich.expense.controller;
 
 import com.poortorich.expense.facade.ExpenseFacade;
+import com.poortorich.expense.request.ExpenseDeleteRequest;
 import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.response.BaseResponse;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,5 +41,13 @@ public class ExpenseController {
                 ExpenseResponse.GET_EXPENSE_SUCCESS,
                 expenseFacade.getExpense(expenseId, userDetails.getUsername())
         );
+    }
+
+    @DeleteMapping("/{expenseId}")
+    public ResponseEntity<BaseResponse> deleteExpense(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long expenseId,
+            @RequestBody @Valid ExpenseDeleteRequest expenseDeleteRequest) {
+        return BaseResponse.toResponseEntity(expenseFacade.deleteExpense(expenseId, expenseDeleteRequest, userDetails.getUsername()));
     }
 }

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -4,7 +4,9 @@ import com.poortorich.category.entity.Category;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.entity.enums.IterationType;
+import com.poortorich.expense.request.ExpenseDeleteRequest;
 import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.request.enums.IterationAction;
 import com.poortorich.expense.response.ExpenseInfoResponse;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.expense.service.ExpenseService;
@@ -41,9 +43,7 @@ public class ExpenseFacade {
         List<Expense> iterationExpenses
                 = iterationService.createIterationExpenses(expenseRequest.getCustomIteration(), expense, username);
         List<Expense> savedExpenses = expenseService.createExpenseAll(iterationExpenses);
-        if (expense.getIterationType() == IterationType.CUSTOM) {
-            iterationService.createIterationInfo(expenseRequest.getCustomIteration(), expense, savedExpenses, username);
-        }
+        iterationService.createIterationInfo(expenseRequest, expense, savedExpenses, username);
     }
 
     @Transactional

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -57,4 +57,23 @@ public class ExpenseFacade {
 
         return expenseService.getExpenseInfoResponse(id, username, customIteration);
     }
+
+    @Transactional
+    public ExpenseResponse deleteExpense(Long expenseId, ExpenseDeleteRequest expenseDeleteRequest, String username) {
+        if (expenseDeleteRequest.parseIterationAction() == IterationAction.NONE) {
+            expenseService.deleteExpense(expenseId, username);
+        }
+
+        if (expenseDeleteRequest.parseIterationAction() != IterationAction.NONE) {
+            Expense targetExpense = expenseService.getExpenseOrThrow(expenseId, username);
+            expenseService.deleteExpenseAll(
+                    iterationService.deleteIterationExpenses(
+                            targetExpense,
+                            username,
+                            expenseDeleteRequest.parseIterationAction())
+            );
+        }
+
+        return ExpenseResponse.DELETE_EXPENSE_SUCCESS;
+    }
 }

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -65,10 +65,10 @@ public class ExpenseFacade {
         }
 
         if (expenseDeleteRequest.parseIterationAction() != IterationAction.NONE) {
-            Expense targetExpense = expenseService.getExpenseOrThrow(expenseId, username);
+            Expense expenseToDelete = expenseService.getExpenseOrThrow(expenseId, username);
             expenseService.deleteExpenseAll(
                     iterationService.deleteIterationExpenses(
-                            targetExpense,
+                            expenseToDelete,
                             username,
                             expenseDeleteRequest.parseIterationAction())
             );

--- a/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     Optional<Expense> findByIdAndUser(Long id, User user);
+
+    void deleteByIdAndUser(Long id, User user);
 }

--- a/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
@@ -11,6 +11,4 @@ import java.util.Optional;
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     Optional<Expense> findByIdAndUser(Long id, User user);
-
-    void deleteByIdAndUser(Long id, User user);
 }

--- a/src/main/java/com/poortorich/expense/request/ExpenseDeleteRequest.java
+++ b/src/main/java/com/poortorich/expense/request/ExpenseDeleteRequest.java
@@ -1,0 +1,16 @@
+package com.poortorich.expense.request;
+
+import com.poortorich.expense.request.enums.IterationAction;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ExpenseDeleteRequest {
+
+    private String iterationAction;
+
+    public IterationAction parseIterationAction() {
+        return IterationAction.from(iterationAction);
+    }
+}

--- a/src/main/java/com/poortorich/expense/request/enums/IterationAction.java
+++ b/src/main/java/com/poortorich/expense/request/enums/IterationAction.java
@@ -1,0 +1,30 @@
+package com.poortorich.expense.request.enums;
+
+import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+public enum IterationAction {
+
+    NONE("NONE"),
+    THIS_ONLY("THIS_ONLY"),
+    THIS_AND_FUTURE("THIS_AND_FUTURE"),
+    ALL("ALL");
+
+    private final String action;
+
+    public static IterationAction from(String action) {
+        if (Objects.isNull(action)) {
+            return NONE;
+        }
+
+        return Arrays.stream(IterationAction.values())
+                .filter(iterationAction -> Objects.equals(iterationAction.action, action))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(ExpenseResponse.ITERATION_ACTION_INVALID));
+    }
+}

--- a/src/main/java/com/poortorich/expense/request/enums/IterationAction.java
+++ b/src/main/java/com/poortorich/expense/request/enums/IterationAction.java
@@ -1,7 +1,5 @@
 package com.poortorich.expense.request.enums;
 
-import com.poortorich.expense.response.ExpenseResponse;
-import com.poortorich.global.exceptions.BadRequestException;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
@@ -18,13 +16,9 @@ public enum IterationAction {
     private final String action;
 
     public static IterationAction from(String action) {
-        if (Objects.isNull(action)) {
-            return NONE;
-        }
-
         return Arrays.stream(IterationAction.values())
                 .filter(iterationAction -> Objects.equals(iterationAction.action, action))
                 .findFirst()
-                .orElseThrow(() -> new BadRequestException(ExpenseResponse.ITERATION_ACTION_INVALID));
+                .orElse(NONE);
     }
 }

--- a/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
+++ b/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
@@ -10,11 +10,13 @@ public enum ExpenseResponse implements Response {
 
     CREATE_EXPENSE_SUCCESS(HttpStatus.CREATED, ExpenseResponseMessages.CREATE_EXPENSE_SUCCESS, null),
     GET_EXPENSE_SUCCESS(HttpStatus.OK, ExpenseResponseMessages.GET_EXPENSE_SUCCESS, null),
+    DELETE_EXPENSE_SUCCESS(HttpStatus.OK, ExpenseResponseMessages.DELETE_EXPENSE_SUCCESS, null),
 
     TITLE_TOO_SHORT(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.TITLE_TOO_SHORT, "title"),
     PAYMENT_METHOD_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.PAYMENT_METHOD_INVALID, "paymentMethod"),
     ITERATION_TYPE_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.ITERATION_TYPE_INVALID, "iterationType"),
     DATE_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.DATE_INVALID, "date"),
+    ITERATION_ACTION_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.ITERATION_ACTION_INVALID, "iterationAction"),
 
     EXPENSE_NON_EXISTENT(HttpStatus.NOT_FOUND, ExpenseResponseMessages.EXPENSE_NON_EXISTENT, "expenseId");
 

--- a/src/main/java/com/poortorich/expense/service/ExpenseService.java
+++ b/src/main/java/com/poortorich/expense/service/ExpenseService.java
@@ -48,17 +48,12 @@ public class ExpenseService {
     }
 
     public IterationExpenses getIterationExpenses(Long id, String username) {
-        Expense expense = getExpense(id, username);
+        Expense expense = getExpenseOrThrow(id, username);
         return expense.getGeneratedIterationExpenses();
     }
 
-    private User findUserByUsername(String username) {
-        return userRepository.findByUsername(username)
-                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
-    }
-
     public ExpenseInfoResponse getExpenseInfoResponse(Long id, String username, CustomIterationInfoResponse customIteration) {
-        Expense expense = getExpense(id, username);
+        Expense expense = getExpenseOrThrow(id, username);
         return ExpenseInfoResponse.builder()
                 .date(expense.getExpenseDate())
                 .categoryName(expense.getCategory().getName())
@@ -71,8 +66,22 @@ public class ExpenseService {
                 .build();
     }
 
-    private Expense getExpense(Long id, String username) {
+    public void deleteExpense(Long expenseId, String username) {
+        Expense expense = getExpenseOrThrow(expenseId, username);
+        expenseRepository.delete(expense);
+    }
+
+    public Expense getExpenseOrThrow(Long id, String username) {
         return expenseRepository.findByIdAndUser(id, findUserByUsername(username))
                 .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
+    }
+
+    public void deleteExpenseAll(List<Expense> deleteExpenses) {
+        expenseRepository.deleteAll(deleteExpenses);
+    }
+
+    private User findUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/poortorich/expense/service/ExpenseService.java
+++ b/src/main/java/com/poortorich/expense/service/ExpenseService.java
@@ -8,8 +8,6 @@ import com.poortorich.expense.response.ExpenseInfoResponse;
 import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
-import com.poortorich.user.repository.UserRepository;
-import com.poortorich.user.response.enums.UserResponse;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.iteration.entity.IterationExpenses;
 import lombok.RequiredArgsConstructor;
@@ -22,10 +20,9 @@ import java.util.List;
 public class ExpenseService {
 
     private final ExpenseRepository expenseRepository;
-    private final UserRepository userRepository;
 
-    public Expense createExpense(ExpenseRequest expenseRequest, Category category, String username) {
-        Expense expense = buildExpense(expenseRequest, category, findUserByUsername(username));
+    public Expense createExpense(ExpenseRequest expenseRequest, Category category, User user) {
+        Expense expense = buildExpense(expenseRequest, category, user);
         expenseRepository.save(expense);
         return expense;
     }
@@ -47,13 +44,13 @@ public class ExpenseService {
                 .build();
     }
 
-    public IterationExpenses getIterationExpenses(Long id, String username) {
-        Expense expense = getExpenseOrThrow(id, username);
+    public IterationExpenses getIterationExpenses(Long id, User user) {
+        Expense expense = getExpenseOrThrow(id, user);
         return expense.getGeneratedIterationExpenses();
     }
 
-    public ExpenseInfoResponse getExpenseInfoResponse(Long id, String username, CustomIterationInfoResponse customIteration) {
-        Expense expense = getExpenseOrThrow(id, username);
+    public ExpenseInfoResponse getExpenseInfoResponse(Long id, User user, CustomIterationInfoResponse customIteration) {
+        Expense expense = getExpenseOrThrow(id, user);
         return ExpenseInfoResponse.builder()
                 .date(expense.getExpenseDate())
                 .categoryName(expense.getCategory().getName())
@@ -66,22 +63,17 @@ public class ExpenseService {
                 .build();
     }
 
-    public void deleteExpense(Long expenseId, String username) {
-        Expense expense = getExpenseOrThrow(expenseId, username);
+    public void deleteExpense(Long expenseId, User user) {
+        Expense expense = getExpenseOrThrow(expenseId, user);
         expenseRepository.delete(expense);
     }
 
-    public Expense getExpenseOrThrow(Long id, String username) {
-        return expenseRepository.findByIdAndUser(id, findUserByUsername(username))
+    public Expense getExpenseOrThrow(Long id, User user) {
+        return expenseRepository.findByIdAndUser(id, user)
                 .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
     }
 
     public void deleteExpenseAll(List<Expense> deleteExpenses) {
         expenseRepository.deleteAll(deleteExpenses);
-    }
-
-    private User findUserByUsername(String username) {
-        return userRepository.findByUsername(username)
-                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/poortorich/iteration/entity/IterationExpenses.java
+++ b/src/main/java/com/poortorich/iteration/entity/IterationExpenses.java
@@ -60,4 +60,8 @@ public class IterationExpenses {
     @UpdateTimestamp
     @Column(name = "updatedDate")
     private LocalDateTime updatedDate;
+
+    public void updateOriginalExpense(Expense originalExpense) {
+        this.originalExpense = originalExpense;
+    }
 }

--- a/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
@@ -1,9 +1,30 @@
 package com.poortorich.iteration.repository;
 
+import com.poortorich.expense.entity.Expense;
 import com.poortorich.iteration.entity.IterationExpenses;
+import com.poortorich.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface IterationExpensesRepository extends JpaRepository<IterationExpenses, Long> {
+
+    @Query("SELECT ie FROM IterationExpenses ie JOIN FETCH ie.generatedExpense ge " +
+            "WHERE ie.originalExpense = :originalExpense AND ie.user = :user AND ge.expenseDate >= :startDate " +
+            "ORDER BY ge.expenseDate ASC")
+    List<IterationExpenses> findAllByOriginalExpenseAndUserAndGeneratedExpenseDateAfterOrEqual(
+            Expense originalExpense,
+            User user,
+            LocalDate startDate
+    );
+
+    void deleteByGeneratedExpenseAndUser(Expense targetExpense, User userByUsername);
+
+    IterationExpenses findByGeneratedExpenseAndUser(Expense targetExpense, User userByUsername);
+
+    List<IterationExpenses> findAllByOriginalExpenseAndUser(Expense origianlExpense, User user);
 }

--- a/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
@@ -17,9 +17,15 @@ public interface IterationExpensesRepository extends JpaRepository<IterationExpe
 
     List<IterationExpenses> findAllByOriginalExpenseAndUser(Expense origianlExpense, User user);
 
-    @Query("SELECT ie FROM IterationExpenses ie JOIN FETCH ie.generatedExpense ge " +
-            "WHERE ie.originalExpense = :originalExpense AND ie.user = :user AND ge.expenseDate >= :startDate " +
-            "ORDER BY ge.expenseDate ASC")
+    @Query("""
+        SELECT DISTINCT ie
+        FROM IterationExpenses ie
+        JOIN FETCH ie.generatedExpense ge
+        WHERE ie.originalExpense = :originalExpense
+          AND ie.user = :user
+          AND ge.expenseDate >= :startDate
+        ORDER BY ge.expenseDate ASC
+        """)
     List<IterationExpenses> findAllByOriginalExpenseAndUserAndGeneratedExpenseDateAfterOrEqual(
             Expense originalExpense,
             User user,

--- a/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
@@ -13,6 +13,10 @@ import java.util.List;
 @Repository
 public interface IterationExpensesRepository extends JpaRepository<IterationExpenses, Long> {
 
+    IterationExpenses findByGeneratedExpenseAndUser(Expense targetExpense, User userByUsername);
+
+    List<IterationExpenses> findAllByOriginalExpenseAndUser(Expense origianlExpense, User user);
+
     @Query("SELECT ie FROM IterationExpenses ie JOIN FETCH ie.generatedExpense ge " +
             "WHERE ie.originalExpense = :originalExpense AND ie.user = :user AND ge.expenseDate >= :startDate " +
             "ORDER BY ge.expenseDate ASC")
@@ -21,10 +25,4 @@ public interface IterationExpensesRepository extends JpaRepository<IterationExpe
             User user,
             LocalDate startDate
     );
-
-    void deleteByGeneratedExpenseAndUser(Expense targetExpense, User userByUsername);
-
-    IterationExpenses findByGeneratedExpenseAndUser(Expense targetExpense, User userByUsername);
-
-    List<IterationExpenses> findAllByOriginalExpenseAndUser(Expense origianlExpense, User user);
 }

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -6,7 +6,6 @@ import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.expense.request.enums.IterationAction;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.exceptions.BadRequestException;
-import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.iteration.entity.enums.Weekday;
 import com.poortorich.iteration.entity.enums.EndType;
@@ -31,7 +30,6 @@ import com.poortorich.iteration.response.MonthlyOptionInfoResponse;
 import com.poortorich.iteration.util.IterationDateCalculator;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.repository.UserRepository;
-import com.poortorich.user.response.enums.UserResponse;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
@@ -52,8 +50,7 @@ public class IterationService {
 
     public List<Expense> createIterationExpenses(CustomIteration customIteration,
                                                  Expense expense,
-                                                 String username) {
-        User user = findUserByUsername(username);
+                                                 User user) {
         LocalDate startDate = expense.getExpenseDate();
         return getIterationExpenses(
                 customIteration,
@@ -229,8 +226,7 @@ public class IterationService {
     public void createIterationInfo(ExpenseRequest expenseRequest,
                                     Expense originalExpense,
                                     List<Expense> savedIterationExpenses,
-                                    String username) {
-        User user = findUserByUsername(username);
+                                    User user) {
         IterationInfo iterationInfo = null;
         if (expenseRequest.parseIterationType() == IterationType.CUSTOM) {
             iterationInfo = getIterationInfo(expenseRequest.getCustomIteration());
@@ -388,8 +384,7 @@ public class IterationService {
                 .build();
     }
 
-    public List<Expense> deleteIterationExpenses(Expense expenseToDelete, String username, IterationAction iterationAction) {
-        User user = findUserByUsername(username);
+    public List<Expense> deleteIterationExpenses(Expense expenseToDelete, User user, IterationAction iterationAction) {
         IterationExpenses iterationExpense = iterationExpensesRepository.findByGeneratedExpenseAndUser(expenseToDelete, user);
         Expense originalExpense = iterationExpense.getOriginalExpense();
         List<IterationExpenses> allIterationExpenses = iterationExpensesRepository.findAllByOriginalExpenseAndUser(originalExpense, user);
@@ -468,10 +463,5 @@ public class IterationService {
         return iterationExpensesRepository.findAllByOriginalExpenseAndUserAndGeneratedExpenseDateAfterOrEqual(
                 originalExpense, user, targetExpense.getExpenseDate()
         );
-    }
-
-    private User findUserByUsername(String username) {
-        return userRepository.findByUsername(username)
-                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -387,25 +387,25 @@ public class IterationService {
                 .build();
     }
 
-    public List<Expense> deleteIterationExpenses(Expense targetExpense, String username, IterationAction iterationAction) {
+    public List<Expense> deleteIterationExpenses(Expense expenseToDelete, String username, IterationAction iterationAction) {
         User user = findUserByUsername(username);
-        IterationExpenses iterationExpense = iterationExpensesRepository.findByGeneratedExpenseAndUser(targetExpense, user);
+        IterationExpenses iterationExpense = iterationExpensesRepository.findByGeneratedExpenseAndUser(expenseToDelete, user);
 
         Expense originalExpense = iterationExpense.getOriginalExpense();
         List<IterationExpenses> allIterationExpenses = iterationExpensesRepository.findAllByOriginalExpenseAndUser(originalExpense, user);
         List<IterationExpenses> deleteIterationExpenses = List.of();
 
         if (iterationAction == IterationAction.THIS_ONLY) {
-            deleteIterationExpenses = handleThisOnly(originalExpense, targetExpense, iterationExpense, allIterationExpenses);
+            deleteIterationExpenses = handleThisOnly(originalExpense, expenseToDelete, iterationExpense, allIterationExpenses);
         }
 
         if (iterationAction == IterationAction.ALL
-                || (iterationAction == IterationAction.THIS_AND_FUTURE && targetExpense.equals(originalExpense))) {
+                || (iterationAction == IterationAction.THIS_AND_FUTURE && expenseToDelete.equals(originalExpense))) {
             deleteIterationExpenses = handleAll(iterationExpense, allIterationExpenses);
         }
 
-        if (iterationAction == IterationAction.THIS_AND_FUTURE && !targetExpense.equals(originalExpense)) {
-            deleteIterationExpenses = handleThisAndFuture(originalExpense, targetExpense, user);
+        if (iterationAction == IterationAction.THIS_AND_FUTURE && !expenseToDelete.equals(originalExpense)) {
+            deleteIterationExpenses = handleThisAndFuture(originalExpense, expenseToDelete, user);
         }
 
         iterationExpensesRepository.deleteAll(deleteIterationExpenses);
@@ -416,15 +416,15 @@ public class IterationService {
 
     private List<IterationExpenses> handleThisOnly(
             Expense originalExpense,
-            Expense targetExpense,
+            Expense expenseToDelete,
             IterationExpenses iterationExpense,
             List<IterationExpenses> allIterationExpenses
     ) {
-        if (targetExpense.equals(originalExpense) && allIterationExpenses.size() < 2) {
+        if (expenseToDelete.equals(originalExpense) && allIterationExpenses.size() < 2) {
             return handleAll(iterationExpense, allIterationExpenses);
         }
 
-        if (targetExpense.equals(originalExpense)) {
+        if (expenseToDelete.equals(originalExpense)) {
             updateOriginalExpense(allIterationExpenses);
         }
 
@@ -446,6 +446,7 @@ public class IterationService {
         if (iterationInfo != null) {
             iterationInfoRepository.delete(deleteIterationExpenses.getFirst().getIterationInfo());
         }
+
         return deleteIterationExpenses;
     }
 

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -2,6 +2,8 @@ package com.poortorich.iteration.service;
 
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.entity.enums.IterationType;
+import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.request.enums.IterationAction;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.iteration.entity.IterationExpenses;
@@ -223,23 +225,21 @@ public class IterationService {
                 .build();
     }
 
-    public void createIterationInfo(CustomIteration customIteration,
+    public void createIterationInfo(ExpenseRequest expenseRequest,
                                     Expense originalExpense,
                                     List<Expense> savedIterationExpenses,
                                     String username) {
         User user = findUserByUsername(username);
-        IterationInfo iterationInfo = getIterationInfo(customIteration);
-        iterationInfoRepository.save(iterationInfo);
+        IterationInfo iterationInfo = null;
+        if (expenseRequest.parseIterationType() == IterationType.CUSTOM) {
+            iterationInfo = getIterationInfo(expenseRequest.getCustomIteration());
+            iterationInfoRepository.save(iterationInfo);
+        }
 
         for (Expense savedExpense : savedIterationExpenses) {
             IterationExpenses iterationExpenses = buildIterationExpenses(originalExpense, savedExpense, iterationInfo, user);
             iterationExpensesRepository.save(iterationExpenses);
         }
-    }
-
-    private User findUserByUsername(String username) {
-        return userRepository.findByUsername(username)
-                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
     }
 
     private IterationInfo getIterationInfo(CustomIteration customIteration) {
@@ -385,5 +385,10 @@ public class IterationService {
         return EndInfoResponse.builder()
                 .type(info.getEndType().toString())
                 .build();
+    }
+
+    private User findUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -76,4 +76,9 @@ public class UserService {
                 .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND))
                 .updatePassword(passwordEncoder.encode(newPassword));
     }
+
+    public User findUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
+    }
 }

--- a/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
+++ b/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
@@ -9,6 +9,7 @@ import com.poortorich.expense.service.ExpenseService;
 import com.poortorich.expense.util.ExpenseRequestTestBuilder;
 import com.poortorich.iteration.service.IterationService;
 import com.poortorich.user.entity.User;
+import com.poortorich.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,9 @@ class ExpenseFacadeTest {
 
     @Mock
     private CategoryService categoryService;
+
+    @Mock
+    private UserService userService;
 
     @Mock
     private IterationService iterationService;
@@ -55,12 +59,13 @@ class ExpenseFacadeTest {
     @Test
     @DisplayName("Category, Expense 서비스가 적절히 호출된다.")
     void createExpense_shouldCallServiceMethods() {
-        when(categoryService.findCategoryByName(expenseRequest.getCategoryName(), user.getUsername())).thenReturn(category);
-        when(expenseService.createExpense(expenseRequest, category, user.getUsername())).thenReturn(expense);
+        when(userService.findUserByUsername(user.getUsername())).thenReturn(user);
+        when(categoryService.findCategoryByName(expenseRequest.getCategoryName(), user)).thenReturn(category);
+        when(expenseService.createExpense(expenseRequest, category, user)).thenReturn(expense);
 
         expenseFacade.createExpense(expenseRequest, user.getUsername());
-        verify(expenseService).createExpense(expenseRequest, category, user.getUsername());
-        verify(categoryService).findCategoryByName(expenseRequest.getCategoryName(), user.getUsername());
-        verify(iterationService).createIterationExpenses(expenseRequest.getCustomIteration(), expense, user.getUsername());
+        verify(expenseService).createExpense(expenseRequest, category, user);
+        verify(categoryService).findCategoryByName(expenseRequest.getCategoryName(), user);
+        verify(iterationService).createIterationExpenses(expenseRequest.getCustomIteration(), expense, user);
     }
 }

--- a/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
@@ -7,7 +7,6 @@ import com.poortorich.expense.repository.ExpenseRepository;
 import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.expense.util.ExpenseRequestTestBuilder;
 import com.poortorich.user.entity.User;
-import com.poortorich.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,21 +17,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ExpenseServiceTest {
 
     @Mock
     private ExpenseRepository expenseRepository;
-
-    @Mock
-    private UserRepository userRepository;
 
     @InjectMocks
     private ExpenseService expenseService;
@@ -58,9 +51,7 @@ public class ExpenseServiceTest {
     @Test
     @DisplayName("유효한 지출 정보가 성공적으로 저장된다.")
     void createValidExpense() {
-        when(userRepository.findByUsername(user.getUsername())).thenReturn(Optional.of(user));
-
-        expenseService.createExpense(expenseRequest, category, user.getUsername());
+        expenseService.createExpense(expenseRequest, category, user);
 
         verify(expenseRepository).save(expenseCaptor.capture());
         Expense savedExpense = expenseCaptor.getValue();


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#86 
 
 ## 📝작업 내용

지출 수정 API 먼저 구현하고 있었으나, 지출 수정 기능 일부에 삭제 로직이 필요하다고 판단하여 지출 삭제 API를 먼저 구현하였습니다. 

## `IterationAction`

- 반복데이터 지출 수정 / 삭제에 필요한 Enum

IterationAction | 사용 용도
--|--
NONE | 반복데이터가 아닌 지출 삭제
THIS_ONLY | (반복 지출데이터인 경우) 해당 데이터만 삭제
THIS_AND_FUTURE | (반복 지출데이터인 경우) 해당 데이터와 이후 데이터 삭제
ALL | (반복 지출데이터인 경우) 모든 데이터 삭제

> 반복데이터가 아닌 경우 `ExpenseDeleteRequest`에 `iterationAction` 값이 입력으로 들어오지 않습니다.
> 따라서 null이 들어오는 경우는 예외 처리 대상이 아니기 때문에 `NONE` 타입으로 바뀌도록 처리하였습니다.

## `ExpenseDeleteRequest`

- 지출 데이터가 **반복데이터인 경우에만** 사용되는 Request

## `ExpenseFacade`

### deleteExpense() `new`

`IterationAction.NONE`인 경우
- 입력으로 들어온 `expenseId` 값에 해당되는 지출 데이터만 삭제

`IterationAction.NONE`이 아닌 경우
- 입력으로 들어온 `expenseId`를 바탕으로 기준이 되는 지출데이터인 `targetExpense`를 얻음
   -> `iterationService`에서 반환되는 `List<Expense>` 값을 모두 삭제

## `ExpenseService`

### deleteExpense() `new`

- 단일 Expense 삭제 메소드

### deleteExpenseAll() `new`

- Expense들을 삭제하는 메소드

### getExpenseOrThrow()

- `targetExpense`를 얻기 위해 필요하기 때문에 `public`으로 변경

## `IterationService`

### deleteIterationExpenses() `new`

- `IterationAction`을 기준으로 반복 지출데이터 관련 정보를 삭제하는 메서드

### resolveIterationExpensesToDelete() `new`

- `iterationAction`에 따라 반복 지출 삭제 대상을 결정하는 메서드

### handleThisOnly `new`
**`THIS_ONLY`의 경우**

- 해당하는 Expense가 `generatedExpense`인 경우인 `iterationExpenses`를 삭제 후 해당 `Expense` List에 담아 반환

- 만약 `expenseToDelete`가 `originalExpense`와 같은 경우
   - 반복데이터가 하나밖에 없는 경우 -> `handleAll()` 메서드에서 처리
   - 반복데이터가 여러 개인 경우 -> `updateOriginalExpense()` 메서드에서 처리

### updateOriginalExpense() `new`

- `originalExpense`을 삭제해야하는 경우 `iterationExpenses`의 두번째 `generatedExpense`를 새로운 기준 데이터로 변경하기 위한 메서드

### handleAll() `new`
**`ALL`의 경우**

- `originalExpense`가 같은 `iterationExpenses`들을 모두 삭제
- 사용자화 반복데이터인 경우 (null이 아닌 경우) 반복데이터 정보를 담는 `IterationInfo`도 삭제

해당하는 `generatedExpense` List를 반환

### handleThisAndFuture() `new`
**`THIS_AND_FUTURE`의 경우**
- `origianlExpense`가 같은 `iterationExpenses`들 중 `expenseToDelete`와 날짜가 같거나 이후인 것들을 삭제

해당하는 `generatedExpense` List를 반환

## `IterationExpensesRepository`

### findByGeneratedExpenseAndUser() `new`

- `generatedExpense`와 `user`를 이용하여 일치하는 `IterationExpenses` 반환

### findAllByOriginalExpenseAndUser() `new`

- `originalExpense`와 `user`를 이용하여 일치하는 `IterationExpenses` List 반환

### findAllByOriginalExpenseAndUserAndGeneratedExpenseDateAfterOrEqual() `new`

- `originalExpense`와 `user`, `generatedExpense`의 `date`정보를 이용하여 date와 같거나 이후 날짜인 `IterationExpenses` List 반환
- 복잡한 로직이기 때문에 `@Query` 사용

## `IterationExpenses`

### updateOriginalExpense `new`
`originalExpense`를 변경하기 위한 코드

## 기타 수정사항

- 기본 반복데이터를 생성할 때, `IterationExpenses`를 생성하지 않는 문제를 발견하여 수정
 
 ### 스크린샷 (선택)

> 지출 가계부를 성공적으로 삭제한 경우
![image](https://github.com/user-attachments/assets/1fb87f2d-b1d7-4d98-849e-0a19f36816b4)

> 존재하지 않는 ID 값이 들어온 경우
![image](https://github.com/user-attachments/assets/93ceaba1-9046-4516-976e-94d72fe61d2f)

 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 성능 측면에서 쿼리를 사용하는게 더 유리하다 생각하여 쿼리문을 사용해 정보를 불러왔는데, 쿼리 사용에 대한 의견이 궁금합니다! (더 좋은 쿼리나 쿼리를 사용하지 않는 더 좋은 방법이 있을지 등)
- 메서드 네이밍