### PR TITLE
[#119] 수입 가계부 편집 API 구현

### DIFF
--- a/src/main/java/com/poortorich/accountbook/entity/AccountBook.java
+++ b/src/main/java/com/poortorich/accountbook/entity/AccountBook.java
@@ -25,4 +25,8 @@ public interface AccountBook {
     User getUser();
 
     Iteration getGeneratedIteration();
+
+    void updateAccountBook(String title, Long cost, String memo, IterationType iterationType, Category category);
+
+    void updateAccountBookDate(LocalDate accountBookDate);
 }

--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -59,6 +59,7 @@ public class AccountBookService {
         return accountBook;
     }
 
+    @Transient
     public void modifyAccountBook(AccountBook accountBook, AccountBookRequest request, Category category) {
         accountBook.updateAccountBook(
                 request.trimTitle(),

--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -12,6 +12,8 @@ import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
+
+import java.beans.Transient;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +50,23 @@ public class AccountBookService {
     public InfoResponse getInfoResponse(User user, Long id, CustomIterationInfoResponse customIteration, AccountBookType type) {
         AccountBook accountBook = getAccountBookOrThrow(id, user, type);
         return AccountBookBuilder.buildInfoResponse(accountBook, customIteration, type);
+    }
+
+    @Transient
+    public AccountBook modifyAccountBook(User user, Category category, Long id, AccountBookRequest request, AccountBookType type) {
+        AccountBook accountBook = getAccountBookOrThrow(id, user, type);
+        modifyAccountBook(accountBook, request, category);
+        return accountBook;
+    }
+
+    public void modifyAccountBook(AccountBook accountBook, AccountBookRequest request, Category category) {
+        accountBook.updateAccountBook(
+                request.trimTitle(),
+                request.getCost(),
+                request.getMemo(),
+                request.parseIterationType(),
+                category
+        );
     }
 
     public void deleteAccountBook(Long accountBookId, User user, AccountBookType type) {

--- a/src/main/java/com/poortorich/expense/entity/Expense.java
+++ b/src/main/java/com/poortorich/expense/entity/Expense.java
@@ -96,17 +96,21 @@ public class Expense implements AccountBook {
         return generatedIterationExpenses;
     }
 
-    public void updateExpense(String title, Long cost, PaymentMethod paymentMethod, String memo,
-                              IterationType iterationType, Category category) {
+    @Override
+    public void updateAccountBook(String title, Long cost, String memo, IterationType iterationType, Category category) {
         this.title = title;
         this.cost = cost;
-        this.paymentMethod = paymentMethod;
         this.memo = memo;
         this.iterationType = iterationType;
         this.category = category;
     }
 
-    public void updateExpenseDate(LocalDate expenseDate) {
-        this.expenseDate = expenseDate;
+    @Override
+    public void updateAccountBookDate(LocalDate accountBookDate) {
+        this.expenseDate = accountBookDate;
+    }
+
+    public void updatePaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
     }
 }

--- a/src/main/java/com/poortorich/expense/service/ExpenseService.java
+++ b/src/main/java/com/poortorich/expense/service/ExpenseService.java
@@ -2,6 +2,7 @@ package com.poortorich.expense.service;
 
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
+import com.poortorich.expense.entity.enums.PaymentMethod;
 import com.poortorich.expense.repository.ExpenseRepository;
 import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.expense.response.ExpenseResponse;
@@ -46,25 +47,13 @@ public class ExpenseService {
     }
 
     @Transient
-    public Expense modifyExpense(Long expenseId, ExpenseRequest expenseRequest, Category category, User user) {
-        Expense expense = getExpenseOrThrow(expenseId, user);
-        modifyExpense(expense, expenseRequest, category);
-        return expense;
-    }
-
-    public void modifyExpense(Expense expense, ExpenseRequest expenseRequest, Category category) {
-        expense.updateExpense(
-                expenseRequest.trimTitle(),
-                expenseRequest.getCost(),
-                expenseRequest.parsePaymentMethod(),
-                expenseRequest.getMemo(),
-                expenseRequest.parseIterationType(),
-                category);
+    public void modifyPaymentMethod(Expense expense, PaymentMethod paymentMethod) {
+        expense.updatePaymentMethod(paymentMethod);
     }
 
     @Transient
     public void modifyExpenseDate(Expense expense, LocalDate expenseDate) {
-        expense.updateExpenseDate(expenseDate);
+        expense.updateAccountBookDate(expenseDate);
     }
 
     public void deleteExpense(Long expenseId, User user) {

--- a/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
+++ b/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
@@ -4,6 +4,7 @@ public class IncomeResponseMessages {
 
     public static final String CREATE_INCOME_SUCCESS = "수입 가계부를 성공적으로 등록하였습니다.";
     public static final String GET_INCOME_SUCCESS = "수입 가계부를 성공적으로 조회하였습니다.";
+    public static final String MODIFY_INCOME_SUCCESS = "수입 가계부를 성공적으로 편집하였습니다.";
 
     private IncomeResponseMessages() {
     }

--- a/src/main/java/com/poortorich/income/controller/IncomeController.java
+++ b/src/main/java/com/poortorich/income/controller/IncomeController.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,5 +41,14 @@ public class IncomeController {
                 IncomeResponse.GET_INCOME_SUCCESS,
                 incomeFacade.getIncome(userDetails.getUsername(), incomeId)
         );
+    }
+
+    @PutMapping("/{incomeId}")
+    public ResponseEntity<BaseResponse> modifyIncome(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long incomeId,
+            @RequestBody @Valid IncomeRequest incomeRequest
+    ) {
+        return BaseResponse.toResponseEntity(incomeFacade.modifyIncome(userDetails.getUsername(), incomeId, incomeRequest));
     }
 }

--- a/src/main/java/com/poortorich/income/entity/Income.java
+++ b/src/main/java/com/poortorich/income/entity/Income.java
@@ -89,4 +89,18 @@ public class Income implements AccountBook {
     public Iteration getGeneratedIteration() {
         return generatedIterationIncomes;
     }
+
+    @Override
+    public void updateAccountBook(String title, Long cost, String memo, IterationType iterationType, Category category) {
+        this.title = title;
+        this.cost = cost;
+        this.memo = memo;
+        this.iterationType = iterationType;
+        this.category = category;
+    }
+
+    @Override
+    public void updateAccountBookDate(LocalDate accountBookDate) {
+        this.incomeDate = accountBookDate;
+    }
 }

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -151,9 +151,9 @@ public class IncomeFacade {
             Category category,
             User user
     ) {
-        List<Iteration> modifyIterationExpenses
+        List<Iteration> modifyIterationIncomes
                 = iterationService.getIterationByIterationAction(income, user, iterationAction, accountBookType);
-        for (Iteration iteration : modifyIterationExpenses) {
+        for (Iteration iteration : modifyIterationIncomes) {
             accountBookService.modifyAccountBook(iteration.getGeneratedAccountBook(), incomeRequest, category);
         }
     }

--- a/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
+++ b/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum IncomeResponse implements Response {
 
     CREATE_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.CREATE_INCOME_SUCCESS, null),
-    GET_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.GET_INCOME_SUCCESS, null);
+    GET_INCOME_SUCCESS(HttpStatus.OK, IncomeResponseMessages.GET_INCOME_SUCCESS, null),
+    MODIFY_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.MODIFY_INCOME_SUCCESS, null);
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/poortorich/income/service/IncomeService.java
+++ b/src/main/java/com/poortorich/income/service/IncomeService.java
@@ -1,34 +1,18 @@
 package com.poortorich.income.service;
 
-import com.poortorich.category.entity.Category;
 import com.poortorich.income.entity.Income;
-import com.poortorich.income.repository.IncomeRepository;
-import com.poortorich.income.request.IncomeRequest;
-import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.beans.Transient;
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
 public class IncomeService {
 
-    private final IncomeRepository incomeRepository;
-
-    public Income create(IncomeRequest incomeRequest, Category category, User user) {
-        Income income = buildEntity(incomeRequest, category, user);
-        incomeRepository.save(income);
-        return income;
-    }
-
-    protected Income buildEntity(IncomeRequest incomeRequest, Category category, User user) {
-        return Income.builder()
-                .incomeDate(incomeRequest.parseDate())
-                .category(category)
-                .title(incomeRequest.trimTitle())
-                .cost(incomeRequest.getCost())
-                .memo(incomeRequest.getMemo())
-                .iterationType(incomeRequest.parseIterationType())
-                .user(user)
-                .build();
+    @Transient
+    public void modifyIncomeDate(Income income, LocalDate incomeDate) {
+        income.updateAccountBookDate(incomeDate);
     }
 }

--- a/src/main/java/com/poortorich/iteration/entity/Iteration.java
+++ b/src/main/java/com/poortorich/iteration/entity/Iteration.java
@@ -15,4 +15,6 @@ public interface Iteration {
     AccountBook getGeneratedAccountBook();
 
     IterationInfo getIterationInfo();
+
+    void updateOriginalAccountBook(AccountBook accountBook);
 }

--- a/src/main/java/com/poortorich/iteration/entity/IterationExpenses.java
+++ b/src/main/java/com/poortorich/iteration/entity/IterationExpenses.java
@@ -72,7 +72,8 @@ public class IterationExpenses implements Iteration {
         return generatedExpense;
     }
 
-    public void updateOriginalExpense(Expense originalExpense) {
-        this.originalExpense = originalExpense;
+    @Override
+    public void updateOriginalAccountBook(AccountBook originalExpense) {
+        this.originalExpense = (Expense) originalExpense;
     }
 }

--- a/src/main/java/com/poortorich/iteration/entity/IterationIncomes.java
+++ b/src/main/java/com/poortorich/iteration/entity/IterationIncomes.java
@@ -72,7 +72,8 @@ public class IterationIncomes implements Iteration{
         return generatedIncome;
     }
 
-    public void updateOriginalIncome(Income originalIncome) {
-        this.originalIncome = originalIncome;
+    @Override
+    public void updateOriginalAccountBook(AccountBook originalIncome) {
+        this.originalIncome = (Income) originalIncome;
     }
 }

--- a/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
@@ -26,7 +26,7 @@ public interface IterationExpensesRepository extends JpaRepository<IterationExpe
           AND ge.expenseDate >= :startDate
         ORDER BY ge.expenseDate ASC
         """)
-    List<IterationExpenses> findAllByOriginalExpenseAndUserAndGeneratedExpenseDateAfterOrEqual(
+    List<IterationExpenses> getThisAndFutureIterationExpenses(
             Expense originalExpense,
             User user,
             LocalDate startDate

--- a/src/main/java/com/poortorich/iteration/repository/IterationIncomesRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationIncomesRepository.java
@@ -1,9 +1,34 @@
 package com.poortorich.iteration.repository;
 
+import com.poortorich.income.entity.Income;
 import com.poortorich.iteration.entity.IterationIncomes;
+import com.poortorich.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface IterationIncomesRepository extends JpaRepository<IterationIncomes, Long> {
+
+    IterationIncomes findByGeneratedIncomeAndUser(Income accountBookToDelete, User user);
+
+    List<IterationIncomes> findAllByOriginalIncomeAndUser(Income originalAccountBook, User user);
+
+    @Query("""
+        SELECT DISTINCT ii
+        FROM IterationIncomes ii
+        JOIN FETCH ii.generatedIncome gi
+        WHERE ii.originalIncome = :originalIncome
+          AND ii.user = :user
+          AND gi.incomeDate >= :startDate
+        ORDER BY gi.incomeDate ASC
+        """)
+    List<IterationIncomes> getThisAndFutureIterationIncomes(
+            Income originalIncome,
+            User user,
+            LocalDate accountBookDate
+    );
 }

--- a/src/main/java/com/poortorich/iteration/repository/IterationRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationRepository.java
@@ -1,11 +1,18 @@
 package com.poortorich.iteration.repository;
 
+import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.enums.AccountBookType;
+import com.poortorich.expense.entity.Expense;
+import com.poortorich.income.entity.Income;
 import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.iteration.entity.IterationIncomes;
+import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -19,5 +26,47 @@ public class IterationRepository {
             case EXPENSE -> iterationExpensesRepository.save((IterationExpenses) iteration);
             case INCOME -> iterationIncomesRepository.save((IterationIncomes) iteration);
         }
+    }
+
+    public Iteration findByGeneratedAccountBookAndUser(User user, AccountBook accountBookToDelete, AccountBookType type) {
+        return switch (type) {
+            case EXPENSE -> iterationExpensesRepository.findByGeneratedExpenseAndUser((Expense) accountBookToDelete, user);
+            case INCOME -> iterationIncomesRepository.findByGeneratedIncomeAndUser((Income) accountBookToDelete, user);
+        };
+    }
+
+    public List<Iteration> findAllByOriginalAccountBookAndUser(User user, AccountBook originalAccountBook, AccountBookType type) {
+        List<? extends Iteration> allIteration = switch (type) {
+            case EXPENSE -> iterationExpensesRepository.findAllByOriginalExpenseAndUser((Expense) originalAccountBook, user);
+            case INCOME -> iterationIncomesRepository.findAllByOriginalIncomeAndUser((Income) originalAccountBook, user);
+        };
+        return mapToIteration(allIteration);
+    }
+
+    public void deleteAll(List<Iteration> deleteIterations, AccountBookType type) {
+        switch (type) {
+            case EXPENSE -> iterationExpensesRepository.deleteAll(deleteIterations.stream()
+                    .map(iteration -> (IterationExpenses) iteration)
+                    .toList());
+            case INCOME -> iterationIncomesRepository.deleteAll(deleteIterations.stream()
+                    .map(iteration -> (IterationIncomes) iteration)
+                    .toList());
+        }
+    }
+
+    public List<Iteration> getThisAndFutureIterations(AccountBook originalAccountBook, User user, LocalDate accountBookDate, AccountBookType type) {
+        List<? extends Iteration> thisAndFutureIterations = switch (type) {
+            case EXPENSE -> iterationExpensesRepository
+                    .getThisAndFutureIterationExpenses((Expense) originalAccountBook, user, accountBookDate);
+            case INCOME -> iterationIncomesRepository
+                    .getThisAndFutureIterationIncomes((Income) originalAccountBook, user, accountBookDate);
+        };
+        return mapToIteration(thisAndFutureIterations);
+    }
+
+    private List<Iteration> mapToIteration(List<? extends Iteration> iterations) {
+        return iterations.stream()
+                .map(iteration -> (Iteration) iteration)
+                .toList();
     }
 }

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -5,13 +5,10 @@ import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.AccountBookRequest;
 import com.poortorich.accountbook.response.AccountBookResponse;
 import com.poortorich.accountbook.util.AccountBookBuilder;
-import com.poortorich.expense.entity.Expense;
 import com.poortorich.accountbook.entity.enums.IterationType;
-import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.accountbook.request.enums.IterationAction;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.iteration.entity.Iteration;
-import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.iteration.entity.enums.Weekday;
 import com.poortorich.iteration.entity.enums.EndType;
 import com.poortorich.iteration.entity.enums.IterationRuleType;
@@ -21,7 +18,6 @@ import com.poortorich.iteration.entity.info.IterationInfo;
 import com.poortorich.iteration.entity.info.MonthlyIterationRule;
 import com.poortorich.iteration.entity.info.WeeklyIterationRule;
 import com.poortorich.iteration.entity.info.YearlyIterationRule;
-import com.poortorich.iteration.repository.IterationExpensesRepository;
 import com.poortorich.iteration.repository.IterationInfoRepository;
 import com.poortorich.iteration.repository.IterationRepository;
 import com.poortorich.iteration.request.CustomIteration;
@@ -52,8 +48,6 @@ public class IterationService {
     private final IterationDateCalculator dateCalculator;
     private final IterationRepository iterationRepository;
     private final IterationInfoRepository iterationInfoRepository;
-    // TODO: Change Repository Layer
-    private final IterationExpensesRepository iterationExpensesRepository;
 
     private static final String MODIFY_TYPE = "modify";
     private static final String DELETE_TYPE = "delete";
@@ -383,98 +377,115 @@ public class IterationService {
                 .build();
     }
 
-    public List<IterationExpenses> getIterationExpensesByIterationAction(Expense expense, User user, IterationAction iterationAction) {
-        IterationExpenses iterationExpense = iterationExpensesRepository.findByGeneratedExpenseAndUser(expense, user);
-        Expense originalExpense = iterationExpense.getOriginalExpense();
-        List<IterationExpenses> allIterationExpenses = iterationExpensesRepository.findAllByOriginalExpenseAndUser(originalExpense, user);
+    public List<Iteration> getIterationByIterationAction(
+            AccountBook accountBook,
+            User user,
+            IterationAction iterationAction,
+            AccountBookType type
+    ) {
+        Iteration iteration = iterationRepository.findByGeneratedAccountBookAndUser(user, accountBook, type);
+        AccountBook originalAccountBook = iteration.getOriginalAccountBook();
+        List<Iteration> allIterations
+                = iterationRepository.findAllByOriginalAccountBookAndUser(user, originalAccountBook, type);
 
-        return resolveIterationExpenses(
-                iterationAction, originalExpense, expense, iterationExpense, allIterationExpenses, user, MODIFY_TYPE
+        return resolveIterations(
+                iterationAction, originalAccountBook, accountBook, iteration, allIterations, user, MODIFY_TYPE, type
         );
     }
 
-    public List<Expense> deleteIterationExpenses(Expense expenseToDelete, User user, IterationAction iterationAction) {
-        IterationExpenses iterationExpense = iterationExpensesRepository.findByGeneratedExpenseAndUser(expenseToDelete, user);
-        Expense originalExpense = iterationExpense.getOriginalExpense();
-        List<IterationExpenses> allIterationExpenses = iterationExpensesRepository.findAllByOriginalExpenseAndUser(originalExpense, user);
+    public List<AccountBook> deleteIterations(
+            AccountBook accountBookToDelete,
+            User user,
+            IterationAction iterationAction,
+            AccountBookType type
+    ) {
+        Iteration iteration = iterationRepository.findByGeneratedAccountBookAndUser(user, accountBookToDelete, type);
+        AccountBook originalAccountBook = iteration.getOriginalAccountBook();
+        List<Iteration> allIterations
+                = iterationRepository.findAllByOriginalAccountBookAndUser(user, originalAccountBook, type);
 
-        List<IterationExpenses> deleteIterationExpenses = resolveIterationExpenses(
-                iterationAction, originalExpense, expenseToDelete, iterationExpense, allIterationExpenses, user, DELETE_TYPE
+        List<Iteration> deleteIterations = resolveIterations(
+                iterationAction, originalAccountBook, accountBookToDelete, iteration, allIterations, user, DELETE_TYPE, type
         );
 
-        iterationExpensesRepository.deleteAll(deleteIterationExpenses);
-        return deleteIterationExpenses.stream()
-                .map(IterationExpenses::getGeneratedExpense)
+        iterationRepository.deleteAll(deleteIterations, type);
+        return deleteIterations.stream()
+                .map(Iteration::getGeneratedAccountBook)
                 .toList();
     }
 
-    private List<IterationExpenses> resolveIterationExpenses(
+    private List<Iteration> resolveIterations(
             IterationAction iterationAction,
-            Expense originalExpense,
-            Expense expense,
-            IterationExpenses iterationExpense,
-            List<IterationExpenses> allIterationExpenses,
+            AccountBook originalAccountBook,
+            AccountBook accountBook,
+            Iteration iteration,
+            List<Iteration> allIterations,
             User user,
-            String type
+            String type,
+            AccountBookType accountBookType
     ) {
         if (iterationAction == IterationAction.THIS_ONLY) {
-            return handleThisOnly(originalExpense, expense, iterationExpense, allIterationExpenses);
+            return handleThisOnly(originalAccountBook, accountBook, iteration, allIterations);
         }
 
         if (iterationAction == IterationAction.ALL
-                || (iterationAction == IterationAction.THIS_AND_FUTURE && expense.equals(originalExpense))) {
+                || (iterationAction == IterationAction.THIS_AND_FUTURE && accountBook.equals(originalAccountBook))) {
             if (type.equals(MODIFY_TYPE)) {
-                return allIterationExpenses;
+                return allIterations;
             }
-            return handleAll(iterationExpense, allIterationExpenses);
+            return handleAll(iteration, allIterations);
         }
 
-        if (iterationAction == IterationAction.THIS_AND_FUTURE && !expense.equals(originalExpense)) {
-            return handleThisAndFuture(originalExpense, expense, user);
+        if (iterationAction == IterationAction.THIS_AND_FUTURE && !accountBook.equals(originalAccountBook)) {
+            return handleThisAndFuture(originalAccountBook, accountBook, user, accountBookType);
         }
 
         throw new BadRequestException(AccountBookResponse.ITERATION_ACTION_INVALID);
     }
 
-    private List<IterationExpenses> handleThisOnly(
-            Expense originalExpense,
-            Expense expenseToDelete,
-            IterationExpenses iterationExpense,
-            List<IterationExpenses> allIterationExpenses
+    private List<Iteration> handleThisOnly(
+            AccountBook originalAccountBook,
+            AccountBook accountBookToDelete,
+            Iteration iteration,
+            List<Iteration> allIterations
     ) {
-        if (expenseToDelete.equals(originalExpense) && allIterationExpenses.size() < 2) {
-            return handleAll(iterationExpense, allIterationExpenses);
+        if (accountBookToDelete.equals(originalAccountBook) && allIterations.size() < 2) {
+            return handleAll(iteration, allIterations);
         }
 
-        if (expenseToDelete.equals(originalExpense)) {
-            updateOriginalExpense(allIterationExpenses);
+        if (accountBookToDelete.equals(originalAccountBook)) {
+            updateOriginalAccountBook(allIterations);
         }
 
-        return List.of(iterationExpense);
+        return List.of(iteration);
     }
 
-    private void updateOriginalExpense(List<IterationExpenses> allIterationExpenses) {
-        Expense newOriginalExpense = allIterationExpenses.get(1).getGeneratedExpense();
-        for (IterationExpenses iterationExpense : allIterationExpenses) {
-            iterationExpense.updateOriginalExpense(newOriginalExpense);
+    private void updateOriginalAccountBook(List<Iteration> allIterations) {
+        AccountBook newOriginalAccountBook = allIterations.get(1).getGeneratedAccountBook();
+        for (Iteration iteration : allIterations) {
+            iteration.updateOriginalAccountBook(newOriginalAccountBook);
         }
     }
 
-    private List<IterationExpenses> handleAll(
-            IterationExpenses iterationExpenses,
-            List<IterationExpenses> deleteIterationExpenses
+    private List<Iteration> handleAll(
+            Iteration iteration,
+            List<Iteration> deleteIterations
     ) {
-        IterationInfo iterationInfo = iterationExpenses.getIterationInfo();
+        IterationInfo iterationInfo = iteration.getIterationInfo();
         if (iterationInfo != null) {
-            iterationInfoRepository.delete(deleteIterationExpenses.getFirst().getIterationInfo());
+            iterationInfoRepository.delete(deleteIterations.getFirst().getIterationInfo());
         }
 
-        return deleteIterationExpenses;
+        return deleteIterations;
     }
 
-    private List<IterationExpenses> handleThisAndFuture(Expense originalExpense, Expense targetExpense, User user) {
-        return iterationExpensesRepository.findAllByOriginalExpenseAndUserAndGeneratedExpenseDateAfterOrEqual(
-                originalExpense, user, targetExpense.getExpenseDate()
-        );
+    private List<Iteration> handleThisAndFuture(
+            AccountBook originalAccountBook,
+            AccountBook targetAccountBook,
+            User user,
+            AccountBookType type
+    ) {
+        return iterationRepository
+                .getThisAndFutureIterations(originalAccountBook, user, targetAccountBook.getAccountBookDate(), type);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#119 
 
 ## 📝작업 내용
 
- 수입 가계부 편집 API 구현
- 가계부 편집 공통 로직 통합

## 🗂️ `accountbook`

### `AccountBook`

- update 로직 추가

### `AccountBookService`

- 공통되는 가계부 편집 로직 추가

## 🗂️ `expense`

### 🛠️ `Expense`

- 기존의 update() 메서드 삭제 후 `AccountBook` update() 메서드 재정의

### 🛠️ `ExpenseFacade`

- 공통되는 로직 통합을 위해 인터페이스(`AccountBook` `Iteration`)를 사용하도록 수정
 
### 🛠️ `ExpenseService`

- `AccountBookService`로 이전한 공통 로직 삭제

## 🗂️ `income`

### `IncomeResponse` `IncomeResponseMessages`

- 수입 가계부 편집 성공 response 추가

### `IncomeController`

- 수입 가계부 편집 로직 추가

### `Income`

- update() 메서드 재정의

### `IncomeFacade`

- 수입 가계부 편집 로직 추가

### 🛠️ `IncomeService`

- 사용되지 않는 메서드 삭제
- 날짜 변경 메서드 추가

## 🗂️ `iteration`

### `Iteration`

- originalAccountBook 을 update하는 메서드 추가

### `IterationExpenses` `IterationIncomes`

- update() 메서드 재정의

### 🛠️ `IterationExpensesRepository`

- `@Query` 어노테이션을 사용하는 메서드의 이름 수정

### `IterationIncomesRepository`

- 반복데이터 조회 관련 로직 추가

### `IterationRepository`

- 공통된 repository 로직을 처리하기 위한 메서드 추가

### 🛠️ `IterationService`

- 수입/지출 가계부 모두에서 사용할 수 있도록 인터페이스를 활용하여 로직 수정

 ### 스크린샷

![image](https://github.com/user-attachments/assets/1b1ac10e-8376-4466-9ce7-92a7cd76cf02)

 ## 💬리뷰 요구사항
 
- 코드 컨벤션 및 네이밍
