### PR TITLE
[#238] 반복데이터 관련 수정

### DIFF
--- a/src/main/java/com/poortorich/iteration/entity/enums/IterationRuleType.java
+++ b/src/main/java/com/poortorich/iteration/entity/enums/IterationRuleType.java
@@ -10,10 +10,10 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public enum IterationRuleType {
 
-    DAILY("daily", 3700),
-    WEEKLY("weekly", 3700),
-    MONTHLY("monthly", 150),
-    YEARLY("yearly", 50);
+    DAILY("daily", 10000),
+    WEEKLY("weekly", 10000),
+    MONTHLY("monthly", 10000),
+    YEARLY("yearly", 10000);
 
     private final String type;
     public final int maxIterations;

--- a/src/main/java/com/poortorich/iteration/response/IterationResponse.java
+++ b/src/main/java/com/poortorich/iteration/response/IterationResponse.java
@@ -18,7 +18,7 @@ public enum IterationResponse implements Response {
     END_DATE_INVALID(HttpStatus.BAD_REQUEST, IterationResponseMessages.END_DATE_INVALID, "customIteration.end.date"),
     END_DATE_NOT_BEFORE(HttpStatus.BAD_REQUEST, IterationResponseMessages.END_DATE_NOT_BEFORE, "customIteration.end.date"),
 
-    ITERATIONS_TOO_LONG(HttpStatus.BAD_REQUEST, IterationResponseMessages.ITERATIONS_TOO_LONG, null),
+    ITERATIONS_TOO_LONG(HttpStatus.INTERNAL_SERVER_ERROR, IterationResponseMessages.ITERATIONS_TOO_LONG, null),
 
     ITERATION_EXPENSES_NOT_FOUND(HttpStatus.NOT_FOUND, IterationResponseMessages.ITERATION_EXPENSES_NOT_FOUND, null);
 

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -131,7 +131,7 @@ public class IterationService {
             }
 
             return calculateDateByRuleType(
-                    end.getCount() * customIteration.getCycle(), startDate, startDate, rule, rule.getMonthlyOption());
+                    end.getCount() * customIteration.getCycle() - 1, startDate, startDate, rule, rule.getMonthlyOption());
         }
 
         return end.parseDate();

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -76,7 +76,7 @@ public class IterationService {
             AccountBookType type
     ) {
         List<AccountBook> iterations = new ArrayList<>();
-        LocalDate date = getDateByIterationType(customIteration, startDate, accountBook.getIterationType());
+        LocalDate date = getDateByIterationType(customIteration, startDate, startDate, accountBook.getIterationType());
         LocalDate endDate = calculateEndDate(customIteration, accountBook, startDate);
         int maxIterations = 0;
         int allowedIterations = getAllowedIterations(accountBook.getIterationType(), customIteration);
@@ -88,20 +88,21 @@ public class IterationService {
             }
             AccountBook generatedAccountBook = AccountBookBuilder.buildEntity(user, date, accountBook, type);
             iterations.add(generatedAccountBook);
-            date = getDateByIterationType(customIteration, date, accountBook.getIterationType());
+            date = getDateByIterationType(customIteration, date, startDate, accountBook.getIterationType());
             maxIterations++;
         }
 
         return iterations;
     }
 
