### PR TITLE
[#111] 수입 가계부 반복 데이터 구현

### DIFF
--- a/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
+++ b/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
@@ -10,6 +10,8 @@ import com.poortorich.income.entity.Income;
 import com.poortorich.income.request.IncomeRequest;
 import com.poortorich.user.entity.User;
 
+import java.time.LocalDate;
+
 public class AccountBookBuilder {
 
     public static AccountBook buildEntity(
@@ -44,6 +46,43 @@ public class AccountBookBuilder {
                 .cost(incomeRequest.getCost())
                 .memo(incomeRequest.getMemo())
                 .iterationType(incomeRequest.parseIterationType())
+                .user(user)
+                .build();
+    }
+
+    public static AccountBook buildEntity(
+            User user,
+            LocalDate date,
+            AccountBook originalAccountBook,
+            AccountBookType type
+    ) {
+        return switch (type) {
+            case EXPENSE -> AccountBookBuilder.buildIterationExpense(user, date, (Expense) originalAccountBook);
+            case INCOME -> AccountBookBuilder.buildIterationIncome(user, date, (Income) originalAccountBook);
+        };
+    }
+
+    private static AccountBook buildIterationExpense(User user, LocalDate date, Expense originalExpense) {
+        return Expense.builder()
+                .expenseDate(date)
+                .title(originalExpense.getTitle())
+                .cost(originalExpense.getCost())
+                .paymentMethod(originalExpense.getPaymentMethod())
+                .memo(originalExpense.getMemo())
+                .iterationType(originalExpense.getIterationType())
+                .category(originalExpense.getCategory())
+                .user(user)
+                .build();
+    }
+
+    private static AccountBook buildIterationIncome(User user, LocalDate date, Income originalIncome) {
+        return Income.builder()
+                .incomeDate(date)
+                .title(originalIncome.getTitle())
+                .cost(originalIncome.getCost())
+                .memo(originalIncome.getMemo())
+                .iterationType(originalIncome.getIterationType())
+                .category(originalIncome.getCategory())
                 .user(user)
                 .build();
     }

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -1,6 +1,7 @@
 package com.poortorich.income.facade;
 
 import com.poortorich.accountbook.entity.AccountBook;
+import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.entity.Category;
@@ -8,12 +9,14 @@ import com.poortorich.category.service.CategoryService;
 import com.poortorich.global.response.Response;
 import com.poortorich.income.request.IncomeRequest;
 import com.poortorich.income.response.enums.IncomeResponse;
-import com.poortorich.income.service.IncomeService;
+import com.poortorich.iteration.service.IterationService;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,18 +26,26 @@ public class IncomeFacade {
 
     private final UserService userService;
     private final CategoryService categoryService;
-    private final IncomeService incomeService;
-
-    // Change Service Layer
     private final AccountBookService accountBookService;
+    private final IterationService iterationService;
 
     @Transactional
     public Response createIncome(String username, IncomeRequest incomeRequest) {
         User user = userService.findUserByUsername(username);
         Category category = categoryService.findCategoryByName(incomeRequest.getCategoryName(), user);
-        AccountBook accountBook = accountBookService.create(user, category, incomeRequest, accountBookType);
-//        Income income = incomeService.create(incomeRequest, category, user);
+        AccountBook income = accountBookService.create(user, category, incomeRequest, accountBookType);
+
+        if (income.getIterationType() != IterationType.DEFAULT) {
+            createIteration(user, incomeRequest, income);
+        }
 
         return IncomeResponse.CREATE_INCOME_SUCCESS;
+    }
+
+    public void createIteration(User user, IncomeRequest incomeRequest, AccountBook income) {
+        List<AccountBook> iterationExpenses
+                = iterationService.createIterations(user, incomeRequest.getCustomIteration(), income, accountBookType);
+        List<AccountBook> savedExpenses = accountBookService.createAccountBookAll(iterationExpenses, accountBookType);
+        iterationService.createIterationInfo(user, incomeRequest, income, savedExpenses, accountBookType);
     }
 }

--- a/src/main/java/com/poortorich/income/request/IncomeRequest.java
+++ b/src/main/java/com/poortorich/income/request/IncomeRequest.java
@@ -1,8 +1,10 @@
 package com.poortorich.income.request;
 
 import com.poortorich.accountbook.request.AccountBookRequest;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
+@NoArgsConstructor
 public class IncomeRequest extends AccountBookRequest {
 }

--- a/src/main/java/com/poortorich/iteration/entity/Iteration.java
+++ b/src/main/java/com/poortorich/iteration/entity/Iteration.java
@@ -1,0 +1,18 @@
+package com.poortorich.iteration.entity;
+
+import com.poortorich.accountbook.entity.AccountBook;
+import com.poortorich.iteration.entity.info.IterationInfo;
+import com.poortorich.user.entity.User;
+
+public interface Iteration {
+
+    Long getId();
+
+    User getUser();
+
+    AccountBook getOriginalAccountBook();
+
+    AccountBook getGeneratedAccountBook();
+
+    IterationInfo getIterationInfo();
+}

--- a/src/main/java/com/poortorich/iteration/entity/IterationIncomes.java
+++ b/src/main/java/com/poortorich/iteration/entity/IterationIncomes.java
@@ -1,7 +1,7 @@
 package com.poortorich.iteration.entity;
 
 import com.poortorich.accountbook.entity.AccountBook;
-import com.poortorich.expense.entity.Expense;
+import com.poortorich.income.entity.Income;
 import com.poortorich.iteration.entity.info.IterationInfo;
 import com.poortorich.user.entity.User;
 import jakarta.persistence.Column;
@@ -30,8 +30,8 @@ import java.time.LocalDateTime;
 @DynamicUpdate
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "iterationExpenses")
-public class IterationExpenses implements Iteration {
+@Table(name = "iterationIncomes")
+public class IterationIncomes implements Iteration{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,12 +43,12 @@ public class IterationExpenses implements Iteration {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "originalExpenseId")
-    private Expense originalExpense;
+    @JoinColumn(name = "originalIncomeId")
+    private Income originalIncome;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "generatedExpenseId")
-    private Expense generatedExpense;
+    @JoinColumn(name = "generatedIncomeId")
+    private Income generatedIncome;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "iteration_info_id")
@@ -64,15 +64,15 @@ public class IterationExpenses implements Iteration {
 
     @Override
     public AccountBook getOriginalAccountBook() {
-        return originalExpense;
+        return originalIncome;
     }
 
     @Override
     public AccountBook getGeneratedAccountBook() {
-        return generatedExpense;
+        return generatedIncome;
     }
 
-    public void updateOriginalExpense(Expense originalExpense) {
-        this.originalExpense = originalExpense;
+    public void updateOriginalIncome(Income originalIncome) {
+        this.originalIncome = originalIncome;
     }
 }

--- a/src/main/java/com/poortorich/iteration/repository/IterationIncomesRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationIncomesRepository.java
@@ -1,0 +1,9 @@
+package com.poortorich.iteration.repository;
+
+import com.poortorich.iteration.entity.IterationIncomes;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IterationIncomesRepository extends JpaRepository<IterationIncomes, Long> {
+}

--- a/src/main/java/com/poortorich/iteration/repository/IterationRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationRepository.java
@@ -1,0 +1,23 @@
+package com.poortorich.iteration.repository;
+
+import com.poortorich.accountbook.enums.AccountBookType;
+import com.poortorich.iteration.entity.Iteration;
+import com.poortorich.iteration.entity.IterationExpenses;
+import com.poortorich.iteration.entity.IterationIncomes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IterationRepository {
+
+    private final IterationExpensesRepository iterationExpensesRepository;
+    private final IterationIncomesRepository iterationIncomesRepository;
+
+    public void save(Iteration iteration, AccountBookType type) {
+        switch (type) {
+            case EXPENSE -> iterationExpensesRepository.save((IterationExpenses) iteration);
+            case INCOME -> iterationIncomesRepository.save((IterationIncomes) iteration);
+        }
+    }
+}

--- a/src/main/java/com/poortorich/iteration/util/IterationBuilder.java
+++ b/src/main/java/com/poortorich/iteration/util/IterationBuilder.java
@@ -1,0 +1,57 @@
+package com.poortorich.iteration.util;
+
+import com.poortorich.accountbook.entity.AccountBook;
+import com.poortorich.accountbook.enums.AccountBookType;
+import com.poortorich.expense.entity.Expense;
+import com.poortorich.income.entity.Income;
+import com.poortorich.iteration.entity.Iteration;
+import com.poortorich.iteration.entity.IterationExpenses;
+import com.poortorich.iteration.entity.IterationIncomes;
+import com.poortorich.iteration.entity.info.IterationInfo;
+import com.poortorich.user.entity.User;
+
+public class IterationBuilder {
+
+    public static Iteration buildEntity(
+            User user,
+            AccountBook originalAccountBook,
+            AccountBook generatedAccountBook,
+            IterationInfo iterationInfo,
+            AccountBookType type
+    ) {
+        return switch (type) {
+            case EXPENSE -> IterationBuilder
+                    .buildIterationExpenses(user, (Expense) originalAccountBook, (Expense) generatedAccountBook, iterationInfo);
+            case INCOME -> IterationBuilder
+                    .buildIterationIncomes(user, (Income) originalAccountBook, (Income) generatedAccountBook, iterationInfo);
+        };
+    }
+
+    private static IterationExpenses buildIterationExpenses(
+            User user,
+            Expense originalExpense,
+            Expense generatedExpense,
+            IterationInfo iterationInfo
+    ) {
+        return IterationExpenses.builder()
+                .originalExpense(originalExpense)
+                .generatedExpense(generatedExpense)
+                .iterationInfo(iterationInfo)
+                .user(user)
+                .build();
+    }
+
+    private static IterationIncomes buildIterationIncomes(
+            User user,
+            Income originalIncome,
+            Income generatedIncome,
+            IterationInfo iterationInfo
+    ) {
+        return IterationIncomes.builder()
+                .originalIncome(originalIncome)
+                .generatedIncome(generatedIncome)
+                .iterationInfo(iterationInfo)
+                .user(user)
+                .build();
+    }
+}

--- a/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
+++ b/src/test/java/com/poortorich/expense/facade/ExpenseFacadeTest.java
@@ -3,12 +3,13 @@ package com.poortorich.expense.facade;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.poortorich.accountbook.enums.AccountBookType;
+import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.fixture.ExpenseFixture;
 import com.poortorich.expense.request.ExpenseRequest;
-import com.poortorich.expense.service.ExpenseService;
 import com.poortorich.expense.util.ExpenseRequestTestBuilder;
 import com.poortorich.iteration.service.IterationService;
 import com.poortorich.user.entity.User;
@@ -25,7 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ExpenseFacadeTest {
 
     @Mock
-    private ExpenseService expenseService;
+    private AccountBookService accountBookService;
 
     @Mock
     private CategoryService categoryService;
@@ -38,6 +39,8 @@ class ExpenseFacadeTest {
 
     @InjectMocks
     private ExpenseFacade expenseFacade;
+
+    private static final AccountBookType accountBookType = AccountBookType.EXPENSE;
 
     private ExpenseRequest expenseRequest;
     private Category category;
@@ -61,11 +64,11 @@ class ExpenseFacadeTest {
     void createExpense_shouldCallServiceMethods() {
         when(userService.findUserByUsername(user.getUsername())).thenReturn(user);
         when(categoryService.findCategoryByName(expenseRequest.getCategoryName(), user)).thenReturn(category);
-        when(expenseService.create(expenseRequest, category, user)).thenReturn(expense);
+        when(accountBookService.create(user, category, expenseRequest, accountBookType)).thenReturn(expense);
 
         expenseFacade.createExpense(expenseRequest, user.getUsername());
-        verify(expenseService).create(expenseRequest, category, user);
+        verify(accountBookService).create(user, category, expenseRequest, accountBookType);
         verify(categoryService).findCategoryByName(expenseRequest.getCategoryName(), user);
-        verify(iterationService).createIterationExpenses(expenseRequest.getCustomIteration(), expense, user);
+        verify(iterationService).createIterations(user, expenseRequest.getCustomIteration(), expense, accountBookType);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#111
 
 ## 📝작업 내용
 
- 수입 가계부 반복 데이터 부분 구현
- 반복데이터 로직 `IterationService`에서 인터페이스를 활용하여 지출, 수입 두 가계부 모두에서 사용할 수 있도록 수정
- `IterationRepository` 병합
- `ExpenseService` Expense -> AccountBook 으로 교체

## 🗂️ `accountbook`

###  🛠️`AccountBookBuilder`

- `IterationService`에서 필요한 `generatedAccountBook`을 build하기 위한 메서드 추가 구현

## 🗂️ `income`

### `IncomeFacade`

- 수입 가계부 반복데이터 추가를 위한 로직 추가

## 🗂️ `iteration`

### `Iteration`

- 반복데이터 Entity인 `IterationExpenses`와 `IterationIncomes`의 가공 작업을 동시에 수행하기 위해 적용할 인터페이스

### 🛠️ `IterationExpenses`

- `Iteration`을 구현하도록 수정
- 재정의가 필요한 메서드 재정의

### `IterationIncomes`

- 반복 데이터인 수입 가계부들의 연결 정보를 저장하는 Entity
- `Iteration`을 구현

### 🛠️ `IterationService`

- `AccountBook`를 사용하여 공통된 로직을 처리하도록 수정

### `IterationRepository`

- `Expense`와 `Income` 타입에 맞는 Repository 를 불러오는 레이어

### `IterationIncomesRepository`

- `IterationIncomes` Entity의 Repository

### `IterationBuilder`

- `IteraitonService`에서 필요한 `Iteration`을 build하기 위한 클래스
   타입에 따라 적절한 Entity를 build하도록 구현

## 🗂️ `expense`

### 🛠️ `ExpenseFacade`

- `IterationService` 변경에 따른 코드 수정

 ### 스크린샷

![image](https://github.com/user-attachments/assets/e7fe15d0-0e8d-4a8f-837d-ff1b468b17ce)
 
 ## 💬리뷰 요구사항
 
- 코드 컨벤션
