### PR TITLE
[#94] 응답 필드 수정에 영향을 받는 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/security/filter/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/poortorich/security/filter/auth/JwtAuthenticationFilter.java
@@ -134,8 +134,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         BaseResponse responseMessage = BaseResponse
                 .builder()
-                .resultCode(responseInformation.getHttpStatus().value())
-                .resultMessage(responseInformation.getMessage())
+                .status(responseInformation.getHttpStatus().value())
+                .message(responseInformation.getMessage())
                 .build();
 
         objectMapper.writeValue(response.getWriter(), responseMessage);

--- a/src/test/java/com/poortorich/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/poortorich/auth/controller/AuthControllerTest.java
@@ -77,8 +77,8 @@ public class AuthControllerTest extends BaseSecurityTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.resultCode").value(successResponse.getHttpStatus().value()))
-                .andExpect(jsonPath("$.resultMessage").value(successResponse.getMessage()));
+                .andExpect(jsonPath("$.status").value(successResponse.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(successResponse.getMessage()));
 
         verify(authService, Mockito.times(1)).login(any(LoginRequest.class), any(HttpServletResponse.class));
     }
@@ -97,8 +97,8 @@ public class AuthControllerTest extends BaseSecurityTest {
         actions
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.resultCode").value(AuthResponse.CREDENTIALS_INVALID.getHttpStatus().value()))
-                .andExpect(jsonPath("$.resultMessage").value(AuthResponse.CREDENTIALS_INVALID.getMessage()));
+                .andExpect(jsonPath("$.status").value(AuthResponse.CREDENTIALS_INVALID.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(AuthResponse.CREDENTIALS_INVALID.getMessage()));
 
         verify(authService, Mockito.times(1)).login(any(LoginRequest.class), any(HttpServletResponse.class));
     }
@@ -116,8 +116,8 @@ public class AuthControllerTest extends BaseSecurityTest {
         actions
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.resultCode").value(HttpStatus.BAD_REQUEST.value()))
-                .andExpect(jsonPath("$.resultMessage").value(AuthResponseMessage.USERNAME_REQUIRED));
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value(AuthResponseMessage.USERNAME_REQUIRED));
 
         verifyNoInteractions(authService);
     }
@@ -135,8 +135,8 @@ public class AuthControllerTest extends BaseSecurityTest {
         actions
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.resultCode").value(HttpStatus.BAD_REQUEST.value()))
-                .andExpect(jsonPath("$.resultMessage").value(AuthResponseMessage.PASSWORD_REQUIRED));
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value(AuthResponseMessage.PASSWORD_REQUIRED));
 
         verifyNoInteractions(authService);
     }
@@ -152,8 +152,8 @@ public class AuthControllerTest extends BaseSecurityTest {
         actions
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value(AuthResponse.TOKEN_REFRESH_SUCCESS.getHttpStatus().value()))
-                .andExpect(jsonPath("$.resultMessage").value(AuthResponse.TOKEN_REFRESH_SUCCESS.getMessage()));
+                .andExpect(jsonPath("$.status").value(AuthResponse.TOKEN_REFRESH_SUCCESS.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(AuthResponse.TOKEN_REFRESH_SUCCESS.getMessage()));
 
         verify(authService, times(1)).refreshToken(any(HttpServletRequest.class), any(HttpServletResponse.class));
     }
