### PR TITLE
[#184] 중복 검증 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/user/service/UserValidationService.java
+++ b/src/main/java/com/poortorich/user/service/UserValidationService.java
@@ -3,7 +3,6 @@ package com.poortorich.user.service;
 import com.poortorich.email.response.enums.EmailResponse;
 import com.poortorich.email.util.EmailVerificationPolicyManager;
 import com.poortorich.global.exceptions.BadRequestException;
-import com.poortorich.global.exceptions.ConflictException;
 import com.poortorich.global.exceptions.ForbiddenException;
 import com.poortorich.user.request.PasswordUpdateRequest;
 import com.poortorich.user.request.ProfileUpdateRequest;
@@ -48,16 +47,10 @@ public class UserValidationService {
 
     public void validateCheckUsername(String username) {
         userValidator.validateUsernameDuplicate(username);
-        if (userReservationService.existsByUsername(username)) {
-            throw new ConflictException(UserResponse.USERNAME_DUPLICATE);
-        }
     }
 
     public void validateCheckNickname(String nickname) {
         userValidator.validateNicknameDuplicate(nickname);
-        if (userReservationService.existsByNickname(nickname)) {
-            throw new ConflictException(UserResponse.NICKNAME_DUPLICATE);
-        }
     }
 
     public void validateUpdateUserProfile(String username, ProfileUpdateRequest userProfile) {


### PR DESCRIPTION
## #️⃣184
 
 ## 📝작업 내용
레디스를 삭제하는 대신 이미 예약되어있는 닉네임, 아이디가 있는지 검사하는 로직을 삭제

* 중복 검사 로직을 이전에 수행했었는지 가능함
* 직전에 중복 검사했던 닉네임, 아이디를 다시 사용할 수 있음



