### PR TITLE
[#178] 주별 수입/지출 상세내역 수정

### DIFF
--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -19,6 +19,7 @@ import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.user.entity.User;
 import java.beans.Transient;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -135,9 +136,9 @@ public class AccountBookService {
             Pageable pageable,
             AccountBookType type
     ) {
-        return accountBookRepository.findByUserWithinDateRangeWithCursor(
+        return Optional.ofNullable(accountBookRepository.findByUserWithinDateRangeWithCursor(
                 user, startDate, endDate, cursor, pageable, type
-        );
+        )).orElseGet(() -> new SliceImpl<>(Collections.emptyList(), pageable, false));
     }
 
     public List<AccountBook> getAccountBooksByUserAndCategoryAndAccountBookDate(
@@ -152,7 +153,8 @@ public class AccountBookService {
             LocalDate accountBookDate,
             AccountBookType type
     ) {
-        return accountBookRepository.findByUserAndDate(user, accountBookDate, type);
+        return Optional.ofNullable(accountBookRepository.findByUserAndDate(user, accountBookDate, type))
+                .orElse(Collections.emptyList());
     }
 
     public Boolean hasNextPage(User user, Category category, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/poortorich/chart/util/PeriodFormatter.java
+++ b/src/main/java/com/poortorich/chart/util/PeriodFormatter.java
@@ -1,14 +1,20 @@
 package com.poortorich.chart.util;
 
+import com.poortorich.global.date.constants.DatePattern;
+
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.format.DateTimeFormatter;
 
 public class PeriodFormatter {
 
-    private static final DateTimeFormatter DOT_DATE_FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
-    private static final DateTimeFormatter DOT_MONTH_DAY_FORMATTER = DateTimeFormatter.ofPattern("MM.dd");
+    private static final DateTimeFormatter DOT_DATE_FORMATTER
+            = DateTimeFormatter.ofPattern(DatePattern.LOCAL_DATE_DOT_PATTERN);
+    private static final DateTimeFormatter DOT_MONTH_DAY_FORMATTER
+            = DateTimeFormatter.ofPattern(DatePattern.MONTH_DAY_DOT_PATTERN);
+
     private static final String TILDE_DATE_RANGE_SEPARATOR = "~";
+    private static final String TILDE_DATE_RANGE_SEPARATOR_WITH_SPACE = " ~ ";
     private static final String MONTH_KOREAN_SUFFIX = "월";
 
     public static String formatLocalDateRange(LocalDate startDate, LocalDate endDate) {
@@ -21,6 +27,12 @@ public class PeriodFormatter {
         return startDate.format(DOT_MONTH_DAY_FORMATTER)
                 + TILDE_DATE_RANGE_SEPARATOR
                 + endDate.format(DOT_MONTH_DAY_FORMATTER);
+    }
+
+    public static String formatWeeklyReportRange(LocalDate startDate, LocalDate endDate) {
+        return startDate.format(DOT_DATE_FORMATTER)
+                + TILDE_DATE_RANGE_SEPARATOR_WITH_SPACE
+                + endDate.format(DOT_DATE_FORMATTER);
     }
 
     public static String formatMonthKorean(Month currentMonth) {

--- a/src/main/java/com/poortorich/report/facade/ReportFacade.java
+++ b/src/main/java/com/poortorich/report/facade/ReportFacade.java
@@ -91,7 +91,7 @@ public class ReportFacade {
 
         String startDateString = startDate.format(DateTimeFormatter.ofPattern(DatePattern.LOCAL_DATE_DOT_PATTERN));
         String endDateString = endDate.format(DateTimeFormatter.ofPattern(DatePattern.LOCAL_DATE_DOT_PATTERN));
-        String period = startDateString + " - " + endDateString;
+        String period = startDateString + " ~ " + endDateString;
 
         LocalDate nextCursor = getNextCursor(accountBooksByLastDate, endDate);
         Boolean hasNext = accountBookService.hasNextPage(user, nextCursor, endDate);

--- a/src/main/java/com/poortorich/report/facade/ReportFacade.java
+++ b/src/main/java/com/poortorich/report/facade/ReportFacade.java
@@ -4,6 +4,7 @@ import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.accountbook.util.AccountBookCostExtractor;
+import com.poortorich.chart.util.PeriodFormatter;
 import com.poortorich.global.date.constants.DateConstants;
 import com.poortorich.global.date.constants.DatePattern;
 import com.poortorich.global.date.domain.MonthInformation;
@@ -89,14 +90,12 @@ public class ReportFacade {
         List<AccountBook> weeklyAccountBooks
                 = reportService.mergeAccountBookDistinct(mergeSliceAccountBooks, accountBooksByLastDate);
 
-        String startDateString = startDate.format(DateTimeFormatter.ofPattern(DatePattern.LOCAL_DATE_DOT_PATTERN));
-        String endDateString = endDate.format(DateTimeFormatter.ofPattern(DatePattern.LOCAL_DATE_DOT_PATTERN));
-        String period = startDateString + " ~ " + endDateString;
-
         LocalDate nextCursor = getNextCursor(accountBooksByLastDate, endDate);
         Boolean hasNext = accountBookService.hasNextPage(user, nextCursor, endDate);
 
-        return reportService.getWeeklyDetailsReport(weeklyAccountBooks, period, nextCursor, hasNext);
+        return reportService.getWeeklyDetailsReport(
+                weeklyAccountBooks, PeriodFormatter.formatWeeklyReportRange(startDate, endDate), nextCursor, hasNext
+        );
     }
 
     private List<AccountBook> getAccountBooksByLastDate(

--- a/src/main/java/com/poortorich/report/service/ReportService.java
+++ b/src/main/java/com/poortorich/report/service/ReportService.java
@@ -6,6 +6,7 @@ import com.poortorich.accountbook.response.AccountBookInfoResponse;
 import com.poortorich.accountbook.util.AccountBookBuilder;
 import com.poortorich.accountbook.util.AccountBookCostExtractor;
 import com.poortorich.chart.util.AccountBookUtil;
+import com.poortorich.chart.util.PeriodFormatter;
 import com.poortorich.global.date.constants.DatePattern;
 import com.poortorich.global.statistics.util.StatCalculator;
 import com.poortorich.report.response.DailyDetailsResponse;
@@ -154,12 +155,8 @@ public class ReportService {
         Long totalIncome = StatCalculator.calculateSum(AccountBookCostExtractor.extract(monthlyIncomes)).longValue();
         Long totalExpense = StatCalculator.calculateSum(AccountBookCostExtractor.extract(monthlyExpenses)).longValue();
 
-        String startDateString = startDate.format(DateTimeFormatter.ofPattern(DatePattern.MONTH_DAY_DOT_PATTERN));
-        String endDateString = endDate.format(DateTimeFormatter.ofPattern(DatePattern.MONTH_DAY_DOT_PATTERN));
-        String period = startDateString + "~" + endDateString;
-
         return Logs.builder()
-                .period(period)
+                .period(PeriodFormatter.formatMonthDayRange(startDate, endDate))
                 .totalIncome(totalIncome)
                 .totalExpense(totalExpense)
                 .totalAmount(totalIncome - totalExpense)

--- a/src/main/java/com/poortorich/report/service/ReportService.java
+++ b/src/main/java/com/poortorich/report/service/ReportService.java
@@ -79,6 +79,7 @@ public class ReportService {
 
         Long totalIncome = 0L;
         Long totalExpense = 0L;
+        Long countOfLogs = 0L;
         for(AccountBook accountBook : weeklyAccountBooks) {
             if (inferAccountBookType(accountBook) == AccountBookType.EXPENSE) {
                 totalExpense += accountBook.getCost();
@@ -86,6 +87,7 @@ public class ReportService {
             else {
                 totalIncome += accountBook.getCost();
             }
+            countOfLogs++;
         }
 
         return WeeklyDetailsResponse.builder()
@@ -93,7 +95,7 @@ public class ReportService {
                 .totalIncome(totalIncome)
                 .totalExpense(totalExpense)
                 .totalAmount(totalIncome - totalExpense)
-                .countOfLogs((long) dailyTransactions.size())
+                .countOfLogs(countOfLogs)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor.toString())
                 .dailyDetails(dailyTransactions)


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#178 
 
 ## 📝작업 내용

- 조회 에러 수정
   해당 주차에 데이터가 없는 경우 정상적인 응답을 반환하도록 예외 처리
- countOfLogs 값 수정
   해당 기간에 존재하는 모든 가계부의 개수 값을 반환하도록 수정
- period 문자열 수정
   ` - ` -> ` ~ ` 로 수정
 
 ### 스크린샷

> 해당 주차에 데이터가 없는 경우 응답
> <img width="879" alt="image" src="https://github.com/user-attachments/assets/7e1c4ef2-4652-4b22-aaab-19be84f92cba" />

<img width="883" alt="image" src="https://github.com/user-attachments/assets/b52af84d-d8fc-4452-b471-3eb85b0f8d36" />
