### PR TITLE
[#92] response 필드 이름 수정

### DIFF
--- a/src/main/java/com/poortorich/global/response/BaseResponse.java
+++ b/src/main/java/com/poortorich/global/response/BaseResponse.java
@@ -9,9 +9,8 @@ import org.springframework.http.ResponseEntity;
 @Getter
 public class BaseResponse {
 
-    private final Integer resultCode;
-
-    private final String resultMessage;
+    private final Integer status;
+    private final String message;
 
     public static ResponseEntity<BaseResponse> toResponseEntity(Response response) {
         if (response.getField() != null) {
@@ -24,8 +23,8 @@ public class BaseResponse {
         }
 
         BaseResponse baseResponse = BaseResponse.builder()
-                .resultCode(response.getHttpStatus().value())
-                .resultMessage(response.getMessage())
+                .status(response.getHttpStatus().value())
+                .message(response.getMessage())
                 .build();
 
         return ResponseEntity.status(response.getHttpStatus()).body(baseResponse);
@@ -33,8 +32,8 @@ public class BaseResponse {
 
     public static ResponseEntity<BaseResponse> toResponseEntity(HttpStatus httpStatus, String message) {
         BaseResponse baseResponse = BaseResponse.builder()
-                .resultCode(httpStatus.value())
-                .resultMessage(message)
+                .status(httpStatus.value())
+                .message(message)
                 .build();
 
         return ResponseEntity.status(httpStatus.value()).body(baseResponse);

--- a/src/main/java/com/poortorich/global/response/DataResponse.java
+++ b/src/main/java/com/poortorich/global/response/DataResponse.java
@@ -18,8 +18,8 @@ public class DataResponse extends BaseResponse {
 
         return ResponseEntity.status(response.getHttpStatus())
                 .body(DataResponse.builder()
-                        .resultCode(response.getHttpStatus().value())
-                        .resultMessage(response.getMessage())
+                        .status(response.getHttpStatus().value())
+                        .message(response.getMessage())
                         .data(data)
                         .build());
     }
@@ -31,8 +31,8 @@ public class DataResponse extends BaseResponse {
         
         return ResponseEntity.status(httpStatus)
                 .body(DataResponse.builder()
-                        .resultCode(httpStatus.value())
-                        .resultMessage(message)
+                        .status(httpStatus.value())
+                        .message(message)
                         .data(data)
                         .build());
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#92 
 
 ## 📝작업 내용
 
### Response 필드 이름 수정
resultCode -> `status`
resultMessage -> `message`
 
 ### 스크린샷 (선택)
 
 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
