### PR TITLE
[#117] 수입 가계부 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/accountbook/entity/AccountBook.java
+++ b/src/main/java/com/poortorich/accountbook/entity/AccountBook.java
@@ -2,6 +2,7 @@ package com.poortorich.accountbook.entity;
 
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.category.entity.Category;
+import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.user.entity.User;
 import java.time.LocalDate;
 
@@ -22,4 +23,6 @@ public interface AccountBook {
     Category getCategory();
     
     User getUser();
+
+    Iteration getGeneratedIteration();
 }

--- a/src/main/java/com/poortorich/accountbook/response/InfoResponse.java
+++ b/src/main/java/com/poortorich/accountbook/response/InfoResponse.java
@@ -1,0 +1,4 @@
+package com.poortorich.accountbook.response;
+
+public interface InfoResponse {
+}

--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -4,10 +4,13 @@ import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.repository.AccountBookRepository;
 import com.poortorich.accountbook.request.AccountBookRequest;
+import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.util.AccountBookBuilder;
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.iteration.entity.Iteration;
+import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
 import java.time.LocalDate;
 import java.util.List;
@@ -35,6 +38,16 @@ public class AccountBookService {
 
     public List<AccountBook> createAccountBookAll(List<AccountBook> accountBooks, AccountBookType type) {
         return accountBookRepository.saveAll(accountBooks, type);
+    }
+
+    public Iteration getIteration(User user, Long id, AccountBookType type) {
+        AccountBook accountBook = getAccountBookOrThrow(id, user, type);
+        return accountBook.getGeneratedIteration();
+    }
+
+    public InfoResponse getInfoResponse(User user, Long id, CustomIterationInfoResponse customIteration, AccountBookType type) {
+        AccountBook accountBook = getAccountBookOrThrow(id, user, type);
+        return AccountBookBuilder.buildInfoResponse(accountBook, customIteration, type);
     }
 
     public void deleteAccountBook(Long accountBookId, User user, AccountBookType type) {

--- a/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
+++ b/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
@@ -3,11 +3,15 @@ package com.poortorich.accountbook.util;
 import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.AccountBookRequest;
+import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.request.ExpenseRequest;
+import com.poortorich.expense.response.ExpenseInfoResponse;
 import com.poortorich.income.entity.Income;
 import com.poortorich.income.request.IncomeRequest;
+import com.poortorich.income.response.IncomeInfoResponse;
+import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
 
 import java.time.LocalDate;
@@ -84,6 +88,38 @@ public class AccountBookBuilder {
                 .iterationType(originalIncome.getIterationType())
                 .category(originalIncome.getCategory())
                 .user(user)
+                .build();
+    }
+
+    public static InfoResponse buildInfoResponse(AccountBook accountBook, CustomIterationInfoResponse customIteration, AccountBookType type) {
+        return switch (type) {
+            case EXPENSE -> AccountBookBuilder.buildExpenseInfoResponse((Expense) accountBook, customIteration);
+            case INCOME -> AccountBookBuilder.buildIncomeInfoResponse((Income) accountBook, customIteration);
+        };
+    }
+
+    private static InfoResponse buildExpenseInfoResponse(Expense expense, CustomIterationInfoResponse customIteration) {
+        return ExpenseInfoResponse.builder()
+                .date(expense.getAccountBookDate())
+                .categoryName(expense.getCategory().getName())
+                .title(expense.getTitle())
+                .cost(expense.getCost())
+                .paymentMethod(expense.getPaymentMethod().toString())
+                .memo(expense.getMemo())
+                .iterationType(expense.getIterationType().toString())
+                .customIteration(customIteration)
+                .build();
+    }
+
+    private static InfoResponse buildIncomeInfoResponse(Income income, CustomIterationInfoResponse customIteration) {
+        return IncomeInfoResponse.builder()
+                .date(income.getAccountBookDate())
+                .categoryName(income.getCategory().getName())
+                .title(income.getTitle())
+                .cost(income.getCost())
+                .memo(income.getMemo())
+                .iterationType(income.getIterationType().toString())
+                .customIteration(customIteration)
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/expense/entity/Expense.java
+++ b/src/main/java/com/poortorich/expense/entity/Expense.java
@@ -4,6 +4,7 @@ import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.enums.PaymentMethod;
+import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.user.entity.User;
 import jakarta.persistence.Column;
@@ -88,6 +89,11 @@ public class Expense implements AccountBook {
     @Override
     public LocalDate getAccountBookDate() {
         return expenseDate;
+    }
+
+    @Override
+    public Iteration getGeneratedIteration() {
+        return generatedIterationExpenses;
     }
 
     public void updateExpense(String title, Long cost, PaymentMethod paymentMethod, String memo,

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -4,6 +4,7 @@ import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.enums.IterationAction;
+import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.service.CategoryService;
@@ -14,6 +15,7 @@ import com.poortorich.expense.response.ExpenseInfoResponse;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.expense.service.ExpenseService;
 import com.poortorich.global.response.Response;
+import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.iteration.service.IterationService;
@@ -58,16 +60,16 @@ public class ExpenseFacade {
     }
 
     @Transactional
-    public ExpenseInfoResponse getExpense(Long id, String username) {
+    public InfoResponse getExpense(Long id, String username) {
         User user = userService.findUserByUsername(username);
-        IterationExpenses iterationExpenses = expenseService.getIterationExpenses(id, user);
+        Iteration iterationExpenses = accountBookService.getIteration(user, id, accountBookType);
 
         CustomIterationInfoResponse customIteration = null;
         if (iterationExpenses != null) {
             customIteration = iterationService.getCustomIteration(iterationExpenses);
         }
 
-        return expenseService.getExpenseInfoResponse(id, user, customIteration);
+        return accountBookService.getInfoResponse(user, id, customIteration, accountBookType);
     }
 
     @Transactional

--- a/src/main/java/com/poortorich/expense/service/ExpenseService.java
+++ b/src/main/java/com/poortorich/expense/service/ExpenseService.java
@@ -4,11 +4,8 @@ import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.repository.ExpenseRepository;
 import com.poortorich.expense.request.ExpenseRequest;
-import com.poortorich.expense.response.ExpenseInfoResponse;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.exceptions.NotFoundException;
-import com.poortorich.iteration.entity.IterationExpenses;
-import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
 import java.beans.Transient;
 import java.time.LocalDate;
@@ -45,25 +42,6 @@ public class ExpenseService {
                 .memo(expenseRequest.getMemo())
                 .iterationType(expenseRequest.parseIterationType())
                 .user(user)
-                .build();
-    }
-
-    public IterationExpenses getIterationExpenses(Long id, User user) {
-        Expense expense = getExpenseOrThrow(id, user);
-        return expense.getGeneratedIterationExpenses();
-    }
-
-    public ExpenseInfoResponse getExpenseInfoResponse(Long id, User user, CustomIterationInfoResponse customIteration) {
-        Expense expense = getExpenseOrThrow(id, user);
-        return ExpenseInfoResponse.builder()
-                .date(expense.getExpenseDate())
-                .categoryName(expense.getCategory().getName())
-                .title(expense.getTitle())
-                .cost(expense.getCost())
-                .paymentMethod(expense.getPaymentMethod().toString())
-                .memo(expense.getMemo())
-                .iterationType(expense.getIterationType().toString())
-                .customIteration(customIteration)
                 .build();
     }
 

--- a/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
+++ b/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
@@ -3,6 +3,7 @@ package com.poortorich.income.constants;
 public class IncomeResponseMessages {
 
     public static final String CREATE_INCOME_SUCCESS = "수입 가계부를 성공적으로 등록하였습니다.";
+    public static final String GET_INCOME_SUCCESS = "수입 가계부를 성공적으로 조회하였습니다.";
 
     private IncomeResponseMessages() {
     }

--- a/src/main/java/com/poortorich/income/controller/IncomeController.java
+++ b/src/main/java/com/poortorich/income/controller/IncomeController.java
@@ -1,13 +1,17 @@
 package com.poortorich.income.controller;
 
 import com.poortorich.global.response.BaseResponse;
+import com.poortorich.global.response.DataResponse;
 import com.poortorich.income.facade.IncomeFacade;
 import com.poortorich.income.request.IncomeRequest;
+import com.poortorich.income.response.enums.IncomeResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +29,16 @@ public class IncomeController {
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody @Valid IncomeRequest incomeRequest) {
         return BaseResponse.toResponseEntity(incomeFacade.createIncome(userDetails.getUsername(), incomeRequest));
+    }
+
+    @GetMapping("/{incomeId}")
+    public ResponseEntity<BaseResponse> getIncome(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long incomeId
+    ) {
+        return DataResponse.toResponseEntity(
+                IncomeResponse.GET_INCOME_SUCCESS,
+                incomeFacade.getIncome(userDetails.getUsername(), incomeId)
+        );
     }
 }

--- a/src/main/java/com/poortorich/income/entity/Income.java
+++ b/src/main/java/com/poortorich/income/entity/Income.java
@@ -3,6 +3,8 @@ package com.poortorich.income.entity;
 import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.category.entity.Category;
+import com.poortorich.iteration.entity.Iteration;
+import com.poortorich.iteration.entity.IterationIncomes;
 import com.poortorich.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,6 +16,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -66,7 +69,8 @@ public class Income implements AccountBook {
     @JoinColumn(name = "userId")
     private User user;
 
-    // 반복 데이터 테이블과의 연관관계
+    @OneToOne(mappedBy = "generatedIncome")
+    private IterationIncomes generatedIterationIncomes;
 
     @CreationTimestamp
     @Column(name = "createdDate")
@@ -79,5 +83,10 @@ public class Income implements AccountBook {
     @Override
     public LocalDate getAccountBookDate() {
         return incomeDate;
+    }
+
+    @Override
+    public Iteration getGeneratedIteration() {
+        return generatedIterationIncomes;
     }
 }

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -3,12 +3,15 @@ package com.poortorich.income.facade;
 import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.accountbook.enums.AccountBookType;
+import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.global.response.Response;
 import com.poortorich.income.request.IncomeRequest;
 import com.poortorich.income.response.enums.IncomeResponse;
+import com.poortorich.iteration.entity.Iteration;
+import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.iteration.service.IterationService;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
@@ -36,16 +39,29 @@ public class IncomeFacade {
         AccountBook income = accountBookService.create(user, category, incomeRequest, accountBookType);
 
         if (income.getIterationType() != IterationType.DEFAULT) {
-            createIteration(user, incomeRequest, income);
+            createIterationIncome(user, incomeRequest, income);
         }
 
         return IncomeResponse.CREATE_INCOME_SUCCESS;
     }
 
-    public void createIteration(User user, IncomeRequest incomeRequest, AccountBook income) {
+    public void createIterationIncome(User user, IncomeRequest incomeRequest, AccountBook income) {
         List<AccountBook> iterationIncomes
                 = iterationService.createIterations(user, incomeRequest.getCustomIteration(), income, accountBookType);
         List<AccountBook> savedIncomes = accountBookService.createAccountBookAll(iterationIncomes, accountBookType);
         iterationService.createIterationInfo(user, incomeRequest, income, savedIncomes, accountBookType);
+    }
+
+    @Transactional
+    public InfoResponse getIncome(String username, Long id) {
+        User user = userService.findUserByUsername(username);
+        Iteration iterationIncomes = accountBookService.getIteration(user, id, accountBookType);
+
+        CustomIterationInfoResponse customIteration = null;
+        if (iterationIncomes != null) {
+            customIteration = iterationService.getCustomIteration(iterationIncomes);
+        }
+
+        return accountBookService.getInfoResponse(user, id, customIteration, accountBookType);
     }
 }

--- a/src/main/java/com/poortorich/income/response/IncomeInfoResponse.java
+++ b/src/main/java/com/poortorich/income/response/IncomeInfoResponse.java
@@ -1,4 +1,4 @@
-package com.poortorich.expense.response;
+package com.poortorich.income.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.poortorich.accountbook.response.InfoResponse;
@@ -15,13 +15,12 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ExpenseInfoResponse implements InfoResponse {
+public class IncomeInfoResponse implements InfoResponse {
 
     private LocalDate date;
     private String categoryName;
     private String title;
     private Long cost;
-    private String paymentMethod;
     private String memo;
     private String iterationType;
     private CustomIterationInfoResponse customIteration;

--- a/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
+++ b/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum IncomeResponse implements Response {
 
-    CREATE_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.CREATE_INCOME_SUCCESS, null);
+    CREATE_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.CREATE_INCOME_SUCCESS, null),
+    GET_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.GET_INCOME_SUCCESS, null);
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -311,8 +311,8 @@ public class IterationService {
                 .build();
     }
 
-    public CustomIterationInfoResponse getCustomIteration(IterationExpenses iterationExpenses) {
-        IterationInfo iterationInfo = iterationExpenses.getIterationInfo();
+    public CustomIterationInfoResponse getCustomIteration(Iteration iteration) {
+        IterationInfo iterationInfo = iteration.getIterationInfo();
         return CustomIterationInfoResponse.builder()
                 .iterationRule(buildIterationRuleByRuleType(iterationInfo))
                 .cycle(iterationInfo.getCycle())


### PR DESCRIPTION
## #️⃣연관된 이슈

#117 
 
 ## 📝작업 내용
 
- 수입 가계부 조회 API 구현
- `AccountBookService`에서 지출, 수입 두 가계부 모두 조회할 수 있도록 수정

## 🗂️ `accountbook`

### 🛠️ `AccountBook`

- `generatedAccountBook`을 조회하기 위한 get 메서드를 추가

### `InfoResponse`

- `ExpenseInfoResponse`와 `IncomeInfoResponse`의 작업을 수행하기 위한 공통 로직을 위한 인터페이스

### 🛠️ `AccountBookService`

- 가계부 조회를 위한 메서드 `getIteration()` `getInfoResponse()` 추가

### 🛠️ `AccountBookBuilder`

- `InfoResponse`를 AccountBookType에 따라 build하기 위한 메서드 추가 구현

## 🗂️ `income`

### `IncomeResponseMessages` `IncomeResponse`

- 수입 가계부 조회 성공 Response 추가

### `IncomeController` `IncomeFacade`

- 수입 가계부 조회 관련 메서드 구현

### 🛠️ `Income`

- `IterationIncome`과의 연관관계 설정
- `getGeneratedIteration()` 재정의

### `IncomeInfoResponse`

- 수입 가계부 정보를 담는 Response

## 🗂️ `expense`

### 🛠️ `Expense`

- `getGeneratedIteration()` 재정의

### 🛠️ `ExpenseFacade`

- `ExpenseService` 대신 `AccountBookService`를 호출하도록 수정

### 🛠️ `ExpenseInfoResponse`

- `InfoResponse` 인터페이스 구현

### 🛠️ `ExpenseService`

- `AccountBookService`로 로직을 합침에 따른 필요 없는 메서드 삭제

## 🗂️ `iteration`

### 🛠️ `IteraitonService`

- `Iteration`으로 변경
 
 ### 스크린샷

![image](https://github.com/user-attachments/assets/b5254324-1aba-464b-a3de-7bcbb4301f05)
 
 ## 💬리뷰 요구사항
 
- 코드 컨벤션 및 네이밍
