### PR TITLE
[#201] 가계부 추가/편집 카테고리 조회 로직 변경

### DIFF
--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -148,6 +148,11 @@ public class CategoryService {
         }
     }
 
+    public Category findCategoryByName(User user, String name, CategoryType type) {
+        return categoryRepository.findByUserAndNameAndTypeIn(user, name, type.getSameGroupTypes())
+                .orElseThrow(() -> new NotFoundException(CategoryResponse.CATEGORY_NON_EXISTENT));
+    }
+
     public Category findCategoryByName(String name, User user) {
         return categoryRepository.findByNameAndUser(name, user)
                 .orElseThrow(() -> new NotFoundException(CategoryResponse.CATEGORY_NON_EXISTENT));

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -8,6 +8,7 @@ import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.response.IterationDetailsResponse;
 import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.entity.Category;
+import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.expense.entity.Expense;
 import com.poortorich.accountbook.request.AccountBookDeleteRequest;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ExpenseFacade {
 
     private static final AccountBookType accountBookType = AccountBookType.EXPENSE;
+    private static final CategoryType categoryType = CategoryType.DEFAULT_EXPENSE;
 
     private final ExpenseService expenseService;
     private final CategoryService categoryService;
@@ -41,7 +43,7 @@ public class ExpenseFacade {
     @Transactional
     public Response createExpense(ExpenseRequest expenseRequest, String username) {
         User user = userService.findUserByUsername(username);
-        Category category = categoryService.findCategoryByName(expenseRequest.getCategoryName(), user);
+        Category category = categoryService.findCategoryByName(user, expenseRequest.getCategoryName(), categoryType);
         AccountBook expense = accountBookService.create(user, category, expenseRequest, accountBookType);
         if (expense.getIterationType() != IterationType.DEFAULT) {
             createIterationExpense(user, expenseRequest, expense);
@@ -95,7 +97,7 @@ public class ExpenseFacade {
     @Transactional
     public ExpenseResponse modifyExpense(String username, Long expenseId, ExpenseRequest expenseRequest) {
         User user = userService.findUserByUsername(username);
-        Category category = categoryService.findCategoryByName(expenseRequest.getCategoryName(), user);
+        Category category = categoryService.findCategoryByName(user, expenseRequest.getCategoryName(), categoryType);
         AccountBook expense = accountBookService.modifyAccountBook(user, category, expenseId, expenseRequest, accountBookType);
         expenseService.modifyPaymentMethod((Expense) expense, expenseRequest.parsePaymentMethod());
 

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -9,6 +9,7 @@ import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.response.IterationDetailsResponse;
 import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.entity.Category;
+import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.global.response.Response;
 import com.poortorich.income.entity.Income;
@@ -32,6 +33,7 @@ import java.util.List;
 public class IncomeFacade {
 
     private static final AccountBookType accountBookType = AccountBookType.INCOME;
+    private static final CategoryType categoryType = CategoryType.DEFAULT_INCOME;
 
     private final UserService userService;
     private final CategoryService categoryService;
@@ -42,7 +44,7 @@ public class IncomeFacade {
     @Transactional
     public Response createIncome(String username, IncomeRequest incomeRequest) {
         User user = userService.findUserByUsername(username);
-        Category category = categoryService.findCategoryByName(incomeRequest.getCategoryName(), user);
+        Category category = categoryService.findCategoryByName(user, incomeRequest.getCategoryName(), categoryType);
         AccountBook income = accountBookService.create(user, category, incomeRequest, accountBookType);
 
         if (income.getIterationType() != IterationType.DEFAULT) {
@@ -97,7 +99,7 @@ public class IncomeFacade {
     @Transactional
     public IncomeResponse modifyIncome(String username, Long incomeId, IncomeRequest incomeRequest) {
         User user = userService.findUserByUsername(username);
-        Category category = categoryService.findCategoryByName(incomeRequest.getCategoryName(), user);
+        Category category = categoryService.findCategoryByName(user, incomeRequest.getCategoryName(), categoryType);
         AccountBook income = accountBookService.modifyAccountBook(user, category, incomeId, incomeRequest, accountBookType);
 
         IterationAction iterationAction = incomeRequest.parseIterationAction();


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#201
 
 ## 📝작업 내용
 
- 지출/수입 타입이 같은 카테고리를 조회하는 로직을 추가한 후 그 로직을 사용하도록 수정
 
 ### 스크린샷

<img width="633" alt="image" src="https://github.com/user-attachments/assets/329f1260-0b71-43ea-9d43-c8e95299c38d" />

<img width="633" alt="image" src="https://github.com/user-attachments/assets/78c9e9cc-e4e8-4ceb-82b0-4372139e17db" />
