### PR TITLE
[#156] 이메일 인증 로직에서 이메일 중복 확인 추가

### DIFF
--- a/src/main/java/com/poortorich/email/facade/EmailFacade.java
+++ b/src/main/java/com/poortorich/email/facade/EmailFacade.java
@@ -11,6 +11,7 @@ import com.poortorich.email.service.MailService;
 import com.poortorich.email.util.EmailVerificationPolicyManager;
 import com.poortorich.email.util.VerificationCodeGenerator;
 import com.poortorich.global.response.Response;
+import com.poortorich.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,9 +25,13 @@ public class EmailFacade {
     private final VerificationCodeGenerator codeGenerator;
     private final EmailVerificationPolicyManager verificationPolicyManager;
 
+    private final UserValidator userValidator;
+
     @Transactional
     public Response sendVerificationCode(EmailVerificationRequest emailVerificationRequest) {
         String email = emailVerificationRequest.getEmail();
+        userValidator.validateEmailDuplicate(email);
+        
         String verificationPurpose = emailVerificationRequest.getPurpose();
         String verificationCode = codeGenerator.generate();
 


### PR DESCRIPTION
## #️⃣156
 
 ## 📝작업 내용
 프론트 요청에 따라 이메일 인증 코드 전송 로직에서 중복을 확인하는 로직을 추가했습니다.
