### PR TITLE
[#135] 수입 가계부 삭제 API 구현

### DIFF
--- a/src/main/java/com/poortorich/accountbook/request/AccountBookDeleteRequest.java
+++ b/src/main/java/com/poortorich/accountbook/request/AccountBookDeleteRequest.java
@@ -1,4 +1,4 @@
-package com.poortorich.expense.request;
+package com.poortorich.accountbook.request;
 
 import com.poortorich.accountbook.request.enums.IterationAction;
 import lombok.AllArgsConstructor;
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ExpenseDeleteRequest {
+public class AccountBookDeleteRequest {
 
     private String iterationAction;
 

--- a/src/main/java/com/poortorich/expense/controller/ExpenseController.java
+++ b/src/main/java/com/poortorich/expense/controller/ExpenseController.java
@@ -1,7 +1,7 @@
 package com.poortorich.expense.controller;
 
 import com.poortorich.expense.facade.ExpenseFacade;
-import com.poortorich.expense.request.ExpenseDeleteRequest;
+import com.poortorich.accountbook.request.AccountBookDeleteRequest;
 import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.response.BaseResponse;
@@ -56,8 +56,8 @@ public class ExpenseController {
     public ResponseEntity<BaseResponse> deleteExpense(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long expenseId,
-            @RequestBody @Valid ExpenseDeleteRequest expenseDeleteRequest) {
-        return BaseResponse.toResponseEntity(expenseFacade.deleteExpense(expenseId, expenseDeleteRequest, userDetails.getUsername()));
+            @RequestBody @Valid AccountBookDeleteRequest accountBookDeleteRequest) {
+        return BaseResponse.toResponseEntity(expenseFacade.deleteExpense(expenseId, accountBookDeleteRequest, userDetails.getUsername()));
     }
 
     @GetMapping("/iteration/details")

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -10,7 +10,7 @@ import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.expense.entity.Expense;
-import com.poortorich.expense.request.ExpenseDeleteRequest;
+import com.poortorich.accountbook.request.AccountBookDeleteRequest;
 import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.expense.service.ExpenseService;
@@ -36,7 +36,6 @@ public class ExpenseFacade {
     private final CategoryService categoryService;
     private final IterationService iterationService;
     private final UserService userService;
-    // Change Service Layer
     private final AccountBookService accountBookService;
 
     @Transactional
@@ -72,21 +71,19 @@ public class ExpenseFacade {
     }
 
     @Transactional
-    public ExpenseResponse deleteExpense(Long expenseId, ExpenseDeleteRequest expenseDeleteRequest, String username) {
+    public ExpenseResponse deleteExpense(Long expenseId, AccountBookDeleteRequest accountBookDeleteRequest, String username) {
         User user = userService.findUserByUsername(username);
-        if (expenseDeleteRequest.parseIterationAction() == IterationAction.NONE) {
+        if (accountBookDeleteRequest.parseIterationAction() == IterationAction.NONE) {
             accountBookService.deleteAccountBook(expenseId, user, accountBookType);
-            // expenseService.deleteExpense(expenseId, user);
         }
 
-        if (expenseDeleteRequest.parseIterationAction() != IterationAction.NONE) {
+        if (accountBookDeleteRequest.parseIterationAction() != IterationAction.NONE) {
             AccountBook expenseToDelete = accountBookService.getAccountBookOrThrow(expenseId, user, accountBookType);
-//            Expense expenseToDelete = expenseService.getExpenseOrThrow(expenseId, user);
             accountBookService.deleteAccountBookAll(
                     iterationService.deleteIterations(
                             expenseToDelete,
                             user,
-                            expenseDeleteRequest.parseIterationAction(),
+                            accountBookDeleteRequest.parseIterationAction(),
                             accountBookType),
                     accountBookType
             );

--- a/src/main/java/com/poortorich/expense/service/ExpenseService.java
+++ b/src/main/java/com/poortorich/expense/service/ExpenseService.java
@@ -1,50 +1,13 @@
 package com.poortorich.expense.service;
 
-import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.entity.enums.PaymentMethod;
-import com.poortorich.expense.repository.ExpenseRepository;
-import com.poortorich.expense.request.ExpenseRequest;
-import com.poortorich.expense.response.ExpenseResponse;
-import com.poortorich.global.exceptions.NotFoundException;
-import com.poortorich.user.entity.User;
 import java.beans.Transient;
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class ExpenseService {
-
-    private final ExpenseRepository expenseRepository;
-
-    public Expense create(ExpenseRequest expenseRequest, Category category, User user) {
-        Expense expense = buildEntity(expenseRequest, category, user);
-        expenseRepository.save(expense);
-        return expense;
-    }
-
-    public List<Expense> createExpenseAll(List<Expense> expenses) {
-        return expenseRepository.saveAll(expenses);
-    }
-
-    protected Expense buildEntity(ExpenseRequest expenseRequest, Category category, User user) {
-        return Expense.builder()
-                .expenseDate(expenseRequest.parseDate())
-                .category(category)
-                .title(expenseRequest.trimTitle())
-                .cost(expenseRequest.getCost())
-                .paymentMethod(expenseRequest.parsePaymentMethod())
-                .memo(expenseRequest.getMemo())
-                .iterationType(expenseRequest.parseIterationType())
-                .user(user)
-                .build();
-    }
 
     @Transient
     public void modifyPaymentMethod(Expense expense, PaymentMethod paymentMethod) {
@@ -54,57 +17,5 @@ public class ExpenseService {
     @Transient
     public void modifyExpenseDate(Expense expense, LocalDate expenseDate) {
         expense.updateAccountBookDate(expenseDate);
-    }
-
-    public void deleteExpense(Long expenseId, User user) {
-        Expense expense = getExpenseOrThrow(expenseId, user);
-        expenseRepository.delete(expense);
-    }
-
-    public Expense getExpenseOrThrow(Long id, User user) {
-        return expenseRepository.findByIdAndUser(id, user)
-                .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
-    }
-
-    public void deleteExpenseAll(List<Expense> deleteExpenses) {
-        expenseRepository.deleteAll(deleteExpenses);
-    }
-
-    public List<Expense> getExpensesBetweenDates(User user, LocalDate startDate, LocalDate endDate) {
-        return Optional.of(expenseRepository.findByUserAndExpenseDateBetween(user, startDate, endDate))
-                .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
-    }
-
-    public Slice<Expense> getExpenseByUserAndCategoryWithinDateRangeWithCursor(
-            User user,
-            Category category,
-            LocalDate startDate,
-            LocalDate cursor,
-            LocalDate endDate,
-            Pageable pageable
-    ) {
-        return expenseRepository.findExpenseByUserAndCategoryWithinDateRangeWithCursor(
-                user,
-                category,
-                startDate,
-                cursor,
-                endDate,
-                pageable
-        );
-    }
-
-    public List<Expense> getExpenseByUserAndCategoryAndExpenseDate(
-            User user,
-            Category category,
-            LocalDate expenseDate) {
-        return expenseRepository.findByUserAndCategoryAndExpenseDate(
-                user,
-                category,
-                expenseDate
-        );
-    }
-
-    public Boolean hasNextPage(User user, Category category, LocalDate startDate, LocalDate endDate) {
-        return expenseRepository.countByUserAndCategoryBetweenDates(user, category, startDate, endDate) > 0;
     }
 }

--- a/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
+++ b/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
@@ -5,6 +5,7 @@ public class IncomeResponseMessages {
     public static final String CREATE_INCOME_SUCCESS = "수입 가계부를 성공적으로 등록하였습니다.";
     public static final String GET_INCOME_SUCCESS = "수입 가계부를 성공적으로 조회하였습니다.";
     public static final String MODIFY_INCOME_SUCCESS = "수입 가계부를 성공적으로 편집하였습니다.";
+    public static final String DELETE_INCOME_SUCCESS = "수입 가계부를 성공적으로 삭제하였습니다.";
 
     public static final String GET_INCOME_ITERATION_DETAILS_SUCCESS = "수입 반복 데이터들을 성공적으로 조회하였습니다.";
 

--- a/src/main/java/com/poortorich/income/controller/IncomeController.java
+++ b/src/main/java/com/poortorich/income/controller/IncomeController.java
@@ -1,5 +1,6 @@
 package com.poortorich.income.controller;
 
+import com.poortorich.accountbook.request.AccountBookDeleteRequest;
 import com.poortorich.global.response.BaseResponse;
 import com.poortorich.global.response.DataResponse;
 import com.poortorich.income.facade.IncomeFacade;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,6 +52,17 @@ public class IncomeController {
             @RequestBody @Valid IncomeRequest incomeRequest
     ) {
         return BaseResponse.toResponseEntity(incomeFacade.modifyIncome(userDetails.getUsername(), incomeId, incomeRequest));
+    }
+
+    @DeleteMapping("/{incomeId}")
+    public ResponseEntity<BaseResponse> deleteIncome(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long incomeId,
+            @RequestBody @Valid AccountBookDeleteRequest accountBookDeleteRequest
+            ) {
+        return BaseResponse.toResponseEntity(
+                incomeFacade.deleteIncome(userDetails.getUsername(), incomeId, accountBookDeleteRequest)
+        );
     }
 
     @GetMapping("/iteration/details")

--- a/src/main/java/com/poortorich/income/controller/IncomeController.java
+++ b/src/main/java/com/poortorich/income/controller/IncomeController.java
@@ -59,7 +59,7 @@ public class IncomeController {
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long incomeId,
             @RequestBody @Valid AccountBookDeleteRequest accountBookDeleteRequest
-            ) {
+    ) {
         return BaseResponse.toResponseEntity(
                 incomeFacade.deleteIncome(userDetails.getUsername(), incomeId, accountBookDeleteRequest)
         );

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -3,6 +3,7 @@ package com.poortorich.income.facade;
 import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.accountbook.enums.AccountBookType;
+import com.poortorich.accountbook.request.AccountBookDeleteRequest;
 import com.poortorich.accountbook.request.enums.IterationAction;
 import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.response.IterationDetailsResponse;
@@ -69,6 +70,28 @@ public class IncomeFacade {
         }
 
         return accountBookService.getInfoResponse(user, id, customIteration, accountBookType);
+    }
+
+    @Transactional
+    public IncomeResponse deleteIncome(String username, Long incomeId, AccountBookDeleteRequest accountBookDeleteRequest) {
+        User user = userService.findUserByUsername(username);
+        if (accountBookDeleteRequest.parseIterationAction() == IterationAction.NONE) {
+            accountBookService.deleteAccountBook(incomeId, user, accountBookType);
+        }
+
+        if (accountBookDeleteRequest.parseIterationAction() != IterationAction.NONE) {
+            AccountBook incomeToDelete = accountBookService.getAccountBookOrThrow(incomeId, user, accountBookType);
+            accountBookService.deleteAccountBookAll(
+                    iterationService.deleteIterations(
+                            incomeToDelete,
+                            user,
+                            accountBookDeleteRequest.parseIterationAction(),
+                            accountBookType),
+                    accountBookType
+            );
+        }
+
+        return IncomeResponse.DELETE_INCOME_SUCCESS;
     }
 
     @Transactional

--- a/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
+++ b/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
@@ -10,8 +10,8 @@ public enum IncomeResponse implements Response {
 
     CREATE_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.CREATE_INCOME_SUCCESS, null),
     GET_INCOME_SUCCESS(HttpStatus.OK, IncomeResponseMessages.GET_INCOME_SUCCESS, null),
-    MODIFY_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.MODIFY_INCOME_SUCCESS, null);
-    GET_INCOME_SUCCESS(HttpStatus.OK, IncomeResponseMessages.GET_INCOME_SUCCESS, null),
+    MODIFY_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.MODIFY_INCOME_SUCCESS, null),
+    DELETE_INCOME_SUCCESS(HttpStatus.OK, IncomeResponseMessages.DELETE_INCOME_SUCCESS, null),
 
     GET_INCOME_ITERATION_DETAILS_SUCCESS(HttpStatus.OK, IncomeResponseMessages.GET_INCOME_ITERATION_DETAILS_SUCCESS, null);
 

--- a/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/com/poortorich/expense/service/ExpenseServiceTest.java
@@ -1,9 +1,5 @@
 package com.poortorich.expense.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.Mockito.verify;
-
 import com.poortorich.category.entity.Category;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.expense.fixture.ExpenseFixture;
@@ -12,8 +8,6 @@ import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.expense.util.ExpenseRequestTestBuilder;
 import com.poortorich.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -46,23 +40,5 @@ public class ExpenseServiceTest {
         user = User.builder()
                 .username("test")
                 .build();
-    }
-
-    @Test
-    @DisplayName("유효한 지출 정보가 성공적으로 저장된다.")
-    void createValidExpense() {
-        expenseService.create(expenseRequest, category, user);
-
-        verify(expenseRepository).save(expenseCaptor.capture());
-        Expense savedExpense = expenseCaptor.getValue();
-        assertAll(
-                () -> assertThat(savedExpense.getExpenseDate()).isEqualTo(expenseRequest.getDate()),
-                () -> assertThat(savedExpense.getCategory()).isEqualTo(category),
-                () -> assertThat(savedExpense.getTitle()).isEqualTo(expenseRequest.getTitle()),
-                () -> assertThat(savedExpense.getCost()).isEqualTo(expenseRequest.getCost()),
-                () -> assertThat(savedExpense.getPaymentMethod()).isEqualTo(expenseRequest.parsePaymentMethod()),
-                () -> assertThat(savedExpense.getMemo()).isEqualTo(expenseRequest.getMemo()),
-                () -> assertThat(savedExpense.getIterationType()).isEqualTo(expenseRequest.parseIterationType())
-        );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#135 
 
 ## 📝작업 내용
 
- 수입 가계부 삭제 API 구현

## 🗂️ `accountbook`

### `AccountBookDeleteRequest`

- 삭제 Request 객체를 공통으로 사용하기 위해 추가
- 기존의 `ExpenseDeleteRequest`는 삭제

## 🗂️ `expense`

### 🛠️ `ExpenseController` `ExpenseFacade`

- `ExpenseDeleteRequest` 삭제, `AccountBookDeleteRequest` 사용에 따른 코드 수정

### 🛠️ `ExpenseService`

- `AccountBookService`로 로직을 이동함에 따라 사용하지 않게된 메서드 삭제

## 🗂️ `income`

- 수입 삭제 API 관련 코드 추가
 
 ### 스크린샷

<img width="599" alt="image" src="https://github.com/user-attachments/assets/0df49f4f-890e-4637-9bc1-30743a34e946" />
 
 ## 💬리뷰 요구사항

- 코드 컨벤션
