### PR TITLE
[#234] 카테고리 구간 내역 총 내역 수 조회 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -172,6 +172,15 @@ public class AccountBookService {
         return accountBookRepository.countByUserAndBetweenDates(user, startDate, endDate);
     }
 
+    public Long countByUserAndCategoryAndBetweenDates(
+            User user,
+            Category category,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        return accountBookRepository.countByUserAndCategoryBetweenDates(user, category, startDate, endDate);
+    }
+
     public Boolean hasNextPage(User user, LocalDate startDate, LocalDate endDate) {
         return accountBookRepository.countByUserAndBetweenDates(user, startDate, endDate) > 0L;
     }

--- a/src/main/java/com/poortorich/chart/facade/ChartFacade.java
+++ b/src/main/java/com/poortorich/chart/facade/ChartFacade.java
@@ -130,9 +130,11 @@ public class ChartFacade {
                         dateInfo.getEndDate(),
                         nextCursor, direction))
                 .nextCursor(nextCursor.toString())
-                .countOfLogs(categoryLogs.stream()
-                        .mapToLong(CategoryLog::getCountOfTransactions)
-                        .sum())
+                .countOfLogs(accountBookService.countByUserAndCategoryAndBetweenDates(
+                        user,
+                        category,
+                        dateInfo.getStartDate(),
+                        dateInfo.getEndDate()))
                 .categoryLogs(categoryLogs)
                 .build();
     }


### PR DESCRIPTION
## #️⃣234
 
 ## 📝작업 내용
 - [ 시작 날 ] ~ [ 끝 날 ]에 해당하는 가계부 개수를 반환하는 로직을 추가
   - 이를 통해 카테고리 구간 내역의 총 개수를 가져와서 처리
 
 ### 스크린샷 (선택)
 
![image](https://github.com/user-attachments/assets/e2108607-3ee0-4449-a62b-601477f1d184)