@@ -169,8 +169,8 @@ public class AuthControllerTest extends BaseSecurityTest {
         actions
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.resultCode").value(AuthResponse.TOKEN_INVALID.getHttpStatus().value()))
-                .andExpect(jsonPath("$.resultMessage").value(AuthResponse.TOKEN_INVALID.getMessage()));
+                .andExpect(jsonPath("$.status").value(AuthResponse.TOKEN_INVALID.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(AuthResponse.TOKEN_INVALID.getMessage()));
 
         verify(authService, times(1)).refreshToken(any(HttpServletRequest.class), any(HttpServletResponse.class));
     }
@@ -210,8 +210,8 @@ public class AuthControllerTest extends BaseSecurityTest {
 
         actions
                 .andDo(print())
-                .andExpect(jsonPath("$.resultCode").value(AuthResponse.LOGOUT_SUCCESS.getHttpStatus().value()))
-                .andExpect(jsonPath("$.resultMessage").value(AuthResponse.LOGOUT_SUCCESS.getMessage()));
+                .andExpect(jsonPath("$.status").value(AuthResponse.LOGOUT_SUCCESS.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(AuthResponse.LOGOUT_SUCCESS.getMessage()));
 
         verify(authService, times(1)).logout(any(HttpServletResponse.class));
     }

--- a/src/test/java/com/poortorich/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/com/poortorich/expense/controller/ExpenseControllerTest.java
@@ -69,7 +69,7 @@ class ExpenseControllerTest extends BaseSecurityTest {
                         .content(requestJson)
                         .with(csrf()))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.resultMessage").value(ExpenseResponse.CREATE_EXPENSE_SUCCESS.getMessage()));
+                .andExpect(jsonPath("$.message").value(ExpenseResponse.CREATE_EXPENSE_SUCCESS.getMessage()));
 
         verify(expenseFacade, times(1)).createExpense(any(ExpenseRequest.class), anyString());
     }

--- a/src/test/java/com/poortorich/security/filter/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/poortorich/security/filter/auth/JwtAuthenticationFilterTest.java
@@ -189,8 +189,8 @@ public class JwtAuthenticationFilterTest {
     private String getExpectedJsonResponse(Response expectedResponse) throws JsonProcessingException {
         return testObjectMapper.writeValueAsString(
                 BaseResponse.builder()
-                        .resultCode(expectedResponse.getHttpStatus().value())
-                        .resultMessage(expectedResponse.getMessage())
+                        .status(expectedResponse.getHttpStatus().value())
+                        .message(expectedResponse.getMessage())
                         .build()
         );
     }

--- a/src/test/java/com/poortorich/user/controller/UserControllerTest.java
+++ b/src/test/java/com/poortorich/user/controller/UserControllerTest.java
@@ -87,7 +87,7 @@ class UserControllerTest extends BaseSecurityTest {
                         .with(csrf())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.resultMessage").value(UserResponse.REGISTRATION_SUCCESS.getMessage()));
+                .andExpect(jsonPath("$.message").value(UserResponse.REGISTRATION_SUCCESS.getMessage()));
 
         verify(userFacade, times(1)).registerNewUser(any(UserRegistrationRequest.class));
     }
@@ -112,7 +112,7 @@ class UserControllerTest extends BaseSecurityTest {
                         .with(csrf())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.resultMessage").value(UserResponse.REGISTRATION_SUCCESS.getMessage()));
+                .andExpect(jsonPath("$.message").value(UserResponse.REGISTRATION_SUCCESS.getMessage()));
 
         verify(userFacade, times(1)).registerNewUser(any(UserRegistrationRequest.class));
     }
@@ -129,7 +129,7 @@ class UserControllerTest extends BaseSecurityTest {
                         .content(objectMapper.writeValueAsString(request))
                         .with(csrf()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultMessage").value(UserResponse.USERNAME_AVAILABLE.getMessage()));
+                .andExpect(jsonPath("$.message").value(UserResponse.USERNAME_AVAILABLE.getMessage()));
 
         verify(userFacade, times(1)).checkUsernameAndReservation(any(UsernameCheckRequest.class));
     }
@@ -146,7 +146,7 @@ class UserControllerTest extends BaseSecurityTest {
                         .content(objectMapper.writeValueAsString(request))
                         .with(csrf()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultMessage").value(UserResponseMessages.NICKNAME_AVAILABLE));
+                .andExpect(jsonPath("$.message").value(UserResponseMessages.NICKNAME_AVAILABLE));
 
         verify(userFacade, times(1)).checkNicknameAndReservation(any(NicknameCheckRequest.class));
     }
@@ -171,8 +171,8 @@ class UserControllerTest extends BaseSecurityTest {
                         .with(SecurityMockMvcRequestPostProcessors.user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value(HttpStatus.OK.value()))
-                .andExpect(jsonPath("$.resultMessage").value(UserResponse.USER_DETAIL_FIND_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value(UserResponse.USER_DETAIL_FIND_SUCCESS.getMessage()))
                 .andExpect(jsonPath("$.data.profileImage").value(response.getProfileImage()))
                 .andExpect(jsonPath("$.data.name").value(response.getName()))
                 .andExpect(jsonPath("$.data.nickname").value(response.getNickname()))
@@ -199,8 +199,8 @@ class UserControllerTest extends BaseSecurityTest {
                         .with(SecurityMockMvcRequestPostProcessors.user(UserFixture.createDefaultUser()))
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value(HttpStatus.OK.value()))
-                .andExpect(jsonPath("$.resultMessage").value(UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS));
+                .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value(UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS));
 
         verify(userFacade).updateUserProfile(anyString(), any(ProfileUpdateRequest.class));
     }
@@ -222,8 +222,8 @@ class UserControllerTest extends BaseSecurityTest {
                         .with(SecurityMockMvcRequestPostProcessors.user(UserFixture.createDefaultUser()))
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value(HttpStatus.OK.value()))
-                .andExpect(jsonPath("$.resultMessage").value(UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS));
+                .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value(UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS));
 
         verify(userFacade).updateUserProfile(anyString(), any(ProfileUpdateRequest.class));
     }
@@ -249,8 +249,8 @@ class UserControllerTest extends BaseSecurityTest {
                             return request;
                         }))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value(HttpStatus.OK.value()))