-    private LocalDate getDateByIterationType(CustomIteration customIteration, LocalDate date, IterationType type) {
+    private LocalDate getDateByIterationType(
+            CustomIteration customIteration, LocalDate date, LocalDate startDate, IterationType type) {
         if (type == IterationType.CUSTOM) {
             IterationRule rule = customIteration.getIterationRule();
-            return calculateDateByRuleType(customIteration.getCycle(), date, rule, rule.getMonthlyOption());
+            return calculateDateByRuleType(customIteration.getCycle(), date, startDate, rule, rule.getMonthlyOption());
         }
 
-        return calculateDateByIterationType(type, date);
+        return calculateDateByIterationType(type, date, startDate);
     }
 
     private LocalDate calculateEndDate(CustomIteration customIteration, AccountBook accountBook, LocalDate startDate) {
@@ -110,10 +111,10 @@ public class IterationService {
         }
 
         if (accountBook.getIterationType() == IterationType.DAILY || accountBook.getIterationType() == IterationType.WEEKDAY) {
-            return dateCalculator.yearlyTypeDate(startDate, 3);
+            return dateCalculator.yearlyTypeDate(startDate, 3, startDate);
         }
 
-        return dateCalculator.yearlyTypeDate(startDate, 10);
+        return dateCalculator.yearlyTypeDate(startDate, 10, startDate);
     }
 
     private LocalDate calculateEndDate(End end, CustomIteration customIteration, LocalDate startDate) {
@@ -125,10 +126,12 @@ public class IterationService {
             IterationRule rule = customIteration.getIterationRule();
 
             if (rule.parseIterationType() == IterationRuleType.WEEKLY) {
-                return dateCalculator.weeklyEndDate(startDate, end.getCount() * customIteration.getCycle() - 1, rule.daysOfWeekToList());
+                return dateCalculator.weeklyEndDate(
+                        startDate, end.getCount() * customIteration.getCycle() - 1, rule.daysOfWeekToList());
             }
 
-            return calculateDateByRuleType(end.getCount() * customIteration.getCycle(), startDate, rule, rule.getMonthlyOption());
+            return calculateDateByRuleType(
+                    end.getCount() * customIteration.getCycle(), startDate, startDate, rule, rule.getMonthlyOption());
         }
 
         return end.parseDate();
@@ -136,14 +139,14 @@ public class IterationService {
 
     private LocalDate calculateEndDateByIterationRule(IterationRuleType rule, LocalDate startDate) {
         if (rule == IterationRuleType.DAILY) {
-            return dateCalculator.yearlyTypeDate(startDate, 3);
+            return dateCalculator.yearlyTypeDate(startDate, 3, startDate);
         }
 
         if (rule == IterationRuleType.WEEKLY) {
-            return dateCalculator.yearlyTypeDate(startDate, 5);
+            return dateCalculator.yearlyTypeDate(startDate, 5, startDate);
         }
 
-        return dateCalculator.yearlyTypeDate(startDate, 10);
+        return dateCalculator.yearlyTypeDate(startDate, 10, startDate);
     }
 
     private int getAllowedIterations(IterationType type, CustomIteration customIteration) {
@@ -154,7 +157,7 @@ public class IterationService {
         return IterationRuleType.DAILY.maxIterations;
     }
 
-    private LocalDate calculateDateByIterationType(IterationType type, LocalDate date) {
+    private LocalDate calculateDateByIterationType(IterationType type, LocalDate date, LocalDate startDate) {
         if (type == IterationType.DAILY) {
             return dateCalculator.dailyTypeDate(date, 1);
         }
@@ -168,7 +171,7 @@ public class IterationService {
         }
 
         if (type == IterationType.YEARLY) {
-            return dateCalculator.yearlyTypeDate(date, 1);
+            return dateCalculator.yearlyTypeDate(date, 1, startDate);
         }
 
         if (type == IterationType.WEEKDAY) {
@@ -179,10 +182,8 @@ public class IterationService {
         return dateCalculator.monthlyTypeEndModeDate(date);
     }
 
-    private LocalDate calculateDateByRuleType(int cycle,
-                                              LocalDate date,
-                                              IterationRule rule,
-                                              MonthlyOption monthlyOption) {
+    private LocalDate calculateDateByRuleType(
+            int cycle, LocalDate date, LocalDate startDate, IterationRule rule, MonthlyOption monthlyOption) {
         if (rule.parseIterationType() == IterationRuleType.DAILY) {
             return dateCalculator.dailyTypeDate(date, cycle);
         }
@@ -193,20 +194,14 @@ public class IterationService {
 
         if (rule.parseIterationType() == IterationRuleType.MONTHLY) {
             return processCalculatorByMonthlyRule(
-                    date,
-                    cycle,
-                    monthlyOption,
-                    monthlyOption.parseMonthlyMode()
-            );
+                    date, cycle, startDate, monthlyOption, monthlyOption.parseMonthlyMode());
         }
 
-        return dateCalculator.yearlyTypeDate(date, cycle);
+        return dateCalculator.yearlyTypeDate(date, cycle, startDate);
     }
 
-    private LocalDate processCalculatorByMonthlyRule(LocalDate date,
-                                                     int cycle,
-                                                     MonthlyOption option,
-                                                     MonthlyMode mode) {
+    private LocalDate processCalculatorByMonthlyRule(
+            LocalDate date, int cycle, LocalDate startDate, MonthlyOption option, MonthlyMode mode) {
         LocalDate targetDate = date.plusMonths(cycle);
 
         if (mode == MonthlyMode.DAY) {

--- a/src/main/java/com/poortorich/iteration/util/IterationDateCalculator.java
+++ b/src/main/java/com/poortorich/iteration/util/IterationDateCalculator.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
@@ -48,11 +49,10 @@ public class IterationDateCalculator {
     }
 
     public LocalDate monthlyTypeDayModeDate(LocalDate date, int day) {
-        while (day > date.lengthOfMonth()) {
-            date = date.plusMonths(1);
-        }
+        int lastDayOfMonth = date.lengthOfMonth();
+        int targetDay = Math.min(day, lastDayOfMonth);
 
-        return date.withDayOfMonth(day);
+        return date.withDayOfMonth(targetDay);
     }
 
     public LocalDate monthlyTypeWeekDayModeDate(LocalDate date, int week, Weekday weekday) {
@@ -74,7 +74,14 @@ public class IterationDateCalculator {
         return date.plusMonths(cycle);
     }
 
-    public LocalDate yearlyTypeDate(LocalDate date, int cycle) {
-        return date.plusYears(cycle);
+    public LocalDate yearlyTypeDate(LocalDate date, int cycle, LocalDate startDate) {
+        LocalDate targetDate = date.plusYears(cycle);
+
+        int lastDayOfTargetMonth = targetDate.lengthOfMonth();
+        if (startDate.getDayOfMonth() > lastDayOfTargetMonth) {
+            return targetDate.withDayOfMonth(lastDayOfTargetMonth);
+        }
+
+        return targetDate.withDayOfMonth(startDate.getDayOfMonth());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#238 

 ## 📝작업 내용
 
- 무한루프 방지용 반복 제한 횟수를 완화하였습니다
   > **10000번**을 초과하는 경우 **500 에러**를 던지도록 수정하였습니다.

- 매달/매년 29일, 30일, 31일에 반복하는 경우, 이 날짜보다 말일이 짧을 때, 해당 달의 말일로 반복되도록 로직을 수정하였습니다.

- 반복 횟수가 1회 더 반복되는 것을 수정하였습니다.
