### PR TITLE
[#203] 활성화된 카테고리 정렬 방식 수정

### DIFF
--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -59,6 +59,11 @@ public class CategoryService {
                 .stream()
                 .filter(Category::getVisibility)
                 .map(Category::getName)
+                .sorted((a, b) -> {
+                    if (a.equals("기타")) return 1;
+                    if (b.equals("기타")) return -1;
+                    return 0;
+                })
                 .toList();
 
         return ActiveCategoriesResponse.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#203
 
 ## 📝작업 내용
 
- 프론트 요청에 따라 `기타` 카테고리가 항상 맨 뒤에 있도록 정렬 방식 수정
 
 ### 스크린샷

<img width="911" alt="image" src="https://github.com/user-attachments/assets/418dfe3d-bddd-49d0-9cbf-ce1bdeb67053" />
