### PR TITLE
[#101] 기본 카테고리 추가 기능 추가

### DIFF
--- a/src/main/java/com/poortorich/category/domain/model/enums/DefaultExpenseCategory.java
+++ b/src/main/java/com/poortorich/category/domain/model/enums/DefaultExpenseCategory.java
@@ -1,0 +1,41 @@
+package com.poortorich.category.domain.model.enums;
+
+import com.poortorich.category.entity.Category;
+import com.poortorich.category.entity.enums.CategoryType;
+import com.poortorich.user.entity.User;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum DefaultExpenseCategory {
+
+    HOUSING("주거비", "#4A90E2"),
+    FOOD("식비", "#7ED321"),
+    TRANSPORTATION("교통비", "#F5A623"),
+    SHOPPING("쇼핑", "#FF6F61"),
+    HEALTH_MEDICAL("건상/의료", "#50E3C2"),
+    EDUCATION("교육", "#4A4A8A"),
+    CULTURE_HOBBY("문화/취미", "#E563FF"),
+    TRAVEL_ACCOMMODATION("여행/숙박", "#2AB6D9"),
+    GIFTS_EVENTS("선물/경조사", "#E5D038"),
+    BEAUTY("미용", "#FFB1C1"),
+    ALCOHOL_ENTERTAINMENT("술/유흥", "#9B51E0"),
+    CAFE("카페", "#B88A69"),
+    SAVINGS_INVESTMENT("저축/투자", "#228B22"),
+    PET_CARE("펫케어", "#E8CEA0"),
+    OTHER("기타", "#BDBDBD");
+
+    private static final CategoryType type = CategoryType.DEFAULT_EXPENSE;
+
+    private final String name;
+    private final String color;
+
+    public Category toCategoryEntity(User user) {
+        return Category.builder()
+                .type(type)
+                .name(name)
+                .color(color)
+                .visibility(Boolean.TRUE)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/poortorich/category/domain/model/enums/DefaultExpenseCategory.java
+++ b/src/main/java/com/poortorich/category/domain/model/enums/DefaultExpenseCategory.java
@@ -24,14 +24,12 @@ public enum DefaultExpenseCategory {
     PET_CARE("펫케어", "#E8CEA0"),
     OTHER("기타", "#BDBDBD");
 
-    private static final CategoryType type = CategoryType.DEFAULT_EXPENSE;
-
     private final String name;
     private final String color;
 
     public Category toCategoryEntity(User user) {
         return Category.builder()
-                .type(type)
+                .type(CategoryType.DEFAULT_EXPENSE)
                 .name(name)
                 .color(color)
                 .visibility(Boolean.TRUE)

--- a/src/main/java/com/poortorich/category/domain/model/enums/DefaultIncomeCategory.java
+++ b/src/main/java/com/poortorich/category/domain/model/enums/DefaultIncomeCategory.java
@@ -1,0 +1,30 @@
+package com.poortorich.category.domain.model.enums;
+
+import com.poortorich.category.entity.Category;
+import com.poortorich.category.entity.enums.CategoryType;
+import com.poortorich.user.entity.User;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum DefaultIncomeCategory {
+
+    ALLOWANCE("용돈", "#4A90E2"),
+    SALARY("월급", "#228B22"),
+    BONUS("보너스", "#E5D038"),
+    OTHER("기타", "#ADADAD");
+
+    private final static CategoryType type = CategoryType.DEFAULT_INCOME;
+
+    private final String name;
+    private final String color;
+
+    public Category toCategoryEntity(User user) {
+        return Category.builder()
+                .type(type)
+                .name(name)
+                .color(color)
+                .visibility(Boolean.TRUE)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/poortorich/category/domain/model/enums/DefaultIncomeCategory.java
+++ b/src/main/java/com/poortorich/category/domain/model/enums/DefaultIncomeCategory.java
@@ -13,14 +13,12 @@ public enum DefaultIncomeCategory {
     BONUS("보너스", "#E5D038"),
     OTHER("기타", "#ADADAD");
 
-    private final static CategoryType type = CategoryType.DEFAULT_INCOME;
-
     private final String name;
     private final String color;
 
     public Category toCategoryEntity(User user) {
         return Category.builder()
-                .type(type)
+                .type(CategoryType.DEFAULT_INCOME)
                 .name(name)
                 .color(color)
                 .visibility(Boolean.TRUE)

--- a/src/main/java/com/poortorich/category/repository/CategoryRepository.java
+++ b/src/main/java/com/poortorich/category/repository/CategoryRepository.java
@@ -3,11 +3,10 @@ package com.poortorich.category.repository;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.user.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -151,5 +151,4 @@ public class CategoryService {
         return categoryRepository.findByNameAndUser(name, user)
                 .orElseThrow(() -> new NotFoundException(CategoryResponse.CATEGORY_NON_EXISTENT));
     }
-
 }

--- a/src/main/java/com/poortorich/expense/entity/Expense.java
+++ b/src/main/java/com/poortorich/expense/entity/Expense.java
@@ -18,6 +18,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,9 +27,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -16,11 +16,10 @@ import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.iteration.service.IterationService;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/poortorich/expense/service/ExpenseService.java
+++ b/src/main/java/com/poortorich/expense/service/ExpenseService.java
@@ -5,15 +5,14 @@ import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.repository.ExpenseRepository;
 import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.expense.response.ExpenseInfoResponse;
+import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
-import com.poortorich.expense.response.ExpenseResponse;
-import com.poortorich.iteration.entity.IterationExpenses;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/poortorich/user/facade/UserFacade.java
+++ b/src/main/java/com/poortorich/user/facade/UserFacade.java
@@ -1,7 +1,9 @@
 package com.poortorich.user.facade;
 
+import com.poortorich.category.service.CategoryService;
 import com.poortorich.global.response.Response;
 import com.poortorich.s3.service.FileUploadService;
+import com.poortorich.user.entity.User;
 import com.poortorich.user.request.NicknameCheckRequest;
 import com.poortorich.user.request.PasswordUpdateRequest;
 import com.poortorich.user.request.ProfileUpdateRequest;
@@ -26,6 +28,8 @@ public class UserFacade {
     private final FileUploadService fileUploadService;
     private final RedisUserReservationService userReservationService;
 
+    private final CategoryService categoryService;
+
     @Transactional
     public void registerNewUser(UserRegistrationRequest userRegistrationRequest) {
         userValidationService.validateRegistration(userRegistrationRequest);
@@ -33,7 +37,9 @@ public class UserFacade {
         userReservationService.removeNicknameReservation(userRegistrationRequest.getNickname());
 
         String profileImageUrl = fileUploadService.uploadImage(userRegistrationRequest.getProfileImage());
-        userService.save(userRegistrationRequest, profileImageUrl);
+        User user = userService.save(userRegistrationRequest, profileImageUrl);
+
+        categoryService.saveAllDefaultCategories(user);
     }
 
     public Response checkUsernameAndReservation(UsernameCheckRequest usernameCheckRequest) {

--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -19,7 +19,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public void save(UserRegistrationRequest userRegistrationRequest, String profileImageUrl) {
+    public User save(UserRegistrationRequest userRegistrationRequest, String profileImageUrl) {
         User user = User.builder()
                 .profileImage(profileImageUrl)
                 .username(userRegistrationRequest.getUsername())
@@ -33,6 +33,8 @@ public class UserService {
                 .build();
 
         userRepository.save(user);
+        
+        return user;
     }
 
     public void update(String username, ProfileUpdateRequest userProfile, String newProfileImage) {

--- a/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
+++ b/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
@@ -1,5 +1,8 @@
 package com.poortorich.expense.facade;
 
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.expense.entity.Expense;
@@ -17,9 +20,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ExpenseFacadeTest {

--- a/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
@@ -1,5 +1,9 @@
 package com.poortorich.expense.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.verify;
+
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.fixture.ExpenseFixture;
@@ -16,10 +20,6 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class ExpenseServiceTest {


### PR DESCRIPTION
## #️⃣101
 ## 📝작업 내용
 회원가입이 완료된 경우 지출&수입 기본 카테고리를 생성하여 저장하는 로직을 추가하였습니다.

지출 & 수입 기본 카테고리는 enum으로 관리하였습니다. 기본 카테고리가 수정되거나 추가될 때 해당 enum에 추가/수정하는 작업만으로 수정이 가능합니다. 

# Model
## DefaultExpenseCategory __`New`__ 
 enum으로 프론트에서 제공한 디자인 정보를 활용하여 카테고리 이름과 색상을 표기하였습니다.

## DefaultIncomeCategory __`New`__
 `DefaultExpenseCategory`와 같이 작업했습니다.

# Category
## CategoryService
### saveAllDefaultCategories __`New`__
`DefaultExpenseCategory`와 `DefaultIncomeCategory`의 `toCategoryEntity(User)` 의 반환값을 DB에 저장합니다.

# User
## UserService
### save() __`Update`__
`UserRepository`로 저장한 __User Entity__ 를 반환하도록 수정

## UserFacade
### registerNewUser() __`Update`__
DB에 저장 후 반환된 __User Entity__ 를 사용하여 `CategoryService.saveAllDefaultCategories`를 호출하는 로직 추가
 
 ### 스크린샷 (선택)
 
![image](https://github.com/user-attachments/assets/03d073a1-d660-49ae-bc34-0aeacdb86dcd)
![image](https://github.com/user-attachments/assets/2a8272ff-cfdf-4707-86f8-03eb9b7c2616)

회원가입 후 기본 카테고리가 잘 저장되는 것을 확인하였음

 ## 💬리뷰 요구사항(선택)
1. 변수명, 메소드명, 객체명이 적절한지
2. 컨벤션 위배된 코드가 있는지
3. 다른 방식의 코드를 추천할게 있는지
