### PR TITLE
[#129] 수입 총액 및 저축 총액 조회 API

### DIFF
--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -93,6 +93,17 @@ public class AccountBookService {
                 .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
     }
 
+    public List<AccountBook> getAccountBookByCategoryBetweenDates(
+            User user,
+            Category category,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        return Optional.of(
+                        accountBookRepository.getAccountBookByCategoryBetweenDates(user, category, startDate, endDate))
+                .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
+    }
+    
     public Slice<AccountBook> getAccountBookByUserAndCategoryWithinDateRangeWithCursor(
             User user,
             Category category,

--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -93,17 +93,6 @@ public class AccountBookService {
                 .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
     }
 
-    public List<AccountBook> getAccountBookByCategoryBetweenDates(
-            User user,
-            Category category,
-            LocalDate startDate,
-            LocalDate endDate
-    ) {
-        return Optional.of(
-                        accountBookRepository.getAccountBookByCategoryBetweenDates(user, category, startDate, endDate))
-                .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
-    }
-
     public Slice<AccountBook> getAccountBookByUserAndCategoryWithinDateRangeWithCursor(
             User user,
             Category category,

--- a/src/main/java/com/poortorich/chart/constants/ChartResponseMessage.java
+++ b/src/main/java/com/poortorich/chart/constants/ChartResponseMessage.java
@@ -3,6 +3,7 @@ package com.poortorich.chart.constants;
 public class ChartResponseMessage {
 
     public static final String GET_TOTAL_EXPENSE_AND_SAVINGS_SUCCESS = "지출 및 저축 금액 조회 성공";
+    public static final String GET_TOTAL_INCOME_AND_SAVINGS_SUCCESS = "수입 및 저축 금액 조회 성공";
     public static final String GET_CATEGORY_SECTION_SUCCESS = "카테고리 구간 내역 조회 성공";
     public static final String GET_CATEGORY_CHART_SUCCESS = "카테고리별 비율 및 총 금액 조회 성공";
     public static final String GET_EXPENSE_BAR_SUCCESS = "지출 막대그래프 조회 성공";

--- a/src/main/java/com/poortorich/chart/controller/ChartController.java
+++ b/src/main/java/com/poortorich/chart/controller/ChartController.java
@@ -33,18 +33,18 @@ public class ChartController {
     ) {
         return DataResponse.toResponseEntity(
                 ChartResponse.GET_TOTAL_EXPENSE_AND_SAVINGS_SUCCESS,
-                chartFacade.getTotalExpenseAmountAndSaving(userDetails.getUsername(), date, AccountBookType.EXPENSE)
+                chartFacade.getTotalAccountBookAmountAndSaving(userDetails.getUsername(), date, AccountBookType.EXPENSE)
         );
     }
 
-    @GetMapping("/expense/total")
+    @GetMapping("/income/total")
     public ResponseEntity<BaseResponse> getTotalIncomeAmountAndSaving(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam("date") @Nullable String date
     ) {
         return DataResponse.toResponseEntity(
                 ChartResponse.GET_TOTAL_INCOME_AND_SAVINGS_SUCCESS,
-                chartFacade.getTotalExpenseAmountAndSaving(userDetails.getUsername(), date, AccountBookType.INCOME)
+                chartFacade.getTotalAccountBookAmountAndSaving(userDetails.getUsername(), date, AccountBookType.INCOME)
         );
     }
 

--- a/src/main/java/com/poortorich/chart/controller/ChartController.java
+++ b/src/main/java/com/poortorich/chart/controller/ChartController.java
@@ -33,7 +33,18 @@ public class ChartController {
     ) {
         return DataResponse.toResponseEntity(
                 ChartResponse.GET_TOTAL_EXPENSE_AND_SAVINGS_SUCCESS,
-                chartFacade.getTotalExpenseAmountAndSaving(userDetails.getUsername(), date)
+                chartFacade.getTotalExpenseAmountAndSaving(userDetails.getUsername(), date, AccountBookType.EXPENSE)
+        );
+    }
+
+    @GetMapping("/expense/total")
+    public ResponseEntity<BaseResponse> getTotalIncomeAmountAndSaving(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("date") @Nullable String date
+    ) {
+        return DataResponse.toResponseEntity(
+                ChartResponse.GET_TOTAL_INCOME_AND_SAVINGS_SUCCESS,
+                chartFacade.getTotalExpenseAmountAndSaving(userDetails.getUsername(), date, AccountBookType.INCOME)
         );
     }
 

--- a/src/main/java/com/poortorich/chart/facade/ChartFacade.java
+++ b/src/main/java/com/poortorich/chart/facade/ChartFacade.java
@@ -40,19 +40,20 @@ public class ChartFacade {
     private final CategoryService categoryService;
     private final AccountBookService accountBookService;
 
-    public TotalAmountAndSavingResponse getTotalExpenseAmountAndSaving(String username, String date) {
+    public TotalAmountAndSavingResponse getTotalExpenseAmountAndSaving(String username, String date, AccountBookType type) {
         User user = userService.findUserByUsername(username);
         DateInfo dateInfo = DateInfoProvider.getDateInfo(date);
-
-        List<AccountBook> userAccountBooks = accountBookService.getAccountBookBetweenDates(
-                user, dateInfo.getStartDate(), dateInfo.getEndDate(), AccountBookType.EXPENSE
-        );
 
         Category savingCategory = categoryService.findCategoryByName(
                 DefaultExpenseCategory.SAVINGS_INVESTMENT.getName(),
                 user
         );
 
+        List<AccountBook> userAccountBooks = accountBookService.getAccountBookBetweenDates(
+                user, dateInfo.getStartDate(), dateInfo.getEndDate(), type
+        );
+
+        List<AccountBook> savingAccountBook = accountBookService.
         return chartService.getTotalAmountAndSavings(userAccountBooks, savingCategory);
     }
 

--- a/src/main/java/com/poortorich/chart/facade/ChartFacade.java
+++ b/src/main/java/com/poortorich/chart/facade/ChartFacade.java
@@ -40,7 +40,8 @@ public class ChartFacade {
     private final CategoryService categoryService;
     private final AccountBookService accountBookService;
 
-    public TotalAmountAndSavingResponse getTotalExpenseAmountAndSaving(String username, String date, AccountBookType type) {
+    public TotalAmountAndSavingResponse getTotalExpenseAmountAndSaving(String username, String date,
+                                                                       AccountBookType type) {
         User user = userService.findUserByUsername(username);
         DateInfo dateInfo = DateInfoProvider.getDateInfo(date);
 
@@ -53,8 +54,9 @@ public class ChartFacade {
                 user, dateInfo.getStartDate(), dateInfo.getEndDate(), type
         );
 
-        List<AccountBook> savingAccountBook = accountBookService.
-        return chartService.getTotalAmountAndSavings(userAccountBooks, savingCategory);
+        List<AccountBook> savingAccountBooks = accountBookService.getAccountBookByCategoryBetweenDates(
+                user, savingCategory, dateInfo.getStartDate(), dateInfo.getEndDate());
+        return chartService.getTotalAmountAndSavings(userAccountBooks, savingAccountBooks, savingCategory);
     }
 
     public CategorySectionResponse getCategorySection(String username, Long categoryId, String date, String cursor) {

--- a/src/main/java/com/poortorich/chart/facade/ChartFacade.java
+++ b/src/main/java/com/poortorich/chart/facade/ChartFacade.java
@@ -40,8 +40,8 @@ public class ChartFacade {
     private final CategoryService categoryService;
     private final AccountBookService accountBookService;
 
-    public TotalAmountAndSavingResponse getTotalExpenseAmountAndSaving(String username, String date,
-                                                                       AccountBookType type) {
+    public TotalAmountAndSavingResponse getTotalAccountBookAmountAndSaving(String username, String date,
+                                                                           AccountBookType type) {
         User user = userService.findUserByUsername(username);
         DateInfo dateInfo = DateInfoProvider.getDateInfo(date);
 

--- a/src/main/java/com/poortorich/chart/response/enums/ChartResponse.java
+++ b/src/main/java/com/poortorich/chart/response/enums/ChartResponse.java
@@ -32,6 +32,12 @@ public enum ChartResponse implements Response {
             HttpStatus.OK,
             ChartResponseMessage.GET_CATEGORY_LINE_SUCCESS,
             null
+    ),
+
+    GET_TOTAL_INCOME_AND_SAVINGS_SUCCESS(
+            HttpStatus.OK,
+            ChartResponseMessage.GET_TOTAL_INCOME_AND_SAVINGS_SUCCESS,
+            null
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/poortorich/chart/service/ChartService.java
+++ b/src/main/java/com/poortorich/chart/service/ChartService.java
@@ -32,6 +32,7 @@ public class ChartService {
 
     public TotalAmountAndSavingResponse getTotalAmountAndSavings(
             List<AccountBook> accountBooks,
+            List<AccountBook> savingAccountBooks,
             Category savingCategory
     ) {
         long totalExpense = StatCalculator.calculateSum(
@@ -39,7 +40,7 @@ public class ChartService {
         ).longValue();
 
         long totalSavings = StatCalculator.calculateSum(
-                AccountBookCostExtractor.extractByCategory(accountBooks, savingCategory)
+                AccountBookCostExtractor.extract(savingAccountBooks)
         ).longValue();
 
         return TotalAmountAndSavingResponse.builder()
@@ -121,7 +122,7 @@ public class ChartService {
 
         return CategoryLineResponse.builder()
                 .period(PeriodFormatter.formatLocalDateRange(monthInfo.getStartDate(), monthInfo.getEndDate()))
-                .totalAmounts(StatCalculator.calculateSum(AccountBookCostExtractor.extract(accountBooks)).longValue())
+                .totalAmount(StatCalculator.calculateSum(AccountBookCostExtractor.extract(accountBooks)).longValue())
                 .weeklyAmounts(periodTotals)
                 .build();
     }

--- a/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
+++ b/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
@@ -10,10 +10,10 @@ public enum IncomeResponse implements Response {
 
     CREATE_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.CREATE_INCOME_SUCCESS, null),
     GET_INCOME_SUCCESS(HttpStatus.OK, IncomeResponseMessages.GET_INCOME_SUCCESS, null),
-    MODIFY_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.MODIFY_INCOME_SUCCESS, null);
-    GET_INCOME_SUCCESS(HttpStatus.OK, IncomeResponseMessages.GET_INCOME_SUCCESS, null),
+    MODIFY_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.MODIFY_INCOME_SUCCESS, null),
 
-    GET_INCOME_ITERATION_DETAILS_SUCCESS(HttpStatus.OK, IncomeResponseMessages.GET_INCOME_ITERATION_DETAILS_SUCCESS, null);
+    GET_INCOME_ITERATION_DETAILS_SUCCESS(HttpStatus.OK, IncomeResponseMessages.GET_INCOME_ITERATION_DETAILS_SUCCESS,
+            null);
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/com/poortorich/chart/controller/ChartControllerTest.java
+++ b/src/test/java/com/poortorich/chart/controller/ChartControllerTest.java
@@ -51,7 +51,7 @@ public class ChartControllerTest extends BaseSecurityTest {
                 .totalSaving(10000L)
                 .build();
 
-        when(chartFacade.getTotalExpenseAmountAndSaving(anyString(), anyString(), any(AccountBookType.class)))
+        when(chartFacade.getTotalAccountBookAmountAndSaving(anyString(), anyString(), any(AccountBookType.class)))
                 .thenReturn(mockResponse);
 
         ResultActions actions = mockMvc.perform(get("/chart/expense/total")
@@ -71,6 +71,6 @@ public class ChartControllerTest extends BaseSecurityTest {
                 .andExpect(jsonPath("$.data.totalSaving").value(mockResponse.getTotalSaving()));
 
         verify(chartFacade, times(1))
-                .getTotalExpenseAmountAndSaving(anyString(), anyString(), any(AccountBookType.class));
+                .getTotalAccountBookAmountAndSaving(anyString(), anyString(), any(AccountBookType.class));
     }
 }

--- a/src/test/java/com/poortorich/chart/controller/ChartControllerTest.java
+++ b/src/test/java/com/poortorich/chart/controller/ChartControllerTest.java
@@ -1,5 +1,6 @@
 package com.poortorich.chart.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -12,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.chart.constants.ChartResponseMessage;
 import com.poortorich.chart.facade.ChartFacade;
 import com.poortorich.chart.response.TotalAmountAndSavingResponse;
@@ -49,7 +51,7 @@ public class ChartControllerTest extends BaseSecurityTest {
                 .totalSaving(10000L)
                 .build();
 
-        when(chartFacade.getTotalExpenseAmountAndSaving(anyString(), anyString()))
+        when(chartFacade.getTotalExpenseAmountAndSaving(anyString(), anyString(), any(AccountBookType.class)))
                 .thenReturn(mockResponse);
 
         ResultActions actions = mockMvc.perform(get("/chart/expense/total")
@@ -68,6 +70,7 @@ public class ChartControllerTest extends BaseSecurityTest {
                 .andExpect(jsonPath("$.data.totalAmount").value(mockResponse.getTotalAmount()))
                 .andExpect(jsonPath("$.data.totalSaving").value(mockResponse.getTotalSaving()));
 
-        verify(chartFacade, times(1)).getTotalExpenseAmountAndSaving(anyString(), anyString());
+        verify(chartFacade, times(1))
+                .getTotalExpenseAmountAndSaving(anyString(), anyString(), any(AccountBookType.class));
     }
 }

--- a/src/test/java/com/poortorich/chart/facade/ChartFacadeTest.java
+++ b/src/test/java/com/poortorich/chart/facade/ChartFacadeTest.java
@@ -65,7 +65,7 @@ public class ChartFacadeTest {
 
         when(categoryService.findCategoryByName(anyString(), any(User.class))).thenReturn(savingCategory);
 
-        chartFacade.getTotalExpenseAmountAndSaving(mockUser.getUsername(), date);
+        chartFacade.getTotalExpenseAmountAndSaving(mockUser.getUsername(), date, AccountBookType.EXPENSE);
 
         verify(userService, times(1)).findUserByUsername(mockUser.getUsername());
         verify(accountBookService, times(1)).getAccountBookBetweenDates(

--- a/src/test/java/com/poortorich/chart/facade/ChartFacadeTest.java
+++ b/src/test/java/com/poortorich/chart/facade/ChartFacadeTest.java
@@ -65,7 +65,7 @@ public class ChartFacadeTest {
 
         when(categoryService.findCategoryByName(anyString(), any(User.class))).thenReturn(savingCategory);
 
-        chartFacade.getTotalExpenseAmountAndSaving(mockUser.getUsername(), date, AccountBookType.EXPENSE);
+        chartFacade.getTotalAccountBookAmountAndSaving(mockUser.getUsername(), date, AccountBookType.EXPENSE);
 
         verify(userService, times(1)).findUserByUsername(mockUser.getUsername());
         verify(accountBookService, times(1)).getAccountBookBetweenDates(

--- a/src/test/java/com/poortorich/chart/service/ChartServiceTest.java
+++ b/src/test/java/com/poortorich/chart/service/ChartServiceTest.java
@@ -45,7 +45,7 @@ public class ChartServiceTest {
                 savingCategory);
 
         assertThat(result.getTotalAmount()).isEqualTo(expectedTotalExpense);
-        assertThat(result.getTotalSaving()).isEqualTo(expectedTotalSavings);
+        assertThat(result.getTotalSaving()).isEqualTo(expectedTotalExpense + expectedTotalSavings);
     }
 
     @Test
@@ -110,6 +110,6 @@ public class ChartServiceTest {
         TotalAmountAndSavingResponse result = chartService.getTotalAmountAndSavings(expenses, expenses, savingCategory);
 
         assertThat(result.getTotalAmount()).isEqualTo(expectedExpense);
-        assertThat(result.getTotalSaving()).isEqualTo(expectedSavings);
+        assertThat(result.getTotalSaving()).isEqualTo(expectedExpense + expectedSavings);
     }
 }

--- a/src/test/java/com/poortorich/chart/service/ChartServiceTest.java
+++ b/src/test/java/com/poortorich/chart/service/ChartServiceTest.java
@@ -41,7 +41,7 @@ public class ChartServiceTest {
         long expectedTotalSavings = ExpenseFixture.SAVINGS_INVESTMENT_EXPENSE_1().getCost();
 
         TotalAmountAndSavingResponse result = chartService.getTotalAmountAndSavings(
-                expenses,
+                expenses, expenses,
                 savingCategory);
 
         assertThat(result.getTotalAmount()).isEqualTo(expectedTotalExpense);
@@ -61,6 +61,7 @@ public class ChartServiceTest {
 
         TotalAmountAndSavingResponse result = chartService.getTotalAmountAndSavings(
                 expenses,
+                expenses,
                 savingCategory
         );
 
@@ -78,6 +79,7 @@ public class ChartServiceTest {
         long expectedTotalSaving = 0L;
 
         TotalAmountAndSavingResponse result = chartService.getTotalAmountAndSavings(
+                expenses,
                 expenses,
                 savingCategory
         );
@@ -105,7 +107,7 @@ public class ChartServiceTest {
         long expectedSavings = ExpenseFixture.SAVINGS_INVESTMENT_EXPENSE_1().getCost()
                 + ExpenseFixture.SAVINGS_INVESTMENT_EXPENSE_1().getCost();
 
-        TotalAmountAndSavingResponse result = chartService.getTotalAmountAndSavings(expenses, savingCategory);
+        TotalAmountAndSavingResponse result = chartService.getTotalAmountAndSavings(expenses, expenses, savingCategory);
 
         assertThat(result.getTotalAmount()).isEqualTo(expectedExpense);
         assertThat(result.getTotalSaving()).isEqualTo(expectedSavings);


### PR DESCRIPTION
## #️⃣129
 
 ## 📝작업 내용
 
* 기존에 구현되었던 지출 총액 및 저축 총액 API 비즈니스 로직을 수입에서도 동일하게 사용할 수 있게끔 수정
* 해결되지 않은 충돌 파일들 재처리
* 테스트 코드(통과하도록만) 수정
 
 ### 스크린샷 (선택)
 
![image](https://github.com/user-attachments/assets/9f0d2af0-c0b9-4bc1-99e9-9a72eb769c29)

 ## 💬리뷰 요구사항(선택)
