### PR TITLE
[#199] 반복 지출/수입 데이터 조회 수정

### DIFF
--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -185,7 +185,7 @@ public class ExpenseFacade {
     public IterationDetailsResponse getExpenseIterationDetails(String username) {
         User user = userService.findUserByUsername(username);
 
-        List<Long> originalExpenseIds = iterationService.getIterationAccountBookIds(accountBookType);
+        List<Long> originalExpenseIds = iterationService.getIterationAccountBookIds(user, accountBookType);
         return accountBookService.getIterationDetails(user, originalExpenseIds, accountBookType);
     }
 }

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -185,7 +185,7 @@ public class IncomeFacade {
     public IterationDetailsResponse getIncomeIterationDetails(String username) {
         User user = userService.findUserByUsername(username);
 
-        List<Long> originalIncomeIds = iterationService.getIterationAccountBookIds(accountBookType);
+        List<Long> originalIncomeIds = iterationService.getIterationAccountBookIds(user, accountBookType);
         return accountBookService.getIterationDetails(user, originalIncomeIds, accountBookType);
     }
 }

--- a/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationExpensesRepository.java
@@ -36,8 +36,9 @@ public interface IterationExpensesRepository extends JpaRepository<IterationExpe
     @Query("""
             SELECT DISTINCT ie.originalExpense.id
             FROM IterationExpenses ie
+            WHERE ie.user = :user
             """)
-    List<Long> getOriginalExpenseIds();
+    List<Long> getOriginalExpenseIds(User user);
 
     void deleteByUser(User user);
 }

--- a/src/main/java/com/poortorich/iteration/repository/IterationIncomesRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationIncomesRepository.java
@@ -36,8 +36,9 @@ public interface IterationIncomesRepository extends JpaRepository<IterationIncom
     @Query("""
             SELECT DISTINCT ii.originalIncome.id
             FROM IterationIncomes ii
+            WHERE ii.user = :user
             """)
-    List<Long> getOriginalIncomeIds();
+    List<Long> getOriginalIncomeIds(User user);
 
     void deleteByUser(User user);
 }

--- a/src/main/java/com/poortorich/iteration/repository/IterationRepository.java
+++ b/src/main/java/com/poortorich/iteration/repository/IterationRepository.java
@@ -75,10 +75,10 @@ public class IterationRepository {
                 .toList();
     }
 
-    public List<Long> originalAccountBookIds(AccountBookType type) {
+    public List<Long> originalAccountBookIds(User user, AccountBookType type) {
         return switch (type) {
-            case EXPENSE -> iterationExpensesRepository.getOriginalExpenseIds();
-            case INCOME -> iterationIncomesRepository.getOriginalIncomeIds();
+            case EXPENSE -> iterationExpensesRepository.getOriginalExpenseIds(user);
+            case INCOME -> iterationIncomesRepository.getOriginalIncomeIds(user);
         };
     }
 

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -489,7 +489,7 @@ public class IterationService {
                 .getThisAndFutureIterations(originalAccountBook, user, targetAccountBook.getAccountBookDate(), type);
     }
 
-    public List<Long> getIterationAccountBookIds(AccountBookType type) {
-        return iterationRepository.originalAccountBookIds(type);
+    public List<Long> getIterationAccountBookIds(User user, AccountBookType type) {
+        return iterationRepository.originalAccountBookIds(user, type);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#199
 
 ## 📝작업 내용
 
- 반복 지출/수입 데이터 조회를 할 때 유저가 두 명 이상인 경우 제대로 조회되지 않는 오류 발생
  -> 반복 데이터 조회 로직에 `user` 조건 추가
 
 ### 스크린샷

<img width="602" alt="image" src="https://github.com/user-attachments/assets/23ce05dc-f45f-469a-b200-966e2381326e" />

<img width="552" alt="image" src="https://github.com/user-attachments/assets/31471c02-614d-4c23-ab80-a0167f604977" />
