### PR TITLE
[#103] 회원가입 시 기본 프로필 적용

### DIFF
--- a/src/main/java/com/poortorich/s3/service/FileUploadService.java
+++ b/src/main/java/com/poortorich/s3/service/FileUploadService.java
@@ -29,7 +29,7 @@ public class FileUploadService {
     private String bucketName;
 
     public String uploadImage(MultipartFile imageFile) {
-        if (imageFile.isEmpty()) {
+        if (Objects.isNull(imageFile) || imageFile.isEmpty()) {
             return S3Constants.DEFAULT_PROFILE_IMAGE;
         }
 

--- a/src/main/java/com/poortorich/user/request/UserRegistrationRequest.java
+++ b/src/main/java/com/poortorich/user/request/UserRegistrationRequest.java
@@ -6,7 +6,6 @@ import com.poortorich.user.constants.UserValidationRules;
 import com.poortorich.user.entity.enums.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
@@ -88,7 +87,6 @@ public class UserRegistrationRequest {
     private String job;
 
     @JsonIgnore
-    @NotNull(message = UserResponseMessages.PROFILE_IMAGE_REQUIRED)
     private MultipartFile profileImage;
 
     @JsonIgnore


### PR DESCRIPTION
## #️⃣103
 
 ## 📝작업 내용
 회원가입 시 프로필 이미지 필드를 null 허용하며 null이거나 비어있는 경우 기본 프로필 이미지를 반환하도록 수정하였음.
 
 ### 스크린샷 (선택)
 
![image](https://github.com/user-attachments/assets/f9cf4054-a40b-4cd4-8ad7-d2904d6adda0)