-                .andExpect(jsonPath("$.resultMessage").value(UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS));
+                .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value(UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS));
 
         verify(userFacade).updateUserProfile(anyString(), any(ProfileUpdateRequest.class));
     }
@@ -269,8 +269,8 @@ class UserControllerTest extends BaseSecurityTest {
         mockMvc.perform(MockMvcRequestBuilders.get("/user/email")
                         .with(SecurityMockMvcRequestPostProcessors.user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.resultCode").value(HttpStatus.OK.value()))
-                .andExpect(jsonPath("$.resultMessage").value(UserResponseMessages.USER_EMAIL_FIND_SUCCESS))
+                .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value(UserResponseMessages.USER_EMAIL_FIND_SUCCESS))
                 .andExpect(jsonPath("$.data.email").value(mockUser.getEmail()));
 
         verify(userFacade, times(1)).getUserEmail(anyString());
@@ -290,8 +290,8 @@ class UserControllerTest extends BaseSecurityTest {
                         .with(SecurityMockMvcRequestPostProcessors.user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(getRequestJson(request)))
-                .andExpect(jsonPath("$.resultCode").value(HttpStatus.OK.value()))
-                .andExpect(jsonPath("$.resultMessage").value(UserResponseMessages.PASSWORD_UPDATE_SUCCESS));
+                .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value(UserResponseMessages.PASSWORD_UPDATE_SUCCESS));
 
         verify(userFacade).updateUserPassword(anyString(), any(PasswordUpdateRequest.class));
     }

--- a/src/test/java/com/poortorich/user/validator/UserValidatorTest.java
+++ b/src/test/java/com/poortorich/user/validator/UserValidatorTest.java
@@ -157,14 +157,12 @@ class UserValidatorTest {
     class ValidatePasswordTest {
 
         @Test
-        @DisplayName("비밀번호가 일치하지 않는 경우 BadRequestException을 던진다.")
+        @DisplayName("비밀번호가 일치하지 않는 경우 false를 던진다.")
         void validatePasswordMatch_whenPasswordsDoNotMatch_thenThrowBadRequestException() {
             String password = UserFixture.VALID_PASSWORD_SAMPLE_1;
             String differentPasswordConfirm = UserFixture.MISMATCH_PASSWORD_CONFIRM;
 
-            Assertions.assertThatThrownBy(() -> userValidator.isPasswordMatch(password, differentPasswordConfirm))
-                    .isInstanceOf(BadRequestException.class)
-                    .hasMessage(UserResponseMessages.PASSWORD_DO_NOT_MATCH);
+            Assertions.assertThat(userValidator.isPasswordMatch(password, differentPasswordConfirm)).isFalse();
         }
 
         @Test
@@ -204,7 +202,7 @@ class UserValidatorTest {
 
             assertThatThrownBy(() -> userValidator.validatePassword(username, currentPassword))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage(AuthResponseMessage.CREDENTIALS_INVALID);
+                    .hasMessage(UserResponseMessages.CURRENT_PASSWORD_IS_WRONG);
 
             verify(userRepository, times(1)).findByUsername(username);
             verify(passwordEncoder, times(1)).matches(anyString(), anyString());


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#94 
 
 ## 📝작업 내용
 
- JWTFilter에 있는 Response builder의 응답 필드 이름을 수정
- Test에 있는 응답 필드 이름을 수정
- UserValidatorTest에서 실패하는 테스트를 수정

 ### 스크린샷 (선택)
 
 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
