### PR TITLE
[#127] 카테고리 꺾은선 그래프 API

### DIFF
--- a/src/main/java/com/poortorich/accountbook/repository/AccountBookRepository.java
+++ b/src/main/java/com/poortorich/accountbook/repository/AccountBookRepository.java
@@ -84,6 +84,22 @@ public class AccountBookRepository {
         return mapToAccountBooks(accountBooks);
     }
 
+    public List<AccountBook> getAccountBookByCategoryBetweenDates(
+            User user,
+            Category category,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        List<? extends AccountBook> accountBooks = switch (category.getType()) {
+            case DEFAULT_EXPENSE, CUSTOM_EXPENSE ->
+                    expenseRepository.findByUserAndCategoryAndExpenseDateBetween(user, category, startDate, endDate);
+            case DEFAULT_INCOME, CUSTOM_INCOME ->
+                    incomeRepository.findByUserAndCategoryAndIncomeDateBetween(user, category, startDate, endDate);
+        };
+
+        return mapToAccountBooks(accountBooks);
+    }
+
     public Slice<AccountBook> findByUserAndCategoryWithinDateRangeWithCursor(
             User user,
             Category category,

--- a/src/main/java/com/poortorich/chart/constants/ChartResponseMessage.java
+++ b/src/main/java/com/poortorich/chart/constants/ChartResponseMessage.java
@@ -6,7 +6,7 @@ public class ChartResponseMessage {
     public static final String GET_CATEGORY_SECTION_SUCCESS = "카테고리 구간 내역 조회 성공";
     public static final String GET_CATEGORY_CHART_SUCCESS = "카테고리별 비율 및 총 금액 조회 성공";
     public static final String GET_EXPENSE_BAR_SUCCESS = "지출 막대그래프 조회 성공";
-    public static final String GET_CATEGORY_LINE_SUCCESS = "카테고리 꺽은선 그래프 조회 성공";
+    public static final String GET_CATEGORY_LINE_SUCCESS = "카테고리 꺾은선 그래프 조회 성공";
 
     private ChartResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chart/constants/ChartResponseMessage.java
+++ b/src/main/java/com/poortorich/chart/constants/ChartResponseMessage.java
@@ -6,6 +6,7 @@ public class ChartResponseMessage {
     public static final String GET_CATEGORY_SECTION_SUCCESS = "카테고리 구간 내역 조회 성공";
     public static final String GET_CATEGORY_CHART_SUCCESS = "카테고리별 비율 및 총 금액 조회 성공";
     public static final String GET_EXPENSE_BAR_SUCCESS = "지출 막대그래프 조회 성공";
+    public static final String GET_CATEGORY_LINE_SUCCESS = "카테고리 꺽은선 그래프 조회 성공";
 
     private ChartResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chart/controller/ChartController.java
+++ b/src/main/java/com/poortorich/chart/controller/ChartController.java
@@ -3,9 +3,12 @@ package com.poortorich.chart.controller;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.chart.facade.ChartFacade;
 import com.poortorich.chart.response.enums.ChartResponse;
+import com.poortorich.global.date.constants.DatePattern;
+import com.poortorich.global.date.constants.DateResponseMessage;
 import com.poortorich.global.response.BaseResponse;
 import com.poortorich.global.response.DataResponse;
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -66,6 +69,20 @@ public class ChartController {
         return DataResponse.toResponseEntity(
                 ChartResponse.GET_EXPENSE_BAR_SUCCESS,
                 chartFacade.getAccountBookBar(userDetails.getUsername(), date, AccountBookType.EXPENSE)
+        );
+    }
+
+    @GetMapping("/{categoryId}/line")
+    public ResponseEntity<BaseResponse> getCategoryLine(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("categoryId") Long categoryId,
+            @RequestParam("date")
+            @Pattern(regexp = DatePattern.YEAR_MONTH_REGEX, message = DateResponseMessage.UNSUPPORTED_DATE_FORMAT)
+            String date
+    ) {
+        return DataResponse.toResponseEntity(
+                ChartResponse.GET_CATEGORY_LINE_SUCCESS,
+                chartFacade.getCategoryLine(userDetails.getUsername(), categoryId, date)
         );
     }
 }

--- a/src/main/java/com/poortorich/chart/facade/ChartFacade.java
+++ b/src/main/java/com/poortorich/chart/facade/ChartFacade.java
@@ -9,6 +9,7 @@ import com.poortorich.category.service.CategoryService;
 import com.poortorich.chart.response.AccountBookBarResponse;
 import com.poortorich.chart.response.CategoryChart;
 import com.poortorich.chart.response.CategoryChartResponse;
+import com.poortorich.chart.response.CategoryLineResponse;
 import com.poortorich.chart.response.CategoryLog;
 import com.poortorich.chart.response.CategorySectionResponse;
 import com.poortorich.chart.response.TotalAmountAndSavingResponse;
@@ -16,6 +17,7 @@ import com.poortorich.chart.service.ChartService;
 import com.poortorich.chart.util.AccountBookUtil;
 import com.poortorich.global.date.constants.DateConstants;
 import com.poortorich.global.date.domain.DateInfo;
+import com.poortorich.global.date.domain.MonthInformation;
 import com.poortorich.global.date.util.DateInfoProvider;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
@@ -124,5 +126,22 @@ public class ChartFacade {
                 .toList();
 
         return chartService.getAccountBookBar(dateInfos, accountBooksGroupByDateInfo);
+    }
+
+    public CategoryLineResponse getCategoryLine(String username, Long categoryId, String date) {
+        User user = userService.findUserByUsername(username);
+        Category category = categoryService.getCategoryOrThrow(categoryId, user);
+        MonthInformation monthInfo = (MonthInformation) DateInfoProvider.getDateInfo(date);
+
+        List<AccountBook> accountBooks = accountBookService.getAccountBookByCategoryBetweenDates(user, category,
+                monthInfo.getStartDate(), monthInfo.getEndDate());
+
+        List<List<AccountBook>> weeklyAccountBooks = monthInfo.getWeeks().stream()
+                .map(weekInfo -> accountBookService.getAccountBookByCategoryBetweenDates(
+                        user, category, weekInfo.getStartDate(), weekInfo.getEndDate()
+                ))
+                .toList();
+
+        return chartService.getCategoryLine(monthInfo, accountBooks, weeklyAccountBooks);
     }
 }

--- a/src/main/java/com/poortorich/chart/response/CategoryLineResponse.java
+++ b/src/main/java/com/poortorich/chart/response/CategoryLineResponse.java
@@ -9,6 +9,6 @@ import lombok.Data;
 public class CategoryLineResponse {
 
     private String period;
-    private Long totalAmounts;
+    private Long totalAmount;
     private List<PeriodTotal> weeklyAmounts;
 }

--- a/src/main/java/com/poortorich/chart/response/CategoryLineResponse.java
+++ b/src/main/java/com/poortorich/chart/response/CategoryLineResponse.java
@@ -1,0 +1,4 @@
+package com.poortorich.chart.response;
+
+public class CategoryLineResponse {
+}

--- a/src/main/java/com/poortorich/chart/response/CategoryLineResponse.java
+++ b/src/main/java/com/poortorich/chart/response/CategoryLineResponse.java
@@ -1,4 +1,14 @@
 package com.poortorich.chart.response;
 
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
 public class CategoryLineResponse {
+
+    private String period;
+    private Long totalAmounts;
+    private List<PeriodTotal> weeklyAmounts;
 }

--- a/src/main/java/com/poortorich/chart/response/enums/ChartResponse.java
+++ b/src/main/java/com/poortorich/chart/response/enums/ChartResponse.java
@@ -26,7 +26,13 @@ public enum ChartResponse implements Response {
     GET_EXPENSE_BAR_SUCCESS(
             HttpStatus.OK,
             ChartResponseMessage.GET_EXPENSE_BAR_SUCCESS,
-            null);
+            null
+    ),
+    GET_CATEGORY_LINE_SUCCESS(
+            HttpStatus.OK,
+            ChartResponseMessage.GET_CATEGORY_LINE_SUCCESS,
+            null
+    );
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chart/util/PeriodFormatter.java
+++ b/src/main/java/com/poortorich/chart/util/PeriodFormatter.java
@@ -1,0 +1,4 @@
+package com.poortorich.chart.util;
+
+public class PeriodFormatter {
+}

--- a/src/main/java/com/poortorich/chart/util/PeriodFormatter.java
+++ b/src/main/java/com/poortorich/chart/util/PeriodFormatter.java
@@ -1,4 +1,23 @@
 package com.poortorich.chart.util;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 public class PeriodFormatter {
+
+    private static final DateTimeFormatter DOT_DATE_FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
+    private static final DateTimeFormatter DOT_MONTH_DAY_FORMATTER = DateTimeFormatter.ofPattern("MM.dd");
+    private static final String TILDE_DATE_RANGE_SEPARATOR = "~";
+
+    public static String formatLocalDateRange(LocalDate startDate, LocalDate endDate) {
+        return startDate.format(DOT_DATE_FORMATTER)
+                + TILDE_DATE_RANGE_SEPARATOR
+                + endDate.format(DOT_DATE_FORMATTER);
+    }
+
+    public static String formatMonthDayRange(LocalDate startDate, LocalDate endDate) {
+        return startDate.format(DOT_MONTH_DAY_FORMATTER)
+                + TILDE_DATE_RANGE_SEPARATOR
+                + endDate.format(DOT_MONTH_DAY_FORMATTER);
+    }
 }

--- a/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
@@ -20,6 +20,9 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     List<Expense> findByUserAndExpenseDateBetween(User user, LocalDate startDate, LocalDate endDate);
 
+    List<Expense> findByUserAndCategoryAndExpenseDateBetween(User user, Category category, LocalDate startDate,
+                                                             LocalDate endDate);
+
     List<Expense> findByUserAndCategoryAndExpenseDate(User user, Category category, LocalDate expenseDate);
 
     @Query("""

--- a/src/main/java/com/poortorich/global/date/constants/DateResponseMessage.java
+++ b/src/main/java/com/poortorich/global/date/constants/DateResponseMessage.java
@@ -1,0 +1,6 @@
+package com.poortorich.global.date.constants;
+
+public class DateResponseMessage {
+
+    public static final String UNSUPPORTED_DATE_FORMAT = "지원하지 않는 날짜 형식입니다.";
+}

--- a/src/main/java/com/poortorich/global/date/response/enums/DateResponse.java
+++ b/src/main/java/com/poortorich/global/date/response/enums/DateResponse.java
@@ -1,5 +1,6 @@
 package com.poortorich.global.date.response.enums;
 
+import com.poortorich.global.date.constants.DateResponseMessage;
 import com.poortorich.global.response.Response;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -7,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum DateResponse implements Response {
 
-    UNSUPPORTED_DATE_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않는 날짜 형식입니다.", "date");
+    UNSUPPORTED_DATE_FORMAT(HttpStatus.BAD_REQUEST, DateResponseMessage.UNSUPPORTED_DATE_FORMAT, "date");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/income/repository/IncomeRepository.java
+++ b/src/main/java/com/poortorich/income/repository/IncomeRepository.java
@@ -21,6 +21,9 @@ public interface IncomeRepository extends JpaRepository<Income, Long> {
 
     List<Income> findByUserAndIncomeDateBetween(User user, LocalDate startDate, LocalDate endDate);
 
+    List<Income> findByUserAndCategoryAndIncomeDateBetween(User user, Category category, LocalDate startDate,
+                                                           LocalDate endDate);
+
     List<Income> findByUserAndCategoryAndIncomeDate(User user, Category category, LocalDate incomeDate);
 
     @Query("""


### PR DESCRIPTION
## #️⃣127
 ## 📝작업 내용
* 카테고리 꺾은선 그래프 API
* 구간 포맷터
 
##  🔥구간 포맷터
`startDate`와 `endDate`를 인수로 받아 문자열 범위 데이터를 제공합니다.

* startDate = LocalDate.of(2025, 05, 01) & endDate = LocalDate.of(2025, 05, 31)
  * `"2025.05.01~2025.05.31"`
  * `"05.01~05.31"`

## 🔥카테고리 꺾은선 그래프 
`RequestParam`으로 요청한 date에 해당하는 달의 총 금액과 각 주의 지출 총액을 제공합니다.

 ### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e8b96983-de52-4db6-bf82-15dd5a0f2c30)

