### PR TITLE
[#115] 지출 막대 그래프 조회 API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-## 배포 환경
-FROM openjdk:21-jdk-slim
-
-ARG JAR_FILE=./build/libs/*.jar
-
-COPY ${JAR_FILE} /app.jar
-
-ENTRYPOINT ["java", "-jar", "/app.jar" ]
-
-### 개발 환경
+### 배포 환경
 #FROM openjdk:21-jdk-slim
 #
-#WORKDIR /app
+#ARG JAR_FILE=./build/libs/*.jar
 #
-#COPY . .
+#COPY ${JAR_FILE} /app.jar
 #
-#RUN chmod +x ./gradlew
-#
-#ENTRYPOINT ["./gradlew", "bootRun"]
+#ENTRYPOINT ["java", "-jar", "/app.jar" ]
+
+## 개발 환경
+FROM openjdk:21-jdk-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN chmod +x ./gradlew
+
+ENTRYPOINT ["./gradlew", "bootRun"]

--- a/src/main/java/com/poortorich/chart/constants/ChartResponseMessage.java
+++ b/src/main/java/com/poortorich/chart/constants/ChartResponseMessage.java
@@ -5,6 +5,7 @@ public class ChartResponseMessage {
     public static final String GET_TOTAL_EXPENSE_AND_SAVINGS_SUCCESS = "지출 및 저축 금액 조회 성공";
     public static final String GET_CATEGORY_SECTION_SUCCESS = "카테고리 구간 내역 조회 성공";
     public static final String GET_CATEGORY_CHART_SUCCESS = "카테고리별 비율 및 총 금액 조회 성공";
+    public static final String GET_EXPENSE_BAR_SUCCESS = "지출 막대그래프 조회 성공";
 
     private ChartResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chart/controller/ChartController.java
+++ b/src/main/java/com/poortorich/chart/controller/ChartController.java
@@ -57,4 +57,15 @@ public class ChartController {
                 chartFacade.getCategoryChart(userDetails.getUsername(), date, AccountBookType.EXPENSE)
         );
     }
+
+    @GetMapping("/expense/bar")
+    public ResponseEntity<BaseResponse> getExpenseBar(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("date") @Nullable String date
+    ) {
+        return DataResponse.toResponseEntity(
+                ChartResponse.GET_EXPENSE_BAR_SUCCESS,
+                chartFacade.getAccountBookBar(userDetails.getUsername(), date, AccountBookType.EXPENSE)
+        );
+    }
 }

--- a/src/main/java/com/poortorich/chart/facade/ChartFacade.java
+++ b/src/main/java/com/poortorich/chart/facade/ChartFacade.java
@@ -6,6 +6,7 @@ import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.domain.model.enums.DefaultExpenseCategory;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.service.CategoryService;
+import com.poortorich.chart.response.AccountBookBarResponse;
 import com.poortorich.chart.response.CategoryChart;
 import com.poortorich.chart.response.CategoryChartResponse;
 import com.poortorich.chart.response.CategoryLog;
@@ -108,5 +109,20 @@ public class ChartFacade {
                         .collect(Collectors.toMap(CategoryChart::getName, CategoryChart::getColor)))
                 .categoryCharts(categoryCharts)
                 .build();
+    }
+
+    public AccountBookBarResponse getAccountBookBar(String username, String date, AccountBookType type) {
+        User user = userService.findUserByUsername(username);
+        List<DateInfo> dateInfos = DateInfoProvider.getPreviousDateInfos(date);
+
+        List<List<AccountBook>> accountBooksGroupByDateInfo = dateInfos.stream()
+                .map(dateInfo -> accountBookService.getAccountBookBetweenDates(
+                        user,
+                        dateInfo.getStartDate(),
+                        dateInfo.getEndDate(),
+                        type))
+                .toList();
+
+        return chartService.getAccountBookBar(dateInfos, accountBooksGroupByDateInfo);
     }
 }

--- a/src/main/java/com/poortorich/chart/response/AccountBookBarResponse.java
+++ b/src/main/java/com/poortorich/chart/response/AccountBookBarResponse.java
@@ -1,0 +1,14 @@
+package com.poortorich.chart.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AccountBookBarResponse {
+
+    private String differenceAmount;
+    private String averageAmount;
+    private List<PeriodTotal> totalAmounts;
+}

--- a/src/main/java/com/poortorich/chart/response/PeriodTotal.java
+++ b/src/main/java/com/poortorich/chart/response/PeriodTotal.java
@@ -1,0 +1,12 @@
+package com.poortorich.chart.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PeriodTotal {
+
+    private String period;
+    private Long totalAmount;
+}

--- a/src/main/java/com/poortorich/chart/response/enums/ChartResponse.java
+++ b/src/main/java/com/poortorich/chart/response/enums/ChartResponse.java
@@ -22,7 +22,11 @@ public enum ChartResponse implements Response {
             HttpStatus.OK,
             ChartResponseMessage.GET_CATEGORY_CHART_SUCCESS,
             null
-    );
+    ),
+    GET_EXPENSE_BAR_SUCCESS(
+            HttpStatus.OK,
+            ChartResponseMessage.GET_EXPENSE_BAR_SUCCESS,
+            null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chart/service/ChartService.java
+++ b/src/main/java/com/poortorich/chart/service/ChartService.java
@@ -3,12 +3,22 @@ package com.poortorich.chart.service;
 import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.util.AccountBookCostExtractor;
 import com.poortorich.category.entity.Category;
+import com.poortorich.chart.response.AccountBookBarResponse;
 import com.poortorich.chart.response.CategoryChart;
 import com.poortorich.chart.response.CategoryLog;
+import com.poortorich.chart.response.PeriodTotal;
 import com.poortorich.chart.response.TotalAmountAndSavingResponse;
 import com.poortorich.chart.response.TransactionRecord;
 import com.poortorich.chart.util.AccountBookUtil;
+import com.poortorich.chart.util.AmountFormatter;
+import com.poortorich.global.date.domain.DateInfo;
+import com.poortorich.global.date.domain.MonthInformation;
+import com.poortorich.global.date.domain.YearInformation;
+import com.poortorich.global.date.response.enums.DateResponse;
+import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.statistics.util.StatCalculator;
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -54,5 +64,37 @@ public class ChartService {
 
     public List<CategoryChart> getCategoryChart(List<AccountBook> accountBooks) {
         return AccountBookUtil.mapToCategoryCharts(AccountBookUtil.groupAccountBooksByCategory(accountBooks));
+    }
+
+    public AccountBookBarResponse getAccountBookBar(
+            List<DateInfo> dateInfos,
+            List<List<AccountBook>> accountBooksGroupByDateInfo
+    ) {
+        List<Long> totalAmounts = accountBooksGroupByDateInfo.stream()
+                .map(AccountBookCostExtractor::extract)
+                .map(StatCalculator::calculateSum)
+                .map(BigDecimal::longValue)
+                .toList();
+
+        List<PeriodTotal> periodTotals = new ArrayList<>();
+        for (int i = 0; i < accountBooksGroupByDateInfo.size(); i++) {
+            DateInfo dateInfo = dateInfos.get(i);
+
+            periodTotals.add(PeriodTotal.builder()
+                    .period(switch (dateInfo) {
+                                case YearInformation yearInfo -> yearInfo.getYear().toString();
+                                case MonthInformation monthInfo -> monthInfo.getYearMonth().toString();
+                                default -> throw new BadRequestException(DateResponse.UNSUPPORTED_DATE_FORMAT);
+                            }
+                    )
+                    .totalAmount(totalAmounts.get(i))
+                    .build());
+        }
+        return AccountBookBarResponse.builder()
+                .differenceAmount(AmountFormatter.compareAmount(totalAmounts.getLast(),
+                        totalAmounts.get(totalAmounts.size() - 2)))
+                .averageAmount(AmountFormatter.convertAmount(StatCalculator.calculateAverage(totalAmounts).longValue()))
+                .totalAmounts(periodTotals)
+                .build();
     }
 }

--- a/src/main/java/com/poortorich/chart/util/AmountFormatter.java
+++ b/src/main/java/com/poortorich/chart/util/AmountFormatter.java
@@ -1,0 +1,30 @@
+package com.poortorich.chart.util;
+
+import java.text.DecimalFormat;
+
+public class AmountFormatter {
+
+    private static final DecimalFormat COMMA_FORMAT = new DecimalFormat("###,###");
+    private static final long TEN_THOUSAND = 10_000L;
+    private static final String WON_SUFFIX = "원";
+    private static final String TEN_THOUSAND_SUFFIX = "만원";
+
+    public static String convertAmount(long amount) {
+        if (amount >= TEN_THOUSAND) {
+            return COMMA_FORMAT.format(amount / TEN_THOUSAND) + TEN_THOUSAND_SUFFIX;
+        }
+
+        return COMMA_FORMAT.format(amount) + WON_SUFFIX;
+    }
+
+    public static String compareAmount(long compareAmount, long averageAmount) {
+        long differenceAmount = Math.abs(averageAmount - compareAmount);
+
+        if (compareAmount > averageAmount) {
+            return convertAmount(differenceAmount) + " 더";
+        } else if (compareAmount < averageAmount) {
+            return convertAmount(differenceAmount) + " 덜";
+        }
+        return convertAmount(differenceAmount);
+    }
+}

--- a/src/main/java/com/poortorich/global/date/util/DateInfoProvider.java
+++ b/src/main/java/com/poortorich/global/date/util/DateInfoProvider.java
@@ -15,6 +15,7 @@ import java.time.Year;
 import java.time.YearMonth;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -22,11 +23,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class DateInfoProvider {
 
     private static final Map<Predicate<String>, Function<String, DateInfo>> DATE_PARSER = new LinkedHashMap<>();
+    private static final int PREVIOUS_PERIODS = 5;
 
     static {
         DATE_PARSER.put(
@@ -51,6 +55,39 @@ public class DateInfoProvider {
                 .findFirst()
                 .map(entry -> entry.getValue().apply(date))
                 .orElseThrow(() -> new BadRequestException(DateResponse.UNSUPPORTED_DATE_FORMAT));
+    }
+
+    public static List<DateInfo> getPreviousDateInfos(String date) {
+        return getPreviousDateInfos(date, PREVIOUS_PERIODS);
+    }
+
+    public static List<DateInfo> getPreviousDateInfos(String date, int offset) {
+        if (date == null) {
+            date = YearMonth.now().toString();
+        }
+
+        List<DateInfo> dateInfos;
+        if (date.matches(DatePattern.YEAR_REGEX)) {
+            Year currentYear = Year.parse(date);
+            dateInfos = IntStream.rangeClosed(1, offset)
+                    .mapToObj(currentYear::minusYears)
+                    .map(DateInfoProvider::getYearInformation)
+                    .map(yearInfo -> (DateInfo) yearInfo)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        } else if (date.matches(DatePattern.YEAR_MONTH_REGEX)) {
+            YearMonth yearMonth = YearMonth.parse(date);
+            dateInfos = IntStream.rangeClosed(1, offset)
+                    .mapToObj(yearMonth::minusMonths)
+                    .map(DateInfoProvider::getMonthInformation)
+                    .map(monthInfo -> (DateInfo) monthInfo)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        } else {
+            throw new BadRequestException(DateResponse.UNSUPPORTED_DATE_FORMAT);
+        }
+
+        Collections.reverse(dateInfos);
+        dateInfos.add(getDateInfo(date));
+        return dateInfos;
     }
 
     private static YearInformation getYearInformation(Year year) {


### PR DESCRIPTION
## #️⃣115
 ## 📝작업 내용
* 지출 막대그래프 조회 API
* 금액 포맷터
*  DateInfoProvider 기능 추가

## 🔥DateInfoProvider
### 🔥getPreviousDateInfo()
매개변수로 받은 `date`와 `offset`을 기준으로 이전 날짜의 DateInfo를 함께 제공합니다. 

## 🔥AmountFormatter
숫자를 원화로 포맷팅해주는 객체
### 🔥convertAmount
`long` 데이터를 기준으로 만원 이상인 경우 `만원` 단위로 포맷팅합니다. 만원 미만인 경우 `원` 단위로 포맷팅합니다.
### 🔥compareAmount
두 데이터를 비교해 "더", "덜"을 붙여서 데이터를 제공합니다.

* ex) 50,000, 10,000
  * **`4 만원 더`

## 지출 막대 그래프 
`RequestParam`으로 받은 date를 기준으로 이전 5달의 지출 총합을 가져와 평균과 함께 필요한 데이터를 가공하여 제공합니다.

### 🔥**AccountBookBarResponse**, **PeriodTotal**
지출 막대 그래프 DTO

 ### 스크린샷 (선택)
![지출 막대 그래프](https://github.com/user-attachments/assets/472bb4fd-2514-4073-8fdd-d0032188bbf7)

