### PR TITLE
[#189] 기본 지출 카테고리 이름 오타 수정

### DIFF
--- a/src/main/java/com/poortorich/category/domain/model/enums/DefaultExpenseCategory.java
+++ b/src/main/java/com/poortorich/category/domain/model/enums/DefaultExpenseCategory.java
@@ -14,7 +14,7 @@ public enum DefaultExpenseCategory {
     FOOD("식비", "#7ED321"),
     TRANSPORTATION("교통비", "#F5A623"),
     SHOPPING("쇼핑", "#FF6F61"),
-    HEALTH_MEDICAL("건상/의료", "#50E3C2"),
+    HEALTH_MEDICAL("건강/의료", "#50E3C2"),
     EDUCATION("교육", "#4A4A8A"),
     CULTURE_HOBBY("문화/취미", "#E563FF"),
     TRAVEL_ACCOMMODATION("여행/숙박", "#2AB6D9"),


### PR DESCRIPTION
## #️⃣189
 ## 📝작업 내용
 * "건상/의료"에서 "건강/의료"로 오타 수정
 ### 스크린샷 (선택)

