### PR TITLE
[#216] 프로필 조회시 기본프로필인 경우 null로 제공

### DIFF
--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -49,9 +49,15 @@ public class UserService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
 
+        boolean isDefaultProfile = user.getProfileImage().equals(S3Constants.DEFAULT_PROFILE_IMAGE);
+        String profileImage = null;
+        if (!isDefaultProfile) {
+            profileImage = user.getProfileImage();
+        }
+
         return UserDetailResponse.builder()
-                .profileImage(user.getProfileImage())
-                .isDefaultProfile(user.getProfileImage().equals(S3Constants.DEFAULT_PROFILE_IMAGE))
+                .profileImage(profileImage)
+                .isDefaultProfile(isDefaultProfile)
                 .name(user.getName())
                 .nickname(user.getNickname())
                 .birth(user.getBirth().toString())


### PR DESCRIPTION
## #️⃣216
 
 ## 📝작업 내용
 - 프론트 요청에 따라 기본 프로필인 경우 null로 제공하도록 수정
 
 ### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/32501ce1-625c-465d-8da0-1e13f96df20a)

