### PR TITLE
[#166] 기본 카테고리 조회 응답 필드 추가

### DIFF
--- a/src/main/java/com/poortorich/category/response/DefaultCategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/DefaultCategoryResponse.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DefaultCategoryResponse {
 
+    private Long id;
     private String color;
     private String name;
     private boolean visibility;

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -33,6 +33,7 @@ public class CategoryService {
     public List<DefaultCategoryResponse> getDefaultCategories(CategoryType type, String username) {
         return categoryRepository.findByTypeAndUser(type, userService.findUserByUsername(username)).stream()
                 .map(category -> DefaultCategoryResponse.builder()
+                        .id(category.getId())
                         .name(category.getName())
                         .color(category.getColor())
                         .visibility(category.getVisibility())


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#166 
 
 ## 📝작업 내용

- 기본 카테고리 조회 API에 사용되는 응답에 ID 필드 추가
 
 ### 스크린샷

![image](https://github.com/user-attachments/assets/1cd18e9d-24a1-49eb-adc9-57bfaf14e8f4)
 
 ## 💬리뷰 요구사항
