### PR TITLE
[#158] 요청 시 쿠키 누락 문제 해결

### DIFF
--- a/src/main/java/com/poortorich/auth/jwt/constants/JwtConstants.java
+++ b/src/main/java/com/poortorich/auth/jwt/constants/JwtConstants.java
@@ -16,7 +16,7 @@ public class JwtConstants {
     public static final int REFRESH_TOKEN_COOKIE_EXPIRY = 7 * 24 * 60 * 60;
     public static final String COOKIE_SAME_SITE = "None";
     public static final String ACCESS_TOKEN_COOKIE_PATH = "/";
-    public static final String REFRESH_TOKEN_COOKIE_PATH = "/user/refresh";
+    public static final String REFRESH_TOKEN_COOKIE_PATH = "/auth/refresh";
 
     public static final String TOKEN_ISSUER = "poorToRich";
     public static final String TOKEN_AUDIENCE = "poorToRich-Users";


### PR DESCRIPTION
## #️⃣158
 
 ## 📝작업 내용
 프론트엔드에서 **AccessToken 재발급 API**를 호출하는 과정에서 쿠키가 포함되지 않아 `401 Unauthorized` 응답이 발생한 것으로 확인되었습니다.  쿠키의 `HTTPS` 설정에서 문제가 생긴 것으로 판단하여 수정 작업을 착수했지만 실제 원인은 다른 부분에서 발견했습니다. 쿠키의 `path` 필드에 다른 `endpoint`를 기입하여 문제가 발생한 것임을 파악했습니다.

수정 후 테스트 결과 `200 OK` 응답을 받았습니다.

 ### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d4804f1f-bf16-42e5-bd39-7ebd0cc08728)
 
