### PR TITLE
[#85] 날짜 정보를 제공하는 유틸 객체 추가

### DIFF
--- a/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
+++ b/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
@@ -5,7 +5,7 @@ import com.poortorich.expense.constants.ExpenseValidationConstraints;
 import com.poortorich.expense.entity.enums.IterationType;
 import com.poortorich.expense.entity.enums.PaymentMethod;
 import com.poortorich.expense.response.ExpenseResponse;
-import com.poortorich.global.constants.DatePattern;
+import com.poortorich.global.date.constants.DatePattern;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.iteration.request.CustomIteration;
 import jakarta.validation.Valid;
@@ -14,12 +14,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/poortorich/global/date/constants/DateConstants.java
+++ b/src/main/java/com/poortorich/global/date/constants/DateConstants.java
@@ -2,9 +2,7 @@ package com.poortorich.global.date.constants;
 
 public class DateConstants {
 
+    public static final int FIRTH_DAY_OF_YEAR = 1;
     public static final int FIRST_DAY_OF_MONTH = 1;
-    public static final int DAYS_IN_WEEK = 7;
-    public static final int FIRST_WEEK = 1;
     public static final int ONE_DAY = 1;
-    public static final int SIX_DAYS = 6;
 }

--- a/src/main/java/com/poortorich/global/date/constants/DateConstants.java
+++ b/src/main/java/com/poortorich/global/date/constants/DateConstants.java
@@ -1,4 +1,10 @@
 package com.poortorich.global.date.constants;
 
 public class DateConstants {
+
+    public static final int FIRST_DAY_OF_MONTH = 1;
+    public static final int DAYS_IN_WEEK = 7;
+    public static final int FIRST_WEEK = 1;
+    public static final int ONE_DAY = 1;
+    public static final int SIX_DAYS = 6;
 }

--- a/src/main/java/com/poortorich/global/date/constants/DateConstants.java
+++ b/src/main/java/com/poortorich/global/date/constants/DateConstants.java
@@ -2,7 +2,7 @@ package com.poortorich.global.date.constants;
 
 public class DateConstants {
 
-    public static final int FIRTH_DAY_OF_YEAR = 1;
+    public static final int FIRST_DAY_OF_YEAR = 1;
     public static final int FIRST_DAY_OF_MONTH = 1;
     public static final int ONE_DAY = 1;
 }

--- a/src/main/java/com/poortorich/global/date/constants/DateConstants.java
+++ b/src/main/java/com/poortorich/global/date/constants/DateConstants.java
@@ -1,0 +1,4 @@
+package com.poortorich.global.date.constants;
+
+public class DateConstants {
+}

--- a/src/main/java/com/poortorich/global/date/constants/DatePattern.java
+++ b/src/main/java/com/poortorich/global/date/constants/DatePattern.java
@@ -1,8 +1,9 @@
-package com.poortorich.global.constants;
+package com.poortorich.global.date.constants;
 
 public class DatePattern {
 
     public static final String BASIC_PATTERN = "yyyy-MM-dd";
 
-    private DatePattern() {}
+    private DatePattern() {
+    }
 }

--- a/src/main/java/com/poortorich/global/date/domain/MonthInformation.java
+++ b/src/main/java/com/poortorich/global/date/domain/MonthInformation.java
@@ -1,4 +1,4 @@
-package com.poortorich.global.domain;
+package com.poortorich.global.date.domain;
 
 import java.time.LocalDate;
 import java.time.YearMonth;

--- a/src/main/java/com/poortorich/global/date/domain/MonthInformation.java
+++ b/src/main/java/com/poortorich/global/date/domain/MonthInformation.java
@@ -1,0 +1,21 @@
+package com.poortorich.global.domain;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class MonthInformation {
+
+    private final YearMonth yearMonth;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+    private final List<WeekInformation> weeks;
+}

--- a/src/main/java/com/poortorich/global/date/domain/WeekInformation.java
+++ b/src/main/java/com/poortorich/global/date/domain/WeekInformation.java
@@ -1,4 +1,4 @@
-package com.poortorich.global.domain;
+package com.poortorich.global.date.domain;
 
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/poortorich/global/date/domain/WeekInformation.java
+++ b/src/main/java/com/poortorich/global/date/domain/WeekInformation.java
@@ -1,0 +1,17 @@
+package com.poortorich.global.domain;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class WeekInformation {
+
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+}

--- a/src/main/java/com/poortorich/global/date/domain/YearInformation.java
+++ b/src/main/java/com/poortorich/global/date/domain/YearInformation.java
@@ -1,0 +1,22 @@
+package com.poortorich.global.domain;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Year;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+@AllArgsConstructor
+public class YearInformation {
+
+    private final Year year;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+    private final Map<Month, MonthInformation> months;
+}

--- a/src/main/java/com/poortorich/global/date/domain/YearInformation.java
+++ b/src/main/java/com/poortorich/global/date/domain/YearInformation.java
@@ -1,4 +1,4 @@
-package com.poortorich.global.domain;
+package com.poortorich.global.date.domain;
 
 import java.time.LocalDate;
 import java.time.Month;

--- a/src/main/java/com/poortorich/global/date/util/DateInfoProvider.java
+++ b/src/main/java/com/poortorich/global/date/util/DateInfoProvider.java
@@ -25,7 +25,7 @@ public class DateInfoProvider {
 
         return YearInformation.builder()
                 .year(year)
-                .startDate(year.atDay(DateConstants.ONE_DAY))
+                .startDate(year.atDay(DateConstants.FIRST_DAY_OF_YEAR))
                 .endDate(year.atMonth(Month.DECEMBER).atEndOfMonth())
                 .months(months)
                 .build();
@@ -34,15 +34,15 @@ public class DateInfoProvider {
     public static MonthInformation getMonthInformation(YearMonth yearMonth) {
         return MonthInformation.builder()
                 .yearMonth(yearMonth)
-                .startDate(yearMonth.atDay(DateConstants.ONE_DAY))
+                .startDate(yearMonth.atDay(DateConstants.FIRST_DAY_OF_MONTH))
                 .endDate(yearMonth.atEndOfMonth())
-                .weeks(DateInfoProvider.getWeekInformation(yearMonth))
+                .weeks(DateInfoProvider.getWeeksInformation(yearMonth))
                 .build();
     }
 
-    public static List<WeekInformation> getWeekInformation(YearMonth yearMonth) {
+    public static List<WeekInformation> getWeeksInformation(YearMonth yearMonth) {
         List<WeekInformation> weeks = new ArrayList<>();
-        LocalDate weekStart = yearMonth.atDay(DateConstants.ONE_DAY)
+        LocalDate weekStart = yearMonth.atDay(DateConstants.FIRST_DAY_OF_MONTH)
                 .with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
 
         while (!weekStart.isAfter(yearMonth.atEndOfMonth())) {

--- a/src/main/java/com/poortorich/global/date/util/DateInfoProvider.java
+++ b/src/main/java/com/poortorich/global/date/util/DateInfoProvider.java
@@ -1,24 +1,59 @@
-package com.poortorich.global.util;
+package com.poortorich.global.date.util;
 
-import com.poortorich.global.domain.MonthInformation;
-import com.poortorich.global.domain.WeekInformation;
-import com.poortorich.global.domain.YearInformation;
+import com.poortorich.global.date.constants.DateConstants;
+import com.poortorich.global.date.domain.MonthInformation;
+import com.poortorich.global.date.domain.WeekInformation;
+import com.poortorich.global.date.domain.YearInformation;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
 import java.time.Year;
 import java.time.YearMonth;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 public class DateInfoProvider {
 
     public static YearInformation getYearInformation(Year year) {
+        Map<Month, MonthInformation> months = new EnumMap<>(Month.class);
+        Stream.of(Month.values())
+                .forEach(month -> months.put(month, getMonthInformation(year.atMonth(month))));
 
+        return YearInformation.builder()
+                .year(year)
+                .startDate(year.atDay(DateConstants.ONE_DAY))
+                .endDate(year.atMonth(Month.DECEMBER).atEndOfMonth())
+                .months(months)
+                .build();
     }
 
     public static MonthInformation getMonthInformation(YearMonth yearMonth) {
-
+        return MonthInformation.builder()
+                .yearMonth(yearMonth)
+                .startDate(yearMonth.atDay(DateConstants.ONE_DAY))
+                .endDate(yearMonth.atEndOfMonth())
+                .weeks(DateInfoProvider.getWeekInformation(yearMonth))
+                .build();
     }
 
     public static List<WeekInformation> getWeekInformation(YearMonth yearMonth) {
-        int lengthOfMonth = yearMonth.lengthOfMonth();
+        List<WeekInformation> weeks = new ArrayList<>();
+        LocalDate weekStart = yearMonth.atDay(DateConstants.ONE_DAY)
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
 
+        while (!weekStart.isAfter(yearMonth.atEndOfMonth())) {
+            LocalDate weekEnd = weekStart.with(TemporalAdjusters.next(DayOfWeek.SATURDAY));
+            weeks.add(WeekInformation.builder()
+                    .startDate(weekStart)
+                    .endDate(weekEnd)
+                    .build());
+            weekStart = weekEnd.plusDays(DateConstants.ONE_DAY);
+        }
+
+        return weeks;
     }
 }

--- a/src/main/java/com/poortorich/global/date/util/DateInfoProvider.java
+++ b/src/main/java/com/poortorich/global/date/util/DateInfoProvider.java
@@ -1,0 +1,24 @@
+package com.poortorich.global.util;
+
+import com.poortorich.global.domain.MonthInformation;
+import com.poortorich.global.domain.WeekInformation;
+import com.poortorich.global.domain.YearInformation;
+import java.time.Year;
+import java.time.YearMonth;
+import java.util.List;
+
+public class DateInfoProvider {
+
+    public static YearInformation getYearInformation(Year year) {
+
+    }
+
+    public static MonthInformation getMonthInformation(YearMonth yearMonth) {
+
+    }
+
+    public static List<WeekInformation> getWeekInformation(YearMonth yearMonth) {
+        int lengthOfMonth = yearMonth.lengthOfMonth();
+
+    }
+}

--- a/src/main/java/com/poortorich/iteration/request/End.java
+++ b/src/main/java/com/poortorich/iteration/request/End.java
@@ -1,6 +1,6 @@
 package com.poortorich.iteration.request;
 
-import com.poortorich.global.constants.DatePattern;
+import com.poortorich.global.date.constants.DatePattern;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.iteration.constants.IterationResponseMessages;
 import com.poortorich.iteration.constants.IterationValidationConstraints;
@@ -9,12 +9,11 @@ import com.poortorich.iteration.response.IterationResponse;
 import com.poortorich.iteration.validator.EndCheck;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor

--- a/src/test/java/com/poortorich/expense/fixture/ExpenseFixture.java
+++ b/src/test/java/com/poortorich/expense/fixture/ExpenseFixture.java
@@ -4,9 +4,7 @@ import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.entity.enums.IterationType;
 import com.poortorich.expense.entity.enums.PaymentMethod;
-import com.poortorich.global.constants.DatePattern;
 import com.poortorich.iteration.request.CustomIteration;
-
 import java.time.LocalDate;
 
 public class ExpenseFixture {
@@ -28,7 +26,8 @@ public class ExpenseFixture {
 
     public static final CustomIteration VALID_CUSTOM_ITERATION = null;
 
-    private ExpenseFixture() {}
+    private ExpenseFixture() {
+    }
 
     public static Expense defaultExpense(LocalDate date) {
         return Expense.builder()

--- a/src/test/java/com/poortorich/global/date/fixture/DateTestFixture.java
+++ b/src/test/java/com/poortorich/global/date/fixture/DateTestFixture.java
@@ -1,4 +1,28 @@
 package com.poortorich.global.date.fixture;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.YearMonth;
+
 public class DateTestFixture {
+
+    public static final Year TEST_YEAR = Year.of(2025);
+
+    public static final YearMonth MAY_2025 = YearMonth.of(2025, 5);
+
+    public static final LocalDate MAY_START = MAY_2025.atDay(1);
+    public static final LocalDate MAY_END = MAY_2025.atEndOfMonth();
+
+    public static final LocalDate YEAR_START = TEST_YEAR.atDay(1);
+    public static final LocalDate YEAR_END = TEST_YEAR.atMonth(12).atEndOfMonth();
+
+    public static final DayOfWeek WEEK_START_DAY = DayOfWeek.SUNDAY;
+    public static final DayOfWeek WEEK_END_DAY = DayOfWeek.SATURDAY;
+
+    public static final LocalDate MAY_2025_WEEK_FIRST_START = LocalDate.of(2025, 4, 27);
+    public static final LocalDate MAY_2025_WEEK_FIRST_END = LocalDate.of(2025, 5, 3);
+
+    public static final LocalDate MAY_2025_WEEK_LAST_START = LocalDate.of(2025, 5, 25);
+    public static final LocalDate MAY_2025_WEEK_LAST_END = LocalDate.of(2025, 5, 31);
 }

--- a/src/test/java/com/poortorich/global/date/fixture/DateTestFixture.java
+++ b/src/test/java/com/poortorich/global/date/fixture/DateTestFixture.java
@@ -1,0 +1,4 @@
+package com.poortorich.global.date.fixture;
+
+public class DateTestFixture {
+}

--- a/src/test/java/com/poortorich/global/date/util/DateInfoProviderTest.java
+++ b/src/test/java/com/poortorich/global/date/util/DateInfoProviderTest.java
@@ -1,0 +1,4 @@
+package com.poortorich.global.date.util;
+
+public class DateInfoProviderTest {
+}

--- a/src/test/java/com/poortorich/global/date/util/DateInfoProviderTest.java
+++ b/src/test/java/com/poortorich/global/date/util/DateInfoProviderTest.java
@@ -1,4 +1,46 @@
 package com.poortorich.global.date.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.poortorich.global.date.domain.MonthInformation;
+import com.poortorich.global.date.domain.WeekInformation;
+import com.poortorich.global.date.domain.YearInformation;
+import com.poortorich.global.date.fixture.DateTestFixture;
+import java.time.Month;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 public class DateInfoProviderTest {
+
+    @Test
+    @DisplayName("해당 연도의 정보를 반환받을 때, 유효한 구조로 반환이 되는지 확인")
+    void getYearInformation_whenGivenYear_shouldReturnValidStructure() {
+        YearInformation result = DateInfoProvider.getYearInformation(DateTestFixture.TEST_YEAR);
+        assertThat(result).isNotNull();
+        assertThat(result.getYear()).isEqualTo(DateTestFixture.TEST_YEAR);
+        assertThat(result.getStartDate()).isEqualTo(DateTestFixture.YEAR_START);
+        assertThat(result.getEndDate()).isEqualTo(DateTestFixture.YEAR_END);
+
+        Map<Month, MonthInformation> months = result.getMonths();
+        assertThat(months).hasSize(12);
+        assertThat(months.keySet()).containsExactlyInAnyOrder(Month.values());
+
+        MonthInformation mayInfo = months.get(Month.MAY);
+        assertThat(mayInfo.getYearMonth()).isEqualTo(DateTestFixture.MAY_2025);
+        assertThat(mayInfo.getStartDate()).isEqualTo(DateTestFixture.MAY_START);
+        assertThat(mayInfo.getEndDate()).isEqualTo(DateTestFixture.MAY_END);
+
+        List<WeekInformation> weeksInMay = mayInfo.getWeeks();
+        assertThat(weeksInMay).isNotEmpty();
+
+        WeekInformation firstWeek = weeksInMay.getFirst();
+        assertThat(firstWeek.getStartDate()).isEqualTo(DateTestFixture.MAY_2025_WEEK_FIRST_START);
+        assertThat(firstWeek.getEndDate()).isEqualTo(DateTestFixture.MAY_2025_WEEK_FIRST_END);
+
+        WeekInformation endWeek = weeksInMay.getLast();
+        assertThat(endWeek.getStartDate()).isEqualTo(DateTestFixture.MAY_2025_WEEK_LAST_START);
+        assertThat(endWeek.getEndDate()).isEqualTo(DateTestFixture.MAY_2025_WEEK_LAST_END);
+    }
 }


### PR DESCRIPTION
## #️⃣85
 
 ## 📝작업 내용
연별/월별/주별 합계&통계를 계산하기 위해 날짜 범위와 정보를 제공하는 객체를 추가하였습니다. 

# 추가&변동된 주요 로직
## Domain
### YearInformation
* 해당연도 시작날과 마지막날을 __`LocalDate`__ 로 제공
* 1월부터 12월까지의 __MonthInformation__ 을 `Month enum`을 통해 조회할 수 있는 맵을 제공
### MonthInformation
* 해당월의 시작날과 마지막날을 __`LocalDate`__ 로 제공
* 첫째주부터 마지막주까지의 __WeekInformation__을 `List<>`로 제공합니다.
### WeekInformation
* 해당 주의 시작날과 마지막날을 __`LocalDate`__ 로 제공
 
## DataInfoProvider
### getYearInformation(Year)
해당 연도의 시작날과 마지막날을 계산하고 `getMonthInformation`을 Month enum을 통해 순회하며 계산합니다.

### getMonthInformation(MonthYear)
해당 월의 시작날과 마지막날을 계산하고 `getWeekInformation`을 통해 List<WeekInformation>`을 받아와 저장합니다.

### getWeekInformation(MonthYear)
해당 월의 첫 주부터 마지막 주까지 구간을 계산하여 저장한 `List<>`를 반환합니다. 주 계산은 아래와 같은 방법으로 진행합니다.

* 달력 기준 한 줄의 시작 날과 마지막 날을 계산하여 저장합니다.
  * 주의 시작 요일은 일요일이며 마지막 요일은 토요일입니다. 
  * 이는 통계를 낼 때 구간의 크기가 달라 비교의 어려움이 있어 __프론트와 상의 후 결정한 계산 방법__ 입니다.
  * e. g.)
    *  2025-05의 첫 주: __4월 27일 ~ 5월 3일__
    *  2025-06의 마지막 주: __6월 29일 ~ 7월 5일__
  
 
 ## 💬리뷰 요구사항(선택)
 
getWeekInformation()의 메소드 명이 적절한거 같나요? 아니라면 다른 이름을 추천해주세요!
