### PR TITLE
[#222] 가계부 추가, 편집, 삭제 응답에 카테고리 아이디 추가

### DIFF
--- a/src/main/java/com/poortorich/accountbook/response/AccountBookActionResponse.java
+++ b/src/main/java/com/poortorich/accountbook/response/AccountBookActionResponse.java
@@ -9,8 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class AccountBookCreateResponse {
+public class AccountBookActionResponse {
 
-    private Long id;
     private Long categoryId;
 }

--- a/src/main/java/com/poortorich/expense/controller/ExpenseController.java
+++ b/src/main/java/com/poortorich/expense/controller/ExpenseController.java
@@ -52,7 +52,10 @@ public class ExpenseController {
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long expenseId,
             @RequestBody @Valid ExpenseRequest expenseRequest) {
-        return BaseResponse.toResponseEntity(expenseFacade.modifyExpense(userDetails.getUsername(), expenseId, expenseRequest));
+        return DataResponse.toResponseEntity(
+                ExpenseResponse.MODIFY_EXPENSE_SUCCESS,
+                expenseFacade.modifyExpense(userDetails.getUsername(), expenseId, expenseRequest)
+        );
     }
 
     @DeleteMapping("/{expenseId}")
@@ -60,7 +63,10 @@ public class ExpenseController {
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long expenseId,
             @RequestBody @Valid AccountBookDeleteRequest accountBookDeleteRequest) {
-        return BaseResponse.toResponseEntity(expenseFacade.deleteExpense(expenseId, accountBookDeleteRequest, userDetails.getUsername()));
+        return DataResponse.toResponseEntity(
+                ExpenseResponse.DELETE_EXPENSE_SUCCESS,
+                expenseFacade.deleteExpense(expenseId, accountBookDeleteRequest, userDetails.getUsername())
+        );
     }
 
     @GetMapping("/iteration/details")

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -4,6 +4,7 @@ import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.enums.IterationAction;
+import com.poortorich.accountbook.response.AccountBookActionResponse;
 import com.poortorich.accountbook.response.AccountBookCreateResponse;
 import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.response.IterationDetailsResponse;
@@ -51,6 +52,7 @@ public class ExpenseFacade {
 
         return AccountBookCreateResponse.builder()
                 .id(expense.getId())
+                .categoryId(category.getId())
                 .build();
     }
 
@@ -75,8 +77,11 @@ public class ExpenseFacade {
     }
 
     @Transactional
-    public ExpenseResponse deleteExpense(Long expenseId, AccountBookDeleteRequest accountBookDeleteRequest, String username) {
+    public AccountBookActionResponse deleteExpense(Long expenseId, AccountBookDeleteRequest accountBookDeleteRequest, String username) {
         User user = userService.findUserByUsername(username);
+        AccountBook expense = accountBookService.getAccountBookOrThrow(expenseId, user, accountBookType);
+        Long categoryId = expense.getCategory().getId();
+
         if (accountBookDeleteRequest.parseIterationAction() == IterationAction.NONE) {
             accountBookService.deleteAccountBook(expenseId, user, accountBookType);
         }
@@ -93,11 +98,13 @@ public class ExpenseFacade {
             );
         }
 
-        return ExpenseResponse.DELETE_EXPENSE_SUCCESS;
+        return AccountBookActionResponse.builder()
+                .categoryId(categoryId)
+                .build();
     }
 
     @Transactional
-    public ExpenseResponse modifyExpense(String username, Long expenseId, ExpenseRequest expenseRequest) {
+    public AccountBookActionResponse modifyExpense(String username, Long expenseId, ExpenseRequest expenseRequest) {
         User user = userService.findUserByUsername(username);
         Category category = categoryService.findCategoryByName(user, expenseRequest.getCategoryName(), categoryType);
         AccountBook expense = accountBookService.modifyAccountBook(user, category, expenseId, expenseRequest, accountBookType);
@@ -112,7 +119,9 @@ public class ExpenseFacade {
             modifyIterationExpenses(expense, expenseRequest, iterationAction, category, user);
         }
 
-        return ExpenseResponse.MODIFY_EXPENSE_SUCCESS;
+        return AccountBookActionResponse.builder()
+                .categoryId(category.getId())
+                .build();
     }
 
     private void modifySingleExpense(AccountBook expense, ExpenseRequest expenseRequest, User user) {

--- a/src/main/java/com/poortorich/income/controller/IncomeController.java
+++ b/src/main/java/com/poortorich/income/controller/IncomeController.java
@@ -54,7 +54,10 @@ public class IncomeController {
             @PathVariable Long incomeId,
             @RequestBody @Valid IncomeRequest incomeRequest
     ) {
-        return BaseResponse.toResponseEntity(incomeFacade.modifyIncome(userDetails.getUsername(), incomeId, incomeRequest));
+        return DataResponse.toResponseEntity(
+                IncomeResponse.MODIFY_INCOME_SUCCESS,
+                incomeFacade.modifyIncome(userDetails.getUsername(), incomeId, incomeRequest)
+        );
     }
 
     @DeleteMapping("/{incomeId}")
@@ -63,7 +66,8 @@ public class IncomeController {
             @PathVariable Long incomeId,
             @RequestBody @Valid AccountBookDeleteRequest accountBookDeleteRequest
     ) {
-        return BaseResponse.toResponseEntity(
+        return DataResponse.toResponseEntity(
+                IncomeResponse.DELETE_INCOME_SUCCESS,
                 incomeFacade.deleteIncome(userDetails.getUsername(), incomeId, accountBookDeleteRequest)
         );
     }

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -5,6 +5,7 @@ import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.AccountBookDeleteRequest;
 import com.poortorich.accountbook.request.enums.IterationAction;
+import com.poortorich.accountbook.response.AccountBookActionResponse;
 import com.poortorich.accountbook.response.AccountBookCreateResponse;
 import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.response.IterationDetailsResponse;
@@ -53,6 +54,7 @@ public class IncomeFacade {
 
         return AccountBookCreateResponse.builder()
                 .id(income.getId())
+                .categoryId(category.getId())
                 .build();
     }
 
@@ -77,8 +79,11 @@ public class IncomeFacade {
     }
 
     @Transactional
-    public IncomeResponse deleteIncome(String username, Long incomeId, AccountBookDeleteRequest accountBookDeleteRequest) {
+    public AccountBookActionResponse deleteIncome(String username, Long incomeId, AccountBookDeleteRequest accountBookDeleteRequest) {
         User user = userService.findUserByUsername(username);
+        AccountBook income = accountBookService.getAccountBookOrThrow(incomeId, user, accountBookType);
+        Long categoryId = income.getCategory().getId();
+
         if (accountBookDeleteRequest.parseIterationAction() == IterationAction.NONE) {
             accountBookService.deleteAccountBook(incomeId, user, accountBookType);
         }
@@ -95,11 +100,13 @@ public class IncomeFacade {
             );
         }
 
-        return IncomeResponse.DELETE_INCOME_SUCCESS;
+        return AccountBookActionResponse.builder()
+                .categoryId(categoryId)
+                .build();
     }
 
     @Transactional
-    public IncomeResponse modifyIncome(String username, Long incomeId, IncomeRequest incomeRequest) {
+    public AccountBookActionResponse modifyIncome(String username, Long incomeId, IncomeRequest incomeRequest) {
         User user = userService.findUserByUsername(username);
         Category category = categoryService.findCategoryByName(user, incomeRequest.getCategoryName(), categoryType);
         AccountBook income = accountBookService.modifyAccountBook(user, category, incomeId, incomeRequest, accountBookType);
@@ -113,7 +120,9 @@ public class IncomeFacade {
             modifyIterationIncomes(income, incomeRequest, iterationAction, category, user);
         }
 
-        return IncomeResponse.MODIFY_INCOME_SUCCESS;
+        return AccountBookActionResponse.builder()
+                .categoryId(category.getId())
+                .build();
     }
 
     private void modifySingleIncome(AccountBook income, IncomeRequest incomeRequest, User user) {


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#222
 
 ## 📝작업 내용

- 프론트 요청에 따라 가계부 추가, 편집, 삭제 응답을 추가한 후 카테고리 아이디를 반환하도록 구현하였습니다.
 
 ### 스크린샷

추가
![image](https://github.com/user-attachments/assets/514255e3-38eb-4dce-bb7a-4138e4dc0448)

편집
![image](https://github.com/user-attachments/assets/3f9ee02b-ad33-49d8-a235-7ae52eee1bae)

삭제
![image](https://github.com/user-attachments/assets/ffa0b7e0-71ea-49d2-88a0-8a640995a9c6)

 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
