### PR TITLE
[#197] 프로필 상세 조회 때 isDefaultProfile 추가

### DIFF
--- a/src/main/java/com/poortorich/user/response/UserDetailResponse.java
+++ b/src/main/java/com/poortorich/user/response/UserDetailResponse.java
@@ -8,6 +8,7 @@ import lombok.Data;
 public class UserDetailResponse {
 
     private String profileImage;
+    private Boolean isDefaultProfile;
     private String name;
     private String nickname;
     private String birth;

--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.poortorich.user.service;
 
 import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.s3.constants.S3Constants;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.repository.UserRepository;
 import com.poortorich.user.request.EmailUpdateRequest;
@@ -50,6 +51,7 @@ public class UserService {
 
         return UserDetailResponse.builder()
                 .profileImage(user.getProfileImage())
+                .isDefaultProfile(user.getProfileImage().equals(S3Constants.DEFAULT_PROFILE_IMAGE))
                 .name(user.getName())
                 .nickname(user.getNickname())
                 .birth(user.getBirth().toString())


### PR DESCRIPTION
## #️⃣197
 
 ## 📝작업 내용
 * 프로필 조회시 isDefaultProfile 필드를 추가하여 현재 프로필 사진이 기본 프로필인지 여부를 클라이언트에게 제공
 
 ### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/ba2c837e-5dde-4672-b454-c6f50890ac03)

