### PR TITLE
[#96] 카테고리 활성화/비활성화 API 구현

### DIFF
--- a/src/main/java/com/poortorich/category/constants/CategoryResponseMessage.java
+++ b/src/main/java/com/poortorich/category/constants/CategoryResponseMessage.java
@@ -9,6 +9,11 @@ public class CategoryResponseMessage {
     public static final String GET_CUSTOM_CATEGORY_SUCCESS = "사용자화 카테고리를 성공적으로 조회했습니다.";
     public static final String GET_ACTIVE_CATEGORIES_SUCCESS = "활성화된 카테고리 목록을 성공적으로 조회했습니다.";
 
+    public static final String CATEGORY_VISIBILITY_TRUE_SUCCESS = "카테고리를 성공적으로 활성화하였습니다.";
+    public static final String CATEGORY_VISIBILITY_FALSE_SUCCESS = "카테고리를 성공적으로 비활성화하였습니다.";
+
+    public static final String CATEGORY_VISIBILITY_REQUIRED = "카테고리 활성화/비활성화 여부는 필수값입니다.";
+
     public static final String CREATE_CATEGORY_SUCCESS = "카테고리를 성공적으로 등록하였습니다.";
     public static final String MODIFY_CATEGORY_SUCCESS = "카테고리를 성공적으로 편집하였습니다.";
     public static final String DELETE_CATEGORY_SUCCESS = "카테고리를 성공적으로 삭제하였습니다.";

--- a/src/main/java/com/poortorich/category/controller/CategoryController.java
+++ b/src/main/java/com/poortorich/category/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.poortorich.category.controller;
 
 import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.category.request.CategoryInfoRequest;
+import com.poortorich.category.request.CategoryVisibilityRequest;
 import com.poortorich.category.response.CategoryResponse;
 import com.poortorich.category.response.CustomCategoriesResponse;
 import com.poortorich.category.response.CustomCategoryResponse;
@@ -73,6 +74,17 @@ public class CategoryController {
         return DataResponse.toResponseEntity(
                 CategoryResponse.GET_ACTIVE_CATEGORIES_SUCCESS,
                 categoryService.getActiveCategories(type, userDetails.getUsername())
+        );
+    }
+
+    @PutMapping("/active/{categoryId}")
+    public ResponseEntity<BaseResponse> updateActiveCategory(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long categoryId,
+            @RequestBody @Valid CategoryVisibilityRequest visibilityRequest
+    ) {
+        return BaseResponse.toResponseEntity(
+                categoryService.updateActiveCategory(categoryId, visibilityRequest, userDetails.getUsername())
         );
     }
 

--- a/src/main/java/com/poortorich/category/entity/Category.java
+++ b/src/main/java/com/poortorich/category/entity/Category.java
@@ -71,4 +71,8 @@ public class Category {
         this.name = name;
         this.color = color;
     }
+
+    public void updateVisibility(Boolean visibility) {
+        this.visibility = visibility;
+    }
 }

--- a/src/main/java/com/poortorich/category/request/CategoryVisibilityRequest.java
+++ b/src/main/java/com/poortorich/category/request/CategoryVisibilityRequest.java
@@ -1,0 +1,14 @@
+package com.poortorich.category.request;
+
+import com.poortorich.category.constants.CategoryResponseMessage;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryVisibilityRequest {
+
+    @NotNull(message = CategoryResponseMessage.CATEGORY_VISIBILITY_REQUIRED)
+    private Boolean visibility;
+}

--- a/src/main/java/com/poortorich/category/response/CategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoryResponse.java
@@ -15,6 +15,9 @@ public enum CategoryResponse implements Response {
     GET_CUSTOM_CATEGORY_SUCCESS(HttpStatus.OK, CategoryResponseMessage.GET_CUSTOM_CATEGORY_SUCCESS, null),
     GET_ACTIVE_CATEGORIES_SUCCESS(HttpStatus.OK, CategoryResponseMessage.GET_ACTIVE_CATEGORIES_SUCCESS, null),
 
+    CATEGORY_VISIBILITY_TRUE_SUCCESS(HttpStatus.OK, CategoryResponseMessage.CATEGORY_VISIBILITY_TRUE_SUCCESS, null),
+    CATEGORY_VISIBILITY_FALSE_SUCCESS(HttpStatus.OK, CategoryResponseMessage.CATEGORY_VISIBILITY_FALSE_SUCCESS, null),
+
     CREATE_CATEGORY_SUCCESS(HttpStatus.CREATED, CategoryResponseMessage.CREATE_CATEGORY_SUCCESS, null),
     MODIFY_CATEGORY_SUCCESS(HttpStatus.CREATED, CategoryResponseMessage.MODIFY_CATEGORY_SUCCESS, null),
     DELETE_CATEGORY_SUCCESS(HttpStatus.OK, CategoryResponseMessage.DELETE_CATEGORY_SUCCESS, null),

--- a/src/main/java/com/poortorich/category/response/CategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoryResponse.java
@@ -23,7 +23,7 @@ public enum CategoryResponse implements Response {
     DELETE_CATEGORY_SUCCESS(HttpStatus.OK, CategoryResponseMessage.DELETE_CATEGORY_SUCCESS, null),
 
     CATEGORY_NAME_DUPLICATE(HttpStatus.CONFLICT, CategoryResponseMessage.CATEGORY_NAME_DUPLICATE, "name"),
-    CATEGORY_NON_EXISTENT(HttpStatus.NOT_FOUND, CategoryResponseMessage.CATEGORY_NON_EXISTENT, "categoryName"),
+    CATEGORY_NON_EXISTENT(HttpStatus.NOT_FOUND, CategoryResponseMessage.CATEGORY_NON_EXISTENT, "categoryId"),
     CATEGORY_TYPE_INVALID(HttpStatus.BAD_REQUEST,CategoryResponseMessage.CATEGORY_TYPE_INVALID, "categoryType"),
 
     DEFAULT(HttpStatus.INTERNAL_SERVER_ERROR, CategoryResponseMessage.DEFAULT, null);

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.poortorich.category.entity.Category;
 import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.category.repository.CategoryRepository;
 import com.poortorich.category.request.CategoryInfoRequest;
+import com.poortorich.category.request.CategoryVisibilityRequest;
 import com.poortorich.category.response.ActiveCategoriesResponse;
 import com.poortorich.category.response.CategoryInfoResponse;
 import com.poortorich.category.response.CategoryResponse;
@@ -58,6 +59,17 @@ public class CategoryService {
         return ActiveCategoriesResponse.builder()
                 .activeCategories(categories)
                 .build();
+    }
+
+    @Transactional
+    public Response updateActiveCategory(Long categoryId, CategoryVisibilityRequest visibilityRequest, String username) {
+        Boolean visibility = visibilityRequest.getVisibility();
+        getCategoryOrThrow(categoryId, findUserByUsername(username)).updateVisibility(visibility);
+
+        if (visibility) {
+            return CategoryResponse.CATEGORY_VISIBILITY_TRUE_SUCCESS;
+        }
+        return CategoryResponse.CATEGORY_VISIBILITY_FALSE_SUCCESS;
     }
 
     public Response createCategory(CategoryInfoRequest customCategory, CategoryType type, String username) {


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#96 
 
 ## 📝작업 내용

카테고리 활성화/비활성화 여부 수정에 대한 API를 구현하였습니다.

## `CategoryVisibilityRequest`

- 활성화/비활성화 정보를 받기 위한 Request

### Boolean visibility

- 필수 입력값이기 때문에 `@NotNull` 어노테이션 사용

## `CategoryResponse`

필드 | 상태 | 내용
--|--|--
CATEGORY_VISIBILITY_TRUE_SUCCESS | 200 (OK) | 카테고리가 활성화로 변경된 경우
 CATEGORY_VISIBILITY_FALSE_SUCCESS | 200 (OK) | 카테고리가 비활성화로 변경된 경우

## `Category`

### updateVisibility() `new`
- 카테고리 활성화 여부를 업데이트하기 위한 메서드

## `CategoryService`

### updateActiveCategory `new`
- 카테고리 활성화/비활성화 여부를 변경하는 메서드
- `visibility` **true**
    카테고리 **활성화** 성공이라는 Response 반환
- `visibility` **false**
    카테고리 **비활성화** 성공이라는 Response 반환

## `CategoryController`

### updateActiveCategory() `new`

- Request에 따라 적절하게 카테고리 활성화 여부를 변경하고 응답을 반환하는 메서드

 ### 스크린샷 (선택)

> 활성화 성공
> <img width="643" alt="image" src="https://github.com/user-attachments/assets/670ddf3a-d070-44d7-a34d-9436eb1e0b88" />

> 비활성화 성공
> <img width="642" alt="image" src="https://github.com/user-attachments/assets/212a0a34-3e72-4c31-9f39-46a13320cc28" />

> 입력 값이 없는 경우
> <img width="500" alt="image" src="https://github.com/user-attachments/assets/eb916083-81b1-4077-a88a-fdf76f429506" />

 ## 💬리뷰 요구사항(선택)