### PR TITLE
[#107] 수입 가계부 추가 API 구현

### DIFF
--- a/src/main/java/com/poortorich/PoorToRichApplication.java
+++ b/src/main/java/com/poortorich/PoorToRichApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
-@EntityScan(basePackages = {"com.poortorich.category.entity", "com.poortorich.user.entity", "com.poortorich.expense.entity", "com.poortorich.iteration.entity"})
+@EntityScan(basePackages = {"com.poortorich.category.entity", "com.poortorich.user.entity", "com.poortorich.expense.entity", "com.poortorich.income.entity", "com.poortorich.iteration.entity"})
 public class PoorToRichApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/poortorich/accountbook/constants/AccountBookResponseMessages.java
+++ b/src/main/java/com/poortorich/accountbook/constants/AccountBookResponseMessages.java
@@ -1,0 +1,23 @@
+package com.poortorich.accountbook.constants;
+
+public class AccountBookResponseMessages {
+
+    public static final String DATE_REQUIRED = "날짜는 필수로 입력해야 합니다.";
+    public static final String DATE_INVALID = "날짜 형식이 적절하지 않습니다.";
+
+    public static final String CATEGORY_NAME_REQUIRED = "카테고리는 필수로 선택해야 합니다.";
+
+    public static final String COST_REQUIRED = "금액은 필수로 입력해야 합니다.";
+    public static final String COST_NEGATIVE = "금액은 0보다 커야합니다.";
+    public static final String COST_TOO_BIG = "금액은 " + AccountBookValidationConstraints.COST_LIMIT + "보다 작아야 합니다.";
+
+    public static final String TITLE_TOO_SHORT = "지출명은 1자 이상 작성해야 합니다.";
+    public static final String TITLE_TOO_LONG = "지출명은 " + AccountBookValidationConstraints.TITLE_MAX_SIZE + "자 이하로 작성해야 합니다.";
+    public static final String MEMO_TOO_LONG = "메모는 " + AccountBookValidationConstraints.MEMO_MAX_SIZE + "자 이하로 작성해야 합니다.";
+
+    public static final String ITERATION_TYPE_INVALID = "반복 데이터 유형이 적절하지 않습니다.";
+
+    public static final String ITERATION_ACTION_INVALID = "반복 데이터 편집/삭제 유형이 적절하지 않습니다.";
+
+    private AccountBookResponseMessages() {}
+}

--- a/src/main/java/com/poortorich/accountbook/constants/AccountBookValidationConstraints.java
+++ b/src/main/java/com/poortorich/accountbook/constants/AccountBookValidationConstraints.java
@@ -1,6 +1,6 @@
-package com.poortorich.expense.constants;
+package com.poortorich.accountbook.constants;
 
-public class ExpenseValidationConstraints {
+public class AccountBookValidationConstraints {
 
     public static final int TITLE_MAX_SIZE = 15;
 
@@ -8,5 +8,5 @@ public class ExpenseValidationConstraints {
 
     public static final int MEMO_MAX_SIZE = 100;
 
-    private ExpenseValidationConstraints() {}
+    private AccountBookValidationConstraints() {}
 }

--- a/src/main/java/com/poortorich/accountbook/entity/enums/IterationType.java
+++ b/src/main/java/com/poortorich/accountbook/entity/enums/IterationType.java
@@ -1,4 +1,4 @@
-package com.poortorich.expense.entity.enums;
+package com.poortorich.accountbook.entity.enums;
 
 import com.poortorich.accountbook.response.AccountBookResponse;
 import com.poortorich.global.exceptions.BadRequestException;

--- a/src/main/java/com/poortorich/accountbook/request/AccountBookRequest.java
+++ b/src/main/java/com/poortorich/accountbook/request/AccountBookRequest.java
@@ -1,0 +1,89 @@
+package com.poortorich.accountbook.request;
+
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
+import com.poortorich.accountbook.constants.AccountBookValidationConstraints;
+import com.poortorich.accountbook.entity.enums.IterationType;
+import com.poortorich.accountbook.request.enums.IterationAction;
+import com.poortorich.accountbook.response.AccountBookResponse;
+import com.poortorich.global.date.constants.DatePattern;
+import com.poortorich.global.exceptions.BadRequestException;
+import com.poortorich.iteration.request.CustomIteration;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class AccountBookRequest {
+
+    @NotNull(message = AccountBookResponseMessages.DATE_REQUIRED)
+    private String date;
+
+    @NotBlank(message = AccountBookResponseMessages.CATEGORY_NAME_REQUIRED)
+    private String categoryName;
+
+    @Size(max = AccountBookValidationConstraints.TITLE_MAX_SIZE,
+            message = AccountBookResponseMessages.TITLE_TOO_LONG)
+    private String title;
+
+    @NotNull(message = AccountBookResponseMessages.COST_REQUIRED)
+    @Positive(message = AccountBookResponseMessages.COST_NEGATIVE)
+    @Max(value = AccountBookValidationConstraints.COST_LIMIT,
+            message = AccountBookResponseMessages.COST_TOO_BIG)
+    private Long cost;
+
+    @Size(max = AccountBookValidationConstraints.MEMO_MAX_SIZE,
+            message = AccountBookResponseMessages.MEMO_TOO_LONG)
+    private String memo;
+
+    private String iterationType;
+
+    private String iterationAction;
+
+    private Boolean isIterationModified;
+
+    @Valid
+    private CustomIteration customIteration;
+
+    public LocalDate parseDate() {
+        try {
+            return LocalDate.parse(date, DateTimeFormatter.ofPattern(DatePattern.BASIC_PATTERN));
+        } catch (DateTimeException e) {
+            throw new BadRequestException(AccountBookResponse.DATE_INVALID);
+        }
+    }
+
+    public String trimTitle() {
+        if (title == null) {
+            return null;
+        }
+
+        String trimTitle = title.trim();
+        if (!trimTitle.isEmpty()) {
+            return trimTitle;
+        }
+
+        throw new BadRequestException(AccountBookResponse.TITLE_TOO_SHORT);
+    }
+
+    public IterationType parseIterationType() {
+        return IterationType.from(iterationType);
+    }
+
+    public IterationAction parseIterationAction() {
+        return IterationAction.from(iterationAction);
+    }
+}

--- a/src/main/java/com/poortorich/accountbook/request/enums/IterationAction.java
+++ b/src/main/java/com/poortorich/accountbook/request/enums/IterationAction.java
@@ -1,4 +1,4 @@
-package com.poortorich.expense.request.enums;
+package com.poortorich.accountbook.request.enums;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/poortorich/accountbook/response/AccountBookResponse.java
+++ b/src/main/java/com/poortorich/accountbook/response/AccountBookResponse.java
@@ -1,0 +1,34 @@
+package com.poortorich.accountbook.response;
+
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
+import com.poortorich.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AccountBookResponse implements Response {
+
+    TITLE_TOO_SHORT(HttpStatus.BAD_REQUEST, AccountBookResponseMessages.TITLE_TOO_SHORT, "title"),
+    ITERATION_TYPE_INVALID(HttpStatus.BAD_REQUEST, AccountBookResponseMessages.ITERATION_TYPE_INVALID, "iterationType"),
+    DATE_INVALID(HttpStatus.BAD_REQUEST, AccountBookResponseMessages.DATE_INVALID, "date"),
+    ITERATION_ACTION_INVALID(HttpStatus.BAD_REQUEST, AccountBookResponseMessages.ITERATION_ACTION_INVALID, "iterationAction");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String field;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
+}

--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -1,0 +1,19 @@
+package com.poortorich.accountbook.service;
+
+import com.poortorich.accountbook.request.AccountBookRequest;
+import com.poortorich.category.entity.Category;
+import com.poortorich.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public abstract class AccountBookService<T extends AccountBookRequest, E> {
+
+    public E create(T request, Category category, User user) {
+        E entity = buildEntity(request, category, user);
+        getRepository().save(entity);
+        return entity;
+    }
+
+    protected abstract E buildEntity(T request, Category category, User user);
+
+    protected abstract JpaRepository<E, Long> getRepository();
+}

--- a/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
+++ b/src/main/java/com/poortorich/expense/constants/ExpenseResponseMessages.java
@@ -2,30 +2,13 @@ package com.poortorich.expense.constants;
 
 public class ExpenseResponseMessages {
 
-    public static final String DATE_REQUIRED = "날짜는 필수로 입력해야 합니다.";
-    public static final String DATE_INVALID = "날짜 형식이 적절하지 않습니다.";
-
-    public static final String CATEGORY_NAME_REQUIRED = "카테고리는 필수로 선택해야 합니다.";
-
-    public static final String COST_REQUIRED = "금액은 필수로 입력해야 합니다.";
-    public static final String COST_NEGATIVE = "금액은 0보다 커야합니다.";
-    public static final String COST_TOO_BIG = "금액은 " + ExpenseValidationConstraints.COST_LIMIT + "보다 작아야 합니다.";
-
-    public static final String TITLE_TOO_SHORT = "지출명은 1자 이상 작성해야 합니다.";
-    public static final String TITLE_TOO_LONG = "지출명은 " + ExpenseValidationConstraints.TITLE_MAX_SIZE + "자 이하로 작성해야 합니다.";
-    public static final String MEMO_TOO_LONG = "메모는 " + ExpenseValidationConstraints.MEMO_MAX_SIZE + "자 이하로 작성해야 합니다.";
-
-    public static final String PAYMENT_METHOD_REQUIRED = "지출수단은 필수로 선택해야 합니다.";
-    public static final String PAYMENT_METHOD_INVALID = "지출수단이 적절하지 않습니다.";
-
-    public static final String ITERATION_TYPE_INVALID = "반복 데이터 유형이 적절하지 않습니다.";
-
-    public static final String ITERATION_ACTION_INVALID = "반복 데이터 편집/삭제 유형이 적절하지 않습니다.";
-
     public static final String CREATE_EXPENSE_SUCCESS = "지출 가계부를 성공적으로 등록하였습니다.";
     public static final String GET_EXPENSE_SUCCESS = "지출 가계부를 성공적으로 조회하였습니다.";
     public static final String MODIFY_EXPENSE_SUCCESS = "지출 가계부를 성공적으로 편집하였습니다.";
     public static final String DELETE_EXPENSE_SUCCESS = "지출 가계부를 성공적으로 삭제하였습니다.";
+
+    public static final String PAYMENT_METHOD_REQUIRED = "지출수단은 필수로 선택해야 합니다.";
+    public static final String PAYMENT_METHOD_INVALID = "지출수단이 적절하지 않습니다.";
 
     public static final String EXPENSE_NON_EXISTENT = "존재하지 않는 지출입니다.";
 

--- a/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
+++ b/src/main/java/com/poortorich/expense/entity/enums/IterationType.java
@@ -1,6 +1,6 @@
 package com.poortorich.expense.entity.enums;
 
-import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.accountbook.response.AccountBookResponse;
 import com.poortorich.global.exceptions.BadRequestException;
 import lombok.RequiredArgsConstructor;
 
@@ -29,7 +29,7 @@ public enum IterationType {
         return Arrays.stream(IterationType.values())
                 .filter(iteration -> Objects.equals(iteration.type, type))
                 .findFirst()
-                .orElseThrow(() -> new BadRequestException(ExpenseResponse.ITERATION_TYPE_INVALID));
+                .orElseThrow(() -> new BadRequestException(AccountBookResponse.ITERATION_TYPE_INVALID));
     }
 
     @Override

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -3,10 +3,10 @@ package com.poortorich.expense.facade;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.expense.entity.Expense;
-import com.poortorich.expense.entity.enums.IterationType;
+import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.expense.request.ExpenseDeleteRequest;
 import com.poortorich.expense.request.ExpenseRequest;
-import com.poortorich.expense.request.enums.IterationAction;
+import com.poortorich.accountbook.request.enums.IterationAction;
 import com.poortorich.expense.response.ExpenseInfoResponse;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.expense.service.ExpenseService;
@@ -36,7 +36,7 @@ public class ExpenseFacade {
     public Response createExpense(ExpenseRequest expenseRequest, String username) {
         User user = userService.findUserByUsername(username);
         Category category = categoryService.findCategoryByName(expenseRequest.getCategoryName(), user);
-        Expense expense = expenseService.createExpense(expenseRequest, category, user);
+        Expense expense = expenseService.create(expenseRequest, category, user);
         if (expense.getIterationType() != IterationType.DEFAULT) {
             createIterationExpense(expenseRequest, expense, user);
         }
@@ -135,7 +135,7 @@ public class ExpenseFacade {
         expenseService.deleteExpenseAll(
                 iterationService.deleteIterationExpenses(expense, user, iterationAction)
         );
-        Expense newExpense = expenseService.createExpense(expenseRequest, category, user);
+        Expense newExpense = expenseService.create(expenseRequest, category, user);
         createIterationExpense(expenseRequest, newExpense, user);
     }
 

--- a/src/main/java/com/poortorich/expense/request/ExpenseDeleteRequest.java
+++ b/src/main/java/com/poortorich/expense/request/ExpenseDeleteRequest.java
@@ -1,6 +1,6 @@
 package com.poortorich.expense.request;
 
-import com.poortorich.expense.request.enums.IterationAction;
+import com.poortorich.accountbook.request.enums.IterationAction;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
+++ b/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
@@ -1,93 +1,22 @@
 package com.poortorich.expense.request;
 
-import com.poortorich.accountbook.constants.AccountBookResponseMessages;
-import com.poortorich.accountbook.constants.AccountBookValidationConstraints;
-import com.poortorich.accountbook.response.AccountBookResponse;
+import com.poortorich.accountbook.request.AccountBookRequest;
 import com.poortorich.expense.constants.ExpenseResponseMessages;
-import com.poortorich.expense.entity.enums.IterationType;
 import com.poortorich.expense.entity.enums.PaymentMethod;
-import com.poortorich.expense.request.enums.IterationAction;
-import com.poortorich.global.date.constants.DatePattern;
-import com.poortorich.global.exceptions.BadRequestException;
-import com.poortorich.iteration.request.CustomIteration;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Size;
-import java.time.DateTimeException;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@AllArgsConstructor
-public class ExpenseRequest {
-
-    @NotNull(message = AccountBookResponseMessages.DATE_REQUIRED)
-    private String date;
-
-    @NotBlank(message = AccountBookResponseMessages.CATEGORY_NAME_REQUIRED)
-    private String categoryName;
-
-    @Size(max = AccountBookValidationConstraints.TITLE_MAX_SIZE,
-            message = AccountBookResponseMessages.TITLE_TOO_LONG)
-    private String title;
-
-    @NotNull(message = AccountBookResponseMessages.COST_REQUIRED)
-    @Positive(message = AccountBookResponseMessages.COST_NEGATIVE)
-    @Max(value = AccountBookValidationConstraints.COST_LIMIT,
-            message = AccountBookResponseMessages.COST_TOO_BIG)
-    private Long cost;
+@SuperBuilder
+@NoArgsConstructor
+public class ExpenseRequest extends AccountBookRequest {
 
     @NotBlank(message = ExpenseResponseMessages.PAYMENT_METHOD_REQUIRED)
     private String paymentMethod;
 
-    @Size(max = AccountBookValidationConstraints.MEMO_MAX_SIZE,
-            message = AccountBookResponseMessages.MEMO_TOO_LONG)
-    private String memo;
-
-    private String iterationType;
-
-    private String iterationAction;
-
-    private Boolean isIterationModified;
-
-    @Valid
-    private CustomIteration customIteration;
-
-    public LocalDate parseDate() {
-        try {
-            return LocalDate.parse(date, DateTimeFormatter.ofPattern(DatePattern.BASIC_PATTERN));
-        } catch (DateTimeException e) {
-            throw new BadRequestException(AccountBookResponse.DATE_INVALID);
-        }
-    }
-
     public PaymentMethod parsePaymentMethod() {
         return PaymentMethod.from(paymentMethod);
-    }
-
-    public String trimTitle() {
-        if (title == null) {
-            return null;
-        }
-
-        String trimTitle = title.trim();
-        if (!trimTitle.isEmpty()) {
-            return trimTitle;
-        }
-
-        throw new BadRequestException(AccountBookResponse.TITLE_TOO_SHORT);
-    }
-
-    public IterationType parseIterationType() {
-        return IterationType.from(iterationType);
-    }
-
-    public IterationAction parseIterationAction() {
-        return IterationAction.from(iterationAction);
     }
 }

--- a/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
+++ b/src/main/java/com/poortorich/expense/request/ExpenseRequest.java
@@ -1,11 +1,12 @@
 package com.poortorich.expense.request;
 
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
+import com.poortorich.accountbook.constants.AccountBookValidationConstraints;
+import com.poortorich.accountbook.response.AccountBookResponse;
 import com.poortorich.expense.constants.ExpenseResponseMessages;
-import com.poortorich.expense.constants.ExpenseValidationConstraints;
 import com.poortorich.expense.entity.enums.IterationType;
 import com.poortorich.expense.entity.enums.PaymentMethod;
 import com.poortorich.expense.request.enums.IterationAction;
-import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.date.constants.DatePattern;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.iteration.request.CustomIteration;
@@ -25,27 +26,27 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ExpenseRequest {
 
-    @NotNull(message = ExpenseResponseMessages.DATE_REQUIRED)
+    @NotNull(message = AccountBookResponseMessages.DATE_REQUIRED)
     private String date;
 
-    @NotBlank(message = ExpenseResponseMessages.CATEGORY_NAME_REQUIRED)
+    @NotBlank(message = AccountBookResponseMessages.CATEGORY_NAME_REQUIRED)
     private String categoryName;
 
-    @Size(max = ExpenseValidationConstraints.TITLE_MAX_SIZE,
-            message = ExpenseResponseMessages.TITLE_TOO_LONG)
+    @Size(max = AccountBookValidationConstraints.TITLE_MAX_SIZE,
+            message = AccountBookResponseMessages.TITLE_TOO_LONG)
     private String title;
 
-    @NotNull(message = ExpenseResponseMessages.COST_REQUIRED)
-    @Positive(message = ExpenseResponseMessages.COST_NEGATIVE)
-    @Max(value = ExpenseValidationConstraints.COST_LIMIT,
-            message = ExpenseResponseMessages.COST_TOO_BIG)
+    @NotNull(message = AccountBookResponseMessages.COST_REQUIRED)
+    @Positive(message = AccountBookResponseMessages.COST_NEGATIVE)
+    @Max(value = AccountBookValidationConstraints.COST_LIMIT,
+            message = AccountBookResponseMessages.COST_TOO_BIG)
     private Long cost;
 
     @NotBlank(message = ExpenseResponseMessages.PAYMENT_METHOD_REQUIRED)
     private String paymentMethod;
 
-    @Size(max = ExpenseValidationConstraints.MEMO_MAX_SIZE,
-            message = ExpenseResponseMessages.MEMO_TOO_LONG)
+    @Size(max = AccountBookValidationConstraints.MEMO_MAX_SIZE,
+            message = AccountBookResponseMessages.MEMO_TOO_LONG)
     private String memo;
 
     private String iterationType;
@@ -61,7 +62,7 @@ public class ExpenseRequest {
         try {
             return LocalDate.parse(date, DateTimeFormatter.ofPattern(DatePattern.BASIC_PATTERN));
         } catch (DateTimeException e) {
-            throw new BadRequestException(ExpenseResponse.DATE_INVALID);
+            throw new BadRequestException(AccountBookResponse.DATE_INVALID);
         }
     }
 
@@ -79,7 +80,7 @@ public class ExpenseRequest {
             return trimTitle;
         }
 
-        throw new BadRequestException(ExpenseResponse.TITLE_TOO_SHORT);
+        throw new BadRequestException(AccountBookResponse.TITLE_TOO_SHORT);
     }
 
     public IterationType parseIterationType() {

--- a/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
+++ b/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
@@ -1,6 +1,5 @@
 package com.poortorich.expense.response;
 
-import com.poortorich.accountbook.constants.AccountBookResponseMessages;
 import com.poortorich.expense.constants.ExpenseResponseMessages;
 import com.poortorich.global.response.Response;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
+++ b/src/main/java/com/poortorich/expense/response/ExpenseResponse.java
@@ -1,5 +1,6 @@
 package com.poortorich.expense.response;
 
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
 import com.poortorich.expense.constants.ExpenseResponseMessages;
 import com.poortorich.global.response.Response;
 import lombok.AllArgsConstructor;
@@ -13,11 +14,7 @@ public enum ExpenseResponse implements Response {
     MODIFY_EXPENSE_SUCCESS(HttpStatus.CREATED, ExpenseResponseMessages.MODIFY_EXPENSE_SUCCESS, null),
     DELETE_EXPENSE_SUCCESS(HttpStatus.OK, ExpenseResponseMessages.DELETE_EXPENSE_SUCCESS, null),
 
-    TITLE_TOO_SHORT(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.TITLE_TOO_SHORT, "title"),
     PAYMENT_METHOD_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.PAYMENT_METHOD_INVALID, "paymentMethod"),
-    ITERATION_TYPE_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.ITERATION_TYPE_INVALID, "iterationType"),
-    DATE_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.DATE_INVALID, "date"),
-    ITERATION_ACTION_INVALID(HttpStatus.BAD_REQUEST, ExpenseResponseMessages.ITERATION_ACTION_INVALID, "iterationAction"),
 
     EXPENSE_NON_EXISTENT(HttpStatus.NOT_FOUND, ExpenseResponseMessages.EXPENSE_NON_EXISTENT, "expenseId");
 

--- a/src/main/java/com/poortorich/expense/service/ExpenseService.java
+++ b/src/main/java/com/poortorich/expense/service/ExpenseService.java
@@ -1,5 +1,6 @@
 package com.poortorich.expense.service;
 
+import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.repository.ExpenseRepository;
@@ -14,27 +15,23 @@ import com.poortorich.user.entity.User;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 
 import java.beans.Transient;
 
 @Service
 @RequiredArgsConstructor
-public class ExpenseService {
+public class ExpenseService extends AccountBookService<ExpenseRequest, Expense> {
 
     private final ExpenseRepository expenseRepository;
-
-    public Expense createExpense(ExpenseRequest expenseRequest, Category category, User user) {
-        Expense expense = buildExpense(expenseRequest, category, user);
-        expenseRepository.save(expense);
-        return expense;
-    }
 
     public List<Expense> createExpenseAll(List<Expense> expenses) {
         return expenseRepository.saveAll(expenses);
     }
 
-    private Expense buildExpense(ExpenseRequest expenseRequest, Category category, User user) {
+    @Override
+    protected Expense buildEntity(ExpenseRequest expenseRequest, Category category, User user) {
         return Expense.builder()
                 .expenseDate(expenseRequest.parseDate())
                 .category(category)
@@ -45,6 +42,11 @@ public class ExpenseService {
                 .iterationType(expenseRequest.parseIterationType())
                 .user(user)
                 .build();
+    }
+
+    @Override
+    protected JpaRepository<Expense, Long> getRepository() {
+        return expenseRepository;
     }
 
     public IterationExpenses getIterationExpenses(Long id, User user) {

--- a/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
+++ b/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
@@ -1,0 +1,10 @@
+package com.poortorich.income.constants;
+
+public class IncomeResponseMessages {
+
+    public static final String CREATE_INCOME_SUCCESS = "수입 가계부를 성공적으로 등록하였습니다.";
+
+    private IncomeResponseMessages() {
+
+    }
+}

--- a/src/main/java/com/poortorich/income/controller/IncomeController.java
+++ b/src/main/java/com/poortorich/income/controller/IncomeController.java
@@ -1,0 +1,29 @@
+package com.poortorich.income.controller;
+
+import com.poortorich.global.response.BaseResponse;
+import com.poortorich.income.facade.IncomeFacade;
+import com.poortorich.income.request.IncomeRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/income")
+@RequiredArgsConstructor
+public class IncomeController {
+
+    private final IncomeFacade incomeFacade;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse> createIncome(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid IncomeRequest incomeRequest) {
+        return BaseResponse.toResponseEntity(incomeFacade.createIncome(incomeRequest, userDetails.getUsername()));
+    }
+}

--- a/src/main/java/com/poortorich/income/entity/Income.java
+++ b/src/main/java/com/poortorich/income/entity/Income.java
@@ -1,9 +1,7 @@
-package com.poortorich.expense.entity;
+package com.poortorich.income.entity;
 
-import com.poortorich.category.entity.Category;
 import com.poortorich.accountbook.entity.enums.IterationType;
-import com.poortorich.expense.entity.enums.PaymentMethod;
-import com.poortorich.iteration.entity.IterationExpenses;
+import com.poortorich.category.entity.Category;
 import com.poortorich.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,11 +13,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,14 +23,17 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
 @DynamicUpdate
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "expense")
-public class Expense {
+@Table(name = "income")
+public class Income {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,19 +41,14 @@ public class Expense {
     private Long id;
 
     @NotNull
-    @Column(name = "expenseDate", nullable = false)
-    private LocalDate expenseDate;
+    @Column(name = "incomeDate", nullable = false)
+    private LocalDate incomeDate;
 
     @Column(name = "title")
     private String title;
 
-    @Column(name = "cost", nullable = false)
+    @Column(name = "cost")
     private Long cost;
-
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    @Column(name = "paymentMethod", nullable = false)
-    private PaymentMethod paymentMethod;
 
     @Column(name = "memo")
     private String memo;
@@ -73,8 +66,7 @@ public class Expense {
     @JoinColumn(name = "userId")
     private User user;
 
-    @OneToOne(mappedBy = "generatedExpense")
-    private IterationExpenses generatedIterationExpenses;
+    // 반복 데이터 테이블과의 연관관계
 
     @CreationTimestamp
     @Column(name = "createdDate")
@@ -83,17 +75,4 @@ public class Expense {
     @UpdateTimestamp
     @Column(name = "updatedDate")
     private LocalDateTime updatedDate;
-
-    public void updateExpense(String title, Long cost, PaymentMethod paymentMethod, String memo, IterationType iterationType, Category category) {
-        this.title = title;
-        this.cost = cost;
-        this.paymentMethod = paymentMethod;
-        this.memo = memo;
-        this.iterationType = iterationType;
-        this.category = category;
-    }
-
-    public void updateExpenseDate(LocalDate expenseDate) {
-        this.expenseDate = expenseDate;
-    }
 }

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -1,0 +1,32 @@
+package com.poortorich.income.facade;
+
+import com.poortorich.category.entity.Category;
+import com.poortorich.category.service.CategoryService;
+import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.global.response.Response;
+import com.poortorich.income.entity.Income;
+import com.poortorich.income.request.IncomeRequest;
+import com.poortorich.income.service.IncomeService;
+import com.poortorich.user.entity.User;
+import com.poortorich.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class IncomeFacade {
+
+    private final UserService userService;
+    private final CategoryService categoryService;
+    private final IncomeService incomeService;
+
+    @Transactional
+    public Response createIncome(IncomeRequest incomeRequest, String username) {
+        User user = userService.findUserByUsername(username);
+        Category category = categoryService.findCategoryByName(incomeRequest.getCategoryName(), user);
+        Income income = incomeService.create(incomeRequest, category, user);
+
+        return ExpenseResponse.CREATE_EXPENSE_SUCCESS;
+    }
+}

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -2,10 +2,10 @@ package com.poortorich.income.facade;
 
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.service.CategoryService;
-import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.response.Response;
 import com.poortorich.income.entity.Income;
 import com.poortorich.income.request.IncomeRequest;
+import com.poortorich.income.response.enums.IncomeResponse;
 import com.poortorich.income.service.IncomeService;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
@@ -27,6 +27,6 @@ public class IncomeFacade {
         Category category = categoryService.findCategoryByName(incomeRequest.getCategoryName(), user);
         Income income = incomeService.create(incomeRequest, category, user);
 
-        return ExpenseResponse.CREATE_EXPENSE_SUCCESS;
+        return IncomeResponse.CREATE_INCOME_SUCCESS;
     }
 }

--- a/src/main/java/com/poortorich/income/repository/IncomeRepository.java
+++ b/src/main/java/com/poortorich/income/repository/IncomeRepository.java
@@ -1,0 +1,9 @@
+package com.poortorich.income.repository;
+
+import com.poortorich.income.entity.Income;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IncomeRepository extends JpaRepository<Income, Long> {
+}

--- a/src/main/java/com/poortorich/income/request/IncomeRequest.java
+++ b/src/main/java/com/poortorich/income/request/IncomeRequest.java
@@ -1,0 +1,9 @@
+package com.poortorich.income.request;
+
+import com.poortorich.accountbook.request.AccountBookRequest;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+public class IncomeRequest extends AccountBookRequest {
+
+}

--- a/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
+++ b/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
@@ -1,0 +1,31 @@
+package com.poortorich.income.response.enums;
+
+import com.poortorich.global.response.Response;
+import com.poortorich.income.constants.IncomeResponseMessages;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum IncomeResponse implements Response {
+
+    CREATE_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.CREATE_INCOME_SUCCESS, null);
+
+    private final HttpStatus status;
+    private final String message;
+    private final String field;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
+}

--- a/src/main/java/com/poortorich/income/service/IncomeService.java
+++ b/src/main/java/com/poortorich/income/service/IncomeService.java
@@ -1,0 +1,36 @@
+package com.poortorich.income.service;
+
+import com.poortorich.accountbook.service.AccountBookService;
+import com.poortorich.category.entity.Category;
+import com.poortorich.income.entity.Income;
+import com.poortorich.income.repository.IncomeRepository;
+import com.poortorich.income.request.IncomeRequest;
+import com.poortorich.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IncomeService extends AccountBookService<IncomeRequest, Income> {
+
+    private final IncomeRepository incomeRepository;
+
+    @Override
+    protected Income buildEntity(IncomeRequest incomeRequest, Category category, User user) {
+        return Income.builder()
+                .incomeDate(incomeRequest.parseDate())
+                .category(category)
+                .title(incomeRequest.trimTitle())
+                .cost(incomeRequest.getCost())
+                .memo(incomeRequest.getMemo())
+                .iterationType(incomeRequest.parseIterationType())
+                .user(user)
+                .build();
+    }
+
+    @Override
+    protected JpaRepository<Income, Long> getRepository() {
+        return incomeRepository;
+    }
+}

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -2,10 +2,9 @@ package com.poortorich.iteration.service;
 
 import com.poortorich.accountbook.response.AccountBookResponse;
 import com.poortorich.expense.entity.Expense;
-import com.poortorich.expense.entity.enums.IterationType;
+import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.expense.request.ExpenseRequest;
-import com.poortorich.expense.request.enums.IterationAction;
-import com.poortorich.expense.response.ExpenseResponse;
+import com.poortorich.accountbook.request.enums.IterationAction;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.iteration.entity.enums.Weekday;

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -1,5 +1,6 @@
 package com.poortorich.iteration.service;
 
+import com.poortorich.accountbook.response.AccountBookResponse;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.entity.enums.IterationType;
 import com.poortorich.expense.request.ExpenseRequest;
@@ -435,7 +436,7 @@ public class IterationService {
             return handleThisAndFuture(originalExpense, expense, user);
         }
 
-        throw new BadRequestException(ExpenseResponse.ITERATION_ACTION_INVALID);
+        throw new BadRequestException(AccountBookResponse.ITERATION_ACTION_INVALID);
     }
 
     private List<IterationExpenses> handleThisOnly(

--- a/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
+++ b/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
@@ -61,10 +61,10 @@ class ExpenseFacadeTest {
     void createExpense_shouldCallServiceMethods() {
         when(userService.findUserByUsername(user.getUsername())).thenReturn(user);
         when(categoryService.findCategoryByName(expenseRequest.getCategoryName(), user)).thenReturn(category);
-        when(expenseService.createExpense(expenseRequest, category, user)).thenReturn(expense);
+        when(expenseService.create(expenseRequest, category, user)).thenReturn(expense);
 
         expenseFacade.createExpense(expenseRequest, user.getUsername());
-        verify(expenseService).createExpense(expenseRequest, category, user);
+        verify(expenseService).create(expenseRequest, category, user);
         verify(categoryService).findCategoryByName(expenseRequest.getCategoryName(), user);
         verify(iterationService).createIterationExpenses(expenseRequest.getCustomIteration(), expense, user);
     }

--- a/src/test/java/com/poortorich/expense/fixture/ExpenseFixture.java
+++ b/src/test/java/com/poortorich/expense/fixture/ExpenseFixture.java
@@ -2,7 +2,7 @@ package com.poortorich.expense.fixture;
 
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
-import com.poortorich.expense.entity.enums.IterationType;
+import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.expense.entity.enums.PaymentMethod;
 import com.poortorich.iteration.request.CustomIteration;
 import java.time.LocalDate;

--- a/src/test/java/com/poortorich/expense/fixture/enums/CategoryNameValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/CategoryNameValidationCase.java
@@ -1,10 +1,10 @@
 package com.poortorich.expense.fixture.enums;
 
-import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
 import com.poortorich.global.testcases.TestCase;
 
 public enum CategoryNameValidationCase implements TestCase<String, String> {
-    NULL(null, ExpenseResponseMessages.CATEGORY_NAME_REQUIRED);
+    NULL(null, AccountBookResponseMessages.CATEGORY_NAME_REQUIRED);
 
     private final String categoryName;
     private final String expectedErrorMessage;

--- a/src/test/java/com/poortorich/expense/fixture/enums/CostValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/CostValidationCase.java
@@ -1,13 +1,13 @@
 package com.poortorich.expense.fixture.enums;
 
-import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
 import com.poortorich.global.testcases.TestCase;
 
 public enum CostValidationCase implements TestCase<Long, String> {
-    NULL(null,ExpenseResponseMessages.COST_REQUIRED),
-    ZERO(0L, ExpenseResponseMessages.COST_NEGATIVE),
-    MINUS(-1L, ExpenseResponseMessages.COST_NEGATIVE),
-    TOO_BIG(100000001L, ExpenseResponseMessages.COST_TOO_BIG);
+    NULL(null, AccountBookResponseMessages.COST_REQUIRED),
+    ZERO(0L, AccountBookResponseMessages.COST_NEGATIVE),
+    MINUS(-1L, AccountBookResponseMessages.COST_NEGATIVE),
+    TOO_BIG(100000001L, AccountBookResponseMessages.COST_TOO_BIG);
 
     private final Long cost;
     private final String expectedErrorMessage;

--- a/src/test/java/com/poortorich/expense/fixture/enums/DateValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/DateValidationCase.java
@@ -1,12 +1,12 @@
 package com.poortorich.expense.fixture.enums;
 
-import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
 import com.poortorich.global.testcases.TestCase;
 
 import java.time.LocalDate;
 
 public enum DateValidationCase implements TestCase<LocalDate, String> {
-    NULL(null, ExpenseResponseMessages.DATE_REQUIRED);
+    NULL(null, AccountBookResponseMessages.DATE_REQUIRED);
 
     private final LocalDate date;
     private final String expectedErrorMessage;

--- a/src/test/java/com/poortorich/expense/fixture/enums/MemoValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/MemoValidationCase.java
@@ -1,11 +1,11 @@
 package com.poortorich.expense.fixture.enums;
 
-import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
 import com.poortorich.global.testcases.TestCase;
 
 public enum MemoValidationCase implements TestCase<String, String> {
     TOO_LONG("아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주아주엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청엄청긴메모를작성해야하는데아직도100자가넘지않았지만이제막넘",
-            ExpenseResponseMessages.MEMO_TOO_LONG);
+            AccountBookResponseMessages.MEMO_TOO_LONG);
 
     private final String memo;
     private final String expectedErrorMessage;

--- a/src/test/java/com/poortorich/expense/fixture/enums/TitleValidationCase.java
+++ b/src/test/java/com/poortorich/expense/fixture/enums/TitleValidationCase.java
@@ -1,10 +1,10 @@
 package com.poortorich.expense.fixture.enums;
 
-import com.poortorich.expense.constants.ExpenseResponseMessages;
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
 import com.poortorich.global.testcases.TestCase;
 
 public enum TitleValidationCase implements TestCase<String, String> {
-    TOO_LONG("아주아주아주아주아주아주긴지출제목", ExpenseResponseMessages.TITLE_TOO_LONG);
+    TOO_LONG("아주아주아주아주아주아주긴지출제목", AccountBookResponseMessages.TITLE_TOO_LONG);
 
     private final String title;
     private final String expectedErrorMessage;

--- a/src/test/java/com/poortorich/expense/request/ExpenseConverterTest.java
+++ b/src/test/java/com/poortorich/expense/request/ExpenseConverterTest.java
@@ -1,5 +1,6 @@
 package com.poortorich.expense.request;
 
+import com.poortorich.accountbook.constants.AccountBookResponseMessages;
 import com.poortorich.expense.constants.ExpenseResponseMessages;
 import com.poortorich.expense.fixture.ExpenseFixture;
 import com.poortorich.expense.util.ExpenseRequestTestBuilder;
@@ -54,7 +55,7 @@ public class ExpenseConverterTest {
 
             assertThatThrownBy(request::trimTitle)
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage(ExpenseResponseMessages.TITLE_TOO_SHORT);
+                    .hasMessage(AccountBookResponseMessages.TITLE_TOO_SHORT);
         }
     }
 
@@ -88,7 +89,7 @@ public class ExpenseConverterTest {
 
             assertThatThrownBy(request::parseIterationType)
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage(ExpenseResponseMessages.ITERATION_TYPE_INVALID);
+                    .hasMessage(AccountBookResponseMessages.ITERATION_TYPE_INVALID);
         }
     }
 }

--- a/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
@@ -51,7 +51,7 @@ public class ExpenseServiceTest {
     @Test
     @DisplayName("유효한 지출 정보가 성공적으로 저장된다.")
     void createValidExpense() {
-        expenseService.createExpense(expenseRequest, category, user);
+        expenseService.create(expenseRequest, category, user);
 
         verify(expenseRepository).save(expenseCaptor.capture());
         Expense savedExpense = expenseCaptor.getValue();

--- a/src/test/java/com/poortorich/expense/util/ExpenseRequestTestBuilder.java
+++ b/src/test/java/com/poortorich/expense/util/ExpenseRequestTestBuilder.java
@@ -58,17 +58,15 @@ public class ExpenseRequestTestBuilder {
     }
 
     public ExpenseRequest build() {
-        return new ExpenseRequest(
-                date,
-                categoryName,
-                title,
-                cost,
-                paymentMethod,
-                memo,
-                iterationType,
-                null,
-                null,
-                customIteration
-        );
+        return ExpenseRequest.builder()
+                .date(date)
+                .categoryName(categoryName)
+                .title(title)
+                .cost(cost)
+                .paymentMethod(paymentMethod)
+                .memo(memo)
+                .iterationType(iterationType)
+                .customIteration(customIteration)
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#107
 
 ## 📝작업 내용
 
- 수입 가계부 추가 API 구현 및 지출 가계부와 공통되는 로직을 분리하기 위해 `accountbook` 패키지를 추가하였습니다.

# 🗂️ `accountbook`
### `AccountBookResponse`

- 공통되는 응답들을 모아둔 Response enum
- AccountBookRequest에서 필요한 Response들을 모아두었습니다.

### `AccountBookMessages`

- 공통되는 응답 메세지들을 모아둔 Message 상수 클래스

### `AccountBookValidationConstraints`

- 공통되는 검증을 위한 제약 조건들을 모아둔 상수 클래스

### `entity.enums.IterationType` `request.enums.IterationAction`

- 공통으로 사용되는 enum 들을 `accountbook` 패키지 하위로 위치를 이동하였습니다.

## abstract class `AccountBookRequest`

- 공통되는 Request 필드와 필요한 메서드를 모아둔 추상 클래스
> `AccountBookRequest`가 직접 인스턴스화 되는 경우를 막기 위해 추상 클래스로 만들었습니다.

- 기존 `ExpenseRequest`에서 공통으로 사용되는 코드들을 넣어줌 
    > `paymentMethod`는 지출에서만 사용되는 필드로 제외

## `AccountBookService`

- 템플릿 메서드 패턴 적용
   > 팩토리 메서드 패턴과 템플릿 메서드 패턴 둘 중 어떤 패턴을 사용할 지 고민했습니다.
   > 반복되는 로직들은 미리 구현해두고, 서로 다른 로직을 가진 메서드는 직접 구현할 수 있도록 추상 메서드를 이용해 미리 선언해둘 수 있는 템플릿 메서드 패턴을 채택하였습니다.
   > 하지만 템플릿 메서드 패턴은 결합도가 높기 때문에 다른 방식을 조금 더 고민해봐야 할 것 같습니다 🤔

- 공통되는 Service 로직들을 구현하고, 필수로 가져야하는 메서드를 추상 메서드로 정의
> 필수로 가져야 하지만 공통되지 않은 로직은 상속을 받은 자식 클래스에서 구현할 수 있도록 하기 위해 추상 메서드로 정의하였습니다. 자식 클래스에서는 `@Override`를 사용하여 메서드를 필수로 구현해주어야 합니다.

### E create() `new`

- E(Entity 객체)를 바탕으로 객체를 build 한 후 적절한 repository를 이용하여 객체를 저장

### abstract E buildEntity() `new`

- 추상 메서드
- 각 가계부 타입에 맞는 Entity를 이용하여 객체를 build 한 후 객체 반환

### abstract JpaRepository<E, Long> getRepository() `new`

- 추상 메서드
- 각 가계부 타입에 맞는 repository를 담는 메서드

# 🗂️ `income`

## `Income`

- 수입 가계부 Entity
- 아직 반복 데이터 부분의 연관관계는 설정하지 않았습니다. 추후 반복 데이터 추가 부분에서 설정할 예정입니다. 

## `IncomeRequset`

- `AccountBookRequest`를 상속받은 request DTO

## `IncomeResponse`

- 수입 가계부에서 필요한 응답들을 모아둔 enum

## `IncomeService`

- `AccountBookService`를 상속받은 수입 가계부 Service
- `buildEntity()`와 `getRepository()`를 재정의

## `IncomeFacade`

- 수입 가계부 facade
   > 반복데이터를 구현하면서 공통 로직들을 분리할 수도 있습니다.

## `IncomeController`

- 수입 가계부 Controller

## `IncomeRepository`

- 수입 가계부 Repository

# 🗂️ `expense`

- `AccountBookService`, `AccountBookRequest` 을 추가하면서 `ExpenseService`, `ExpenseRequest` 코드를 수정하였습니다.
 
 ### 스크린샷 (선택)
 
 ## 💬리뷰 요구사항(선택)
 
- 템플릿 메서드 패턴과 팩토리 메서드 패턴을 사용하는 것에 대한 의견이 궁금합니다! 혹시 공통 로직을 분리하는 것에 다른 좋은 방법이 생각난다면 추천해주세요 😀
- request를 상속받아 사용하다보니 AccountBookRequest와 ExpenseRequest에 `@SuperBuilder`어노테이션을 사용하게 되었습니다. builder를 사용함에 따라 `ExpenseRequestTestBuilder` 코드를 수정하였는데, 이거에 대한 의견이 궁금합니다
