### PR TITLE
[#126] 일별 상세 내역 API 구현

### DIFF
--- a/src/main/java/com/poortorich/accountbook/entity/AccountBook.java
+++ b/src/main/java/com/poortorich/accountbook/entity/AccountBook.java
@@ -2,9 +2,11 @@ package com.poortorich.accountbook.entity;
 
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.category.entity.Category;
+import com.poortorich.expense.entity.enums.PaymentMethod;
 import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.user.entity.User;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public interface AccountBook {
 
@@ -16,13 +18,17 @@ public interface AccountBook {
 
     Long getCost();
 
+    PaymentMethod getPaymentMethod();
+
     String getMemo();
 
     IterationType getIterationType();
 
     Category getCategory();
-    
+
     User getUser();
 
     Iteration getGeneratedIteration();
+
+    LocalDateTime getCreatedDate();
 }

--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -18,7 +18,6 @@ import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -120,19 +119,11 @@ public class AccountBookService {
     }
 
     private List<AccountBookInfoResponse> getAccountBookInfoResponses(
-            List<AccountBook> originalAccountBooks,
+            List<AccountBook> accountBooks,
             AccountBookType type
     ) {
-        return originalAccountBooks.stream()
-                .map(accountBook -> AccountBookInfoResponse.builder()
-                        .id(accountBook.getId())
-                        .categoryName(accountBook.getCategory().getName())
-                        .color(accountBook.getCategory().getColor())
-                        .title(accountBook.getTitle())
-                        .type(type.toString())
-                        .cost(accountBook.getCost())
-                        .build()
-                )
+        return accountBooks.stream()
+                .map(accountBook -> AccountBookBuilder.buildAccountBookInfoResponse(accountBook, type))
                 .toList();
     }
 }

--- a/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
+++ b/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
@@ -3,6 +3,7 @@ package com.poortorich.accountbook.util;
 import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.AccountBookRequest;
+import com.poortorich.accountbook.response.AccountBookInfoResponse;
 import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
@@ -120,6 +121,17 @@ public class AccountBookBuilder {
                 .memo(income.getMemo())
                 .iterationType(income.getIterationType().toString())
                 .customIteration(customIteration)
+                .build();
+    }
+
+    public static AccountBookInfoResponse buildAccountBookInfoResponse(AccountBook accountBook, AccountBookType type) {
+        return AccountBookInfoResponse.builder()
+                .id(accountBook.getId())
+                .categoryName(accountBook.getCategory().getName())
+                .color(accountBook.getCategory().getColor())
+                .title(accountBook.getTitle())
+                .type(type.toString())
+                .cost(accountBook.getCost())
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/global/date/util/DateParser.java
+++ b/src/main/java/com/poortorich/global/date/util/DateParser.java
@@ -1,0 +1,25 @@
+package com.poortorich.global.date.util;
+
+import com.poortorich.global.date.constants.DatePattern;
+import com.poortorich.global.date.response.enums.DateResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class DateParser {
+
+    public static LocalDate parseDate(String date) {
+        if (date == null || date.isBlank()) {
+            return LocalDate.now();
+        }
+
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DatePattern.LOCAL_DATE_PATTERN);
+            return LocalDate.parse(date, formatter);
+        } catch (DateTimeParseException e) {
+            throw new BadRequestException(DateResponse.UNSUPPORTED_DATE_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/poortorich/income/entity/Income.java
+++ b/src/main/java/com/poortorich/income/entity/Income.java
@@ -3,6 +3,7 @@ package com.poortorich.income.entity;
 import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.category.entity.Category;
+import com.poortorich.expense.entity.enums.PaymentMethod;
 import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.entity.IterationIncomes;
 import com.poortorich.user.entity.User;
@@ -88,5 +89,10 @@ public class Income implements AccountBook {
     @Override
     public Iteration getGeneratedIteration() {
         return generatedIterationIncomes;
+    }
+
+    @Override
+    public PaymentMethod getPaymentMethod() {
+        return null;
     }
 }

--- a/src/main/java/com/poortorich/report/constants/ReportResponseMessages.java
+++ b/src/main/java/com/poortorich/report/constants/ReportResponseMessages.java
@@ -1,0 +1,9 @@
+package com.poortorich.report.constants;
+
+public class ReportResponseMessages {
+
+    public static final String GET_DAILY_DETAILS_SUCCESS = "일별 상세 내역을 성공적으로 조회하였습니다.";
+
+    private ReportResponseMessages() {
+    }
+}

--- a/src/main/java/com/poortorich/report/controller/ReportController.java
+++ b/src/main/java/com/poortorich/report/controller/ReportController.java
@@ -1,0 +1,34 @@
+package com.poortorich.report.controller;
+
+import com.poortorich.global.response.BaseResponse;
+import com.poortorich.global.response.DataResponse;
+import com.poortorich.report.facade.ReportFacade;
+import com.poortorich.report.response.enums.ReportResponse;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/report")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportFacade reportFacade;
+
+    @GetMapping("/daily/details")
+    public ResponseEntity<BaseResponse> getDailyDetailsReport(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("date") @Nullable String date
+    ) {
+        return DataResponse.toResponseEntity(
+                ReportResponse.GET_DAILY_DETAILS_SUCCESS,
+                reportFacade.getDailyDetailsReport(userDetails.getUsername(), date)
+        );
+    }
+}

--- a/src/main/java/com/poortorich/report/facade/ReportFacade.java
+++ b/src/main/java/com/poortorich/report/facade/ReportFacade.java
@@ -1,0 +1,36 @@
+package com.poortorich.report.facade;
+
+import com.poortorich.accountbook.entity.AccountBook;
+import com.poortorich.accountbook.enums.AccountBookType;
+import com.poortorich.accountbook.service.AccountBookService;
+import com.poortorich.global.date.util.DateParser;
+import com.poortorich.report.response.DailyDetailsResponse;
+import com.poortorich.report.service.ReportService;
+import com.poortorich.user.entity.User;
+import com.poortorich.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportFacade {
+
+    private final UserService userService;
+    private final ReportService reportService;
+    private final AccountBookService accountBookService;
+
+    public DailyDetailsResponse getDailyDetailsReport(String username, String inputDate) {
+        User user = userService.findUserByUsername(username);
+        LocalDate date = DateParser.parseDate(inputDate);
+
+        List<AccountBook> dailyIncomes
+                = accountBookService.getAccountBookBetweenDates(user, date, date, AccountBookType.INCOME);
+        List<AccountBook> dailyExpenses
+                = accountBookService.getAccountBookBetweenDates(user, date, date, AccountBookType.EXPENSE);
+
+        return reportService.getDailyDetailsReport(dailyIncomes, dailyExpenses);
+    }
+}

--- a/src/main/java/com/poortorich/report/response/DailyDetailsResponse.java
+++ b/src/main/java/com/poortorich/report/response/DailyDetailsResponse.java
@@ -1,0 +1,21 @@
+package com.poortorich.report.response;
+
+import com.poortorich.accountbook.response.AccountBookInfoResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyDetailsResponse {
+
+    private Long totalAmount;
+    private Long totalExpense;
+    private Long totalIncome;
+    private List<AccountBookInfoResponse> dailyDetails;
+}

--- a/src/main/java/com/poortorich/report/response/enums/ReportResponse.java
+++ b/src/main/java/com/poortorich/report/response/enums/ReportResponse.java
@@ -1,0 +1,31 @@
+package com.poortorich.report.response.enums;
+
+import com.poortorich.global.response.Response;
+import com.poortorich.report.constants.ReportResponseMessages;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum ReportResponse implements Response {
+
+    GET_DAILY_DETAILS_SUCCESS(HttpStatus.OK, ReportResponseMessages.GET_DAILY_DETAILS_SUCCESS, null);
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String field;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
+}

--- a/src/main/java/com/poortorich/report/service/ReportService.java
+++ b/src/main/java/com/poortorich/report/service/ReportService.java
@@ -1,0 +1,50 @@
+package com.poortorich.report.service;
+
+import com.poortorich.accountbook.entity.AccountBook;
+import com.poortorich.accountbook.enums.AccountBookType;
+import com.poortorich.accountbook.response.AccountBookInfoResponse;
+import com.poortorich.accountbook.util.AccountBookBuilder;
+import com.poortorich.accountbook.util.AccountBookCostExtractor;
+import com.poortorich.global.statistics.util.StatCalculator;
+import com.poortorich.report.response.DailyDetailsResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Service
+public class ReportService {
+
+    public DailyDetailsResponse getDailyDetailsReport(List<AccountBook> dailyIncomes, List<AccountBook> dailyExpenses) {
+        Long totalIncome = StatCalculator.calculateSum(AccountBookCostExtractor.extract(dailyIncomes)).longValue();
+        Long totalExpense = StatCalculator.calculateSum(AccountBookCostExtractor.extract(dailyExpenses)).longValue();
+
+        List<AccountBookInfoResponse> dailyDetails = getDailyAccountBookDetails(dailyIncomes, dailyExpenses).stream()
+                .map(accountBook ->
+                        AccountBookBuilder.buildAccountBookInfoResponse(accountBook, inferAccountBookType(accountBook))
+                )
+                .toList();
+
+        return DailyDetailsResponse.builder()
+                .totalAmount(totalIncome - totalExpense)
+                .totalIncome(totalIncome)
+                .totalExpense(totalExpense)
+                .dailyDetails(dailyDetails)
+                .build();
+    }
+
+    private List<AccountBook> getDailyAccountBookDetails(List<AccountBook> dailyIncomes, List<AccountBook> dailyExpenses) {
+        return  Stream.concat(dailyIncomes.stream(), dailyExpenses.stream())
+                .sorted(Comparator.comparing(AccountBook::getCreatedDate))
+                .toList();
+    }
+
+    private AccountBookType inferAccountBookType(AccountBook accountBook) {
+        if (accountBook.getPaymentMethod() != null) {
+            return AccountBookType.EXPENSE;
+        }
+
+        return  AccountBookType.INCOME;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#126 
 
 ## 📝작업 내용
 
- 일별 상세 내역 조회 API 구현
- 날짜 변환 클래스 구현

## 🗂️ `accountbook`

### `AccountBook`

- `getPaymentMethod()` `getCreatedDate()` 메서드 추가

### `AccountBookBuilder`

- `AccountBookInfoResponse` build 메서드 추가

### 🛠️ `AccountBookService`

- `AccountBookInfoResponse` build 메서드 추가에 따른 코드 수정

## 🗂️ `global.date.util`

### `DateParser`

- 날짜 문자열이 들어왔을 때 null인 경우 현재 날짜를 반환
- `LOCAL_DATE_PATTERN` 패턴에 맞는 문자열인 경우 LocalDate 객체로 변환
- 패턴이 맞지 않다면 `BadRequest` 예외 발생

## 🗂️ `income`

### `Income`

- `getPaymentMethod()` 재정의 -> null을 반환하도록 구현

## 🗂️ `report`

### `ReportResponse` `ReportResponseMessages`

- 일별 상세 내역 성공 응답 메세지 추가

### `ReportController`

- 일별 상세 내역 로직 추가

### `ReportFacade`

- 각 AccountBook 마다 입력 날짜에 맞는 List 값을 받아온 뒤 `DailyDetailsResponse`로 가공하여 반환

### `ReportService`

- `getDailyDetailsReport()`
   각 AccountBook의 총합을 구한 뒤 `getDailyAccountBookDetails()` 메서드에서 병합된 리스트를 `AccountBookInfoResponse`로 변환
   모든 정보를 합쳐 `DailyDetailsResponse` 반환

- `getDailyAccountBookDetails()`
  각 AccountBook 리스트 병합

- `inferAccountBookType()`
   AccountBook의 타입을 유추
   paymentMethod 값이 있는 경우 `expense` 타입, null인 경우 `income` 타입 반환
 
 ### 스크린샷

![image](https://github.com/user-attachments/assets/86ea13dd-32ec-4b92-b932-6e4537210166)

![image](https://github.com/user-attachments/assets/42805966-4da6-4621-b00c-94d76b462a7d)
 
 ## 💬리뷰 요구사항

- 코드 컨벤션 및 네이밍
