### PR TITLE
[#138] 카테고리 이름 중복 검사 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/category/entity/enums/CategoryType.java
+++ b/src/main/java/com/poortorich/category/entity/enums/CategoryType.java
@@ -5,6 +5,7 @@ import com.poortorich.global.exceptions.BadRequestException;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 @RequiredArgsConstructor
@@ -22,6 +23,12 @@ public enum CategoryType {
                 .filter(category -> Objects.equals(category.type, type))
                 .findFirst()
                 .orElseThrow(() -> new BadRequestException(CategoryResponse.CATEGORY_TYPE_INVALID));
+    }
+
+    public List<CategoryType> getSameGroupTypes() {
+        return Arrays.stream(CategoryType.values())
+                .filter(category -> Objects.equals(category.type, this.type))
+                .toList();
     }
 }
 

--- a/src/main/java/com/poortorich/category/repository/CategoryRepository.java
+++ b/src/main/java/com/poortorich/category/repository/CategoryRepository.java
@@ -3,8 +3,10 @@ package com.poortorich.category.repository;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.user.entity.User;
+
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,6 +16,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByIdAndUser(Long id, User user);
 
     Optional<Category> findByNameAndUser(String name, User user);
+
+    Optional<Category> findByUserAndNameAndTypeIn(User user, String name, List<CategoryType> type);
 
     List<Category> findByTypeAndUser(CategoryType type, User user);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#138 
 
 ## 📝작업 내용
 
- 카테고리 이름 중복 검사를 하는 로직 수정
> 원래는 이름과 유저 정보만을 가지고 카테고리를 찾는 `findCategoryByName()` 메서드를 사용하여 이름 중복을 검사했습니다. 이 경우 다른 가계부 타입일 경우에도 이름이 중복되면 예외 응답을 던지는 이슈가 발생했습니다. 
> 그 문제를 해결하기 위해 카테고리 이름 중복 검사를 하는 새로운 메서드를 추가로 구현하였습니다.

## `CategoryType`

### `getSameGroupTypes()`

- 같은 타입인 것들을 List로 묶어 반환
   > expense => DEFAULT_EXPENSE, CUSTOM_EXPENSE
   > income => DEFAULT_INCOME, CUSTOM_INCOME
 
## `CategotyRepository`

### `findByUserAndNameAndTypeIn()`

- `CategotyType` 리스트에 있는 타입인 카테고리 중 같은 이름이 있는 경우 카테고리값 반환

## `CategoryService`

### 🔥 `validateCategoryNameDuplication()`

- 카테고리 이름이 중복인지 검증하는 메서드
- user, name, type 값을 기반으로 카테고리 이름이 중복이라면 `BadRequest` 예외 발생

### 🛠️ `createCategory()` `modifyCategory()`

 - `validateCategoryNameDuplication()` 메서드를 사용하여 카테고리 이름 중복 검증을 진행하도록 수정

 ### 스크린샷

![image](https://github.com/user-attachments/assets/a7342af4-d199-4761-981e-ffed1fd7c084)

> 지출에서 사용중인 카테고리 이름이지만 수입에서 생성하는 경우 예외 발생없이 생성 완료
![image](https://github.com/user-attachments/assets/b163319e-0888-495b-9231-3f9aa3c8d341)

 
 ## 💬리뷰 요구사항
 
- 코드 컨벤션 및 네이밍