### PR TITLE
[#168] 활성화된 카테고리 목록 조회 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/category/repository/CategoryRepository.java
+++ b/src/main/java/com/poortorich/category/repository/CategoryRepository.java
@@ -19,7 +19,9 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByUserAndNameAndTypeIn(User user, String name, List<CategoryType> type);
 
-    List<Category> findByTypeAndUser(CategoryType type, User user);
+    List<Category> findByUserAndType(User user, CategoryType type);
+
+    List<Category> findByUserAndTypeIn(User user, List<CategoryType> types);
 
     void deleteByUserAndType(User user, CategoryType type);
 }

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -31,7 +31,7 @@ public class CategoryService {
     private final UserService userService;
 
     public List<DefaultCategoryResponse> getDefaultCategories(CategoryType type, String username) {
-        return categoryRepository.findByTypeAndUser(type, userService.findUserByUsername(username)).stream()
+        return categoryRepository.findByUserAndType(userService.findUserByUsername(username), type).stream()
                 .map(category -> DefaultCategoryResponse.builder()
                         .name(category.getName())
                         .color(category.getColor())
@@ -41,7 +41,7 @@ public class CategoryService {
     }
 
     public List<CustomCategoryResponse> getCustomCategories(CategoryType type, String username) {
-        return categoryRepository.findByTypeAndUser(type, userService.findUserByUsername(username)).stream()
+        return categoryRepository.findByUserAndType(userService.findUserByUsername(username), type).stream()
                 .map(category -> CustomCategoryResponse.builder()
                         .id(category.getId())
                         .color(category.getColor())
@@ -52,8 +52,10 @@ public class CategoryService {
 
     public ActiveCategoriesResponse getActiveCategories(String type, String username) {
         List<String> categories
-                = categoryRepository.findByTypeAndUser(CategoryType.from(type),
-                        userService.findUserByUsername(username)).stream()
+                = categoryRepository.findByUserAndTypeIn(
+                        userService.findUserByUsername(username),
+                        CategoryType.from(type).getSameGroupTypes())
+                .stream()
                 .filter(Category::getVisibility)
                 .map(Category::getName)
                 .toList();


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#168 
 
 ## 📝작업 내용
 
- 활성화된 카테고리 목록 조회 로직 수정

## `CategoryRepository`
 
### `findByUserAndTypeIn`

- CategoryType 리스트 안의 값과 같은 카테고리를 조회하는 메서드

### 🛠️ `findByUserAndType`

- `User`과 `Type` 순서 변경

 ### 스크린샷

<img width="884" alt="image" src="https://github.com/user-attachments/assets/b180950c-0f5f-4c20-8b25-a327c4bb4dce" />
