### PR TITLE
[#205] 가계부 추가 응답 데이터 추가

### DIFF
--- a/src/main/java/com/poortorich/accountbook/response/AccountBookCreateResponse.java
+++ b/src/main/java/com/poortorich/accountbook/response/AccountBookCreateResponse.java
@@ -1,0 +1,15 @@
+package com.poortorich.accountbook.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountBookCreateResponse {
+
+    private Long id;
+}

--- a/src/main/java/com/poortorich/expense/controller/ExpenseController.java
+++ b/src/main/java/com/poortorich/expense/controller/ExpenseController.java
@@ -31,7 +31,10 @@ public class ExpenseController {
     public ResponseEntity<BaseResponse> createExpense(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody @Valid ExpenseRequest expenseRequest) {
-        return BaseResponse.toResponseEntity(expenseFacade.createExpense(expenseRequest, userDetails.getUsername()));
+        return DataResponse.toResponseEntity(
+                ExpenseResponse.CREATE_EXPENSE_SUCCESS,
+                expenseFacade.createExpense(expenseRequest, userDetails.getUsername())
+        );
     }
 
     @GetMapping("/{expenseId}")

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -4,6 +4,7 @@ import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.enums.IterationAction;
+import com.poortorich.accountbook.response.AccountBookCreateResponse;
 import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.response.IterationDetailsResponse;
 import com.poortorich.accountbook.service.AccountBookService;
@@ -15,7 +16,6 @@ import com.poortorich.accountbook.request.AccountBookDeleteRequest;
 import com.poortorich.expense.request.ExpenseRequest;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.expense.service.ExpenseService;
-import com.poortorich.global.response.Response;
 import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.iteration.service.IterationService;
@@ -41,7 +41,7 @@ public class ExpenseFacade {
     private final AccountBookService accountBookService;
 
     @Transactional
-    public Response createExpense(ExpenseRequest expenseRequest, String username) {
+    public AccountBookCreateResponse createExpense(ExpenseRequest expenseRequest, String username) {
         User user = userService.findUserByUsername(username);
         Category category = categoryService.findCategoryByName(user, expenseRequest.getCategoryName(), categoryType);
         AccountBook expense = accountBookService.create(user, category, expenseRequest, accountBookType);
@@ -49,7 +49,9 @@ public class ExpenseFacade {
             createIterationExpense(user, expenseRequest, expense);
         }
 
-        return ExpenseResponse.CREATE_EXPENSE_SUCCESS;
+        return AccountBookCreateResponse.builder()
+                .id(expense.getId())
+                .build();
     }
 
     public void createIterationExpense(User user, ExpenseRequest expenseRequest, AccountBook expense) {

--- a/src/main/java/com/poortorich/income/controller/IncomeController.java
+++ b/src/main/java/com/poortorich/income/controller/IncomeController.java
@@ -31,7 +31,10 @@ public class IncomeController {
     public ResponseEntity<BaseResponse> createIncome(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody @Valid IncomeRequest incomeRequest) {
-        return BaseResponse.toResponseEntity(incomeFacade.createIncome(userDetails.getUsername(), incomeRequest));
+        return DataResponse.toResponseEntity(
+                IncomeResponse.CREATE_INCOME_SUCCESS,
+                incomeFacade.createIncome(userDetails.getUsername(), incomeRequest)
+        );
     }
 
     @GetMapping("/{incomeId}")

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -5,13 +5,13 @@ import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.AccountBookDeleteRequest;
 import com.poortorich.accountbook.request.enums.IterationAction;
+import com.poortorich.accountbook.response.AccountBookCreateResponse;
 import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.response.IterationDetailsResponse;
 import com.poortorich.accountbook.service.AccountBookService;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.category.service.CategoryService;
-import com.poortorich.global.response.Response;
 import com.poortorich.income.entity.Income;
 import com.poortorich.income.request.IncomeRequest;
 import com.poortorich.income.response.enums.IncomeResponse;
@@ -42,7 +42,7 @@ public class IncomeFacade {
     private final IncomeService incomeService;
 
     @Transactional
-    public Response createIncome(String username, IncomeRequest incomeRequest) {
+    public AccountBookCreateResponse createIncome(String username, IncomeRequest incomeRequest) {
         User user = userService.findUserByUsername(username);
         Category category = categoryService.findCategoryByName(user, incomeRequest.getCategoryName(), categoryType);
         AccountBook income = accountBookService.create(user, category, incomeRequest, accountBookType);
@@ -51,7 +51,9 @@ public class IncomeFacade {
             createIterationIncome(user, incomeRequest, income);
         }
 
-        return IncomeResponse.CREATE_INCOME_SUCCESS;
+        return AccountBookCreateResponse.builder()
+                .id(income.getId())
+                .build();
     }
 
     public void createIterationIncome(User user, IncomeRequest incomeRequest, AccountBook income) {

--- a/src/test/java/com/poortorich/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/com/poortorich/expense/controller/ExpenseControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.poortorich.accountbook.response.AccountBookCreateResponse;
 import com.poortorich.expense.facade.ExpenseFacade;
 import com.poortorich.expense.fixture.ExpenseApiFixture;
 import com.poortorich.expense.request.ExpenseRequest;
@@ -62,7 +63,7 @@ class ExpenseControllerTest extends BaseSecurityTest {
         String requestJson = objectMapper.writeValueAsString(expenseRequest);
 
         when(expenseFacade.createExpense(any(ExpenseRequest.class), anyString()))
-                .thenReturn(ExpenseResponse.CREATE_EXPENSE_SUCCESS);
+                .thenReturn(AccountBookCreateResponse.builder().build());
 
         mockMvc.perform(post(ExpenseApiFixture.CREATE_PATH)
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#205
 
 ## 📝작업 내용

- 프론트 요청사항에 따라 가계부를 추가하는 경우 추가된 가계부의 ID 값을 반환하도록 수정
 
 ### 스크린샷

<img width="766" alt="image" src="https://github.com/user-attachments/assets/199f1d71-cf51-4d37-aced-49ee1bbba4da" />

![image](https://github.com/user-attachments/assets/da140050-2f52-4391-8a51-52c955b178fb)
