### PR TITLE
[#172] 존재하지 않는 수입 가계부 응답 수정

### DIFF
--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -13,6 +13,7 @@ import com.poortorich.category.entity.Category;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.global.statistics.util.StatCalculator;
+import com.poortorich.income.response.enums.IncomeResponse;
 import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
@@ -164,7 +165,13 @@ public class AccountBookService {
 
     public AccountBook getAccountBookOrThrow(Long id, User user, AccountBookType type) {
         return accountBookRepository.findByIdAndUser(id, user, type)
-                .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
+                .orElseThrow(() -> {
+                    if (type == AccountBookType.EXPENSE) {
+                        return new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT);
+                    }
+                    
+                    return new NotFoundException(IncomeResponse.INCOME_NON_EXISTENT);
+                });
     }
 
     public IterationDetailsResponse getIterationDetails(User user, List<Long> originalAccountBookIds,

--- a/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
+++ b/src/main/java/com/poortorich/income/constants/IncomeResponseMessages.java
@@ -9,6 +9,8 @@ public class IncomeResponseMessages {
 
     public static final String GET_INCOME_ITERATION_DETAILS_SUCCESS = "수입 반복 데이터들을 성공적으로 조회하였습니다.";
 
+    public static final String INCOME_NON_EXISTENT = "존재하지 않는 수입입니다.";
+
     private IncomeResponseMessages() {
     }
 }

--- a/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
+++ b/src/main/java/com/poortorich/income/response/enums/IncomeResponse.java
@@ -13,7 +13,9 @@ public enum IncomeResponse implements Response {
     MODIFY_INCOME_SUCCESS(HttpStatus.CREATED, IncomeResponseMessages.MODIFY_INCOME_SUCCESS, null),
     DELETE_INCOME_SUCCESS(HttpStatus.OK, IncomeResponseMessages.DELETE_INCOME_SUCCESS, null),
     GET_INCOME_ITERATION_DETAILS_SUCCESS(HttpStatus.OK, IncomeResponseMessages.GET_INCOME_ITERATION_DETAILS_SUCCESS,
-            null);
+            null),
+
+    INCOME_NON_EXISTENT(HttpStatus.NOT_FOUND, IncomeResponseMessages.INCOME_NON_EXISTENT, "incomeId");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#172 
 
 ## 📝작업 내용

- `getAccountBookOrThrow()` 메서드에서 가계부 조회에 실패한 경우 `AccountBookType`에 따라 응답을 다르게 반환하도록 수정
 
 ### 스크린샷

<img width="880" alt="image" src="https://github.com/user-attachments/assets/5a579bc5-5acb-46a7-8536-d1e6a36e6bd3" />

<img width="882" alt="image" src="https://github.com/user-attachments/assets/5583a657-3b1f-4390-8a0e-7e8cbdead073" />

 ## 💬리뷰 요구사항
