### PR TITLE
[#240] 카테고리 관련 수정

### DIFF
--- a/src/main/java/com/poortorich/accountbook/repository/AccountBookRepository.java
+++ b/src/main/java/com/poortorich/accountbook/repository/AccountBookRepository.java
@@ -72,6 +72,15 @@ public class AccountBookRepository {
         }
     }
 
+    public boolean findByUserAndCategory(User user, Category category, AccountBookType type) {
+        List<? extends AccountBook> accountBooks = switch (type) {
+            case EXPENSE -> expenseRepository.findByUserAndCategory(user, category);
+            case INCOME -> incomeRepository.findByUserAndCategory(user, category);
+        };
+
+        return !accountBooks.isEmpty();
+    }
+
     public List<AccountBook> findByUserAndExpenseAndDateBetween(
             User user,
             LocalDate startDate,

--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -10,6 +10,7 @@ import com.poortorich.accountbook.response.IterationDetailsResponse;
 import com.poortorich.accountbook.util.AccountBookBuilder;
 import com.poortorich.accountbook.util.AccountBookCostExtractor;
 import com.poortorich.category.entity.Category;
+import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.expense.response.ExpenseResponse;
 import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.global.statistics.util.StatCalculator;
@@ -22,6 +23,8 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -85,6 +88,14 @@ public class AccountBookService {
 
     public void deleteAccountBookAll(List<AccountBook> accountBooks, AccountBookType type) {
         accountBookRepository.deleteAll(accountBooks, type);
+    }
+
+    public boolean isUsedCategory(User user, Category category, CategoryType categoryType) {
+        AccountBookType type = AccountBookType.EXPENSE;
+        if (categoryType.getType().equals("income")) {
+            type = AccountBookType.INCOME;
+        }
+        return accountBookRepository.findByUserAndCategory(user, category, type);
     }
 
     public List<AccountBook> getAccountBookBetweenDates(

--- a/src/main/java/com/poortorich/category/constants/CategoryResponseMessage.java
+++ b/src/main/java/com/poortorich/category/constants/CategoryResponseMessage.java
@@ -18,6 +18,8 @@ public class CategoryResponseMessage {
     public static final String MODIFY_CATEGORY_SUCCESS = "카테고리를 성공적으로 편집하였습니다.";
     public static final String DELETE_CATEGORY_SUCCESS = "카테고리를 성공적으로 삭제하였습니다.";
 
+    public static final String NOT_DELETE_USED_CATEGORY = "사용중인 카테고리는 삭제할 수 없습니다.";
+
     public static final String CATEGORY_NON_EXISTENT = "존재하지 않는 카테고리입니다.";
 
     public static final String CATEGORY_TYPE_INVALID = "카테고리의 타입이 적절하지 않습니다.";

--- a/src/main/java/com/poortorich/category/entity/enums/CategoryType.java
+++ b/src/main/java/com/poortorich/category/entity/enums/CategoryType.java
@@ -2,12 +2,14 @@ package com.poortorich.category.entity.enums;
 
 import com.poortorich.category.response.CategoryResponse;
 import com.poortorich.global.exceptions.BadRequestException;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+@Getter
 @RequiredArgsConstructor
 public enum CategoryType {
 
@@ -30,5 +32,6 @@ public enum CategoryType {
                 .filter(category -> Objects.equals(category.type, this.type))
                 .toList();
     }
+
 }
 

--- a/src/main/java/com/poortorich/category/response/CategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoryResponse.java
@@ -22,7 +22,7 @@ public enum CategoryResponse implements Response {
     MODIFY_CATEGORY_SUCCESS(HttpStatus.CREATED, CategoryResponseMessage.MODIFY_CATEGORY_SUCCESS, null),
     DELETE_CATEGORY_SUCCESS(HttpStatus.OK, CategoryResponseMessage.DELETE_CATEGORY_SUCCESS, null),
 
-    NOT_DELETE_USED_CATEGORY(HttpStatus.BAD_REQUEST, CategoryResponseMessage.NOT_DELETE_USED_CATEGORY, null),
+    NOT_DELETE_USED_CATEGORY(HttpStatus.CONFLICT, CategoryResponseMessage.NOT_DELETE_USED_CATEGORY, null),
     CATEGORY_NAME_DUPLICATE(HttpStatus.CONFLICT, CategoryResponseMessage.CATEGORY_NAME_DUPLICATE, "name"),
     CATEGORY_NON_EXISTENT(HttpStatus.NOT_FOUND, CategoryResponseMessage.CATEGORY_NON_EXISTENT, "categoryId"),
     CATEGORY_TYPE_INVALID(HttpStatus.BAD_REQUEST,CategoryResponseMessage.CATEGORY_TYPE_INVALID, "categoryType"),

--- a/src/main/java/com/poortorich/category/response/CategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/CategoryResponse.java
@@ -22,6 +22,7 @@ public enum CategoryResponse implements Response {
     MODIFY_CATEGORY_SUCCESS(HttpStatus.CREATED, CategoryResponseMessage.MODIFY_CATEGORY_SUCCESS, null),
     DELETE_CATEGORY_SUCCESS(HttpStatus.OK, CategoryResponseMessage.DELETE_CATEGORY_SUCCESS, null),
 
+    NOT_DELETE_USED_CATEGORY(HttpStatus.BAD_REQUEST, CategoryResponseMessage.NOT_DELETE_USED_CATEGORY, null),
     CATEGORY_NAME_DUPLICATE(HttpStatus.CONFLICT, CategoryResponseMessage.CATEGORY_NAME_DUPLICATE, "name"),
     CATEGORY_NON_EXISTENT(HttpStatus.NOT_FOUND, CategoryResponseMessage.CATEGORY_NON_EXISTENT, "categoryId"),
     CATEGORY_TYPE_INVALID(HttpStatus.BAD_REQUEST,CategoryResponseMessage.CATEGORY_TYPE_INVALID, "categoryType"),

--- a/src/main/java/com/poortorich/category/service/CategoryService.java
+++ b/src/main/java/com/poortorich/category/service/CategoryService.java
@@ -131,10 +131,10 @@ public class CategoryService {
     @Transactional
     public Response modifyCategory(Long id, CategoryInfoRequest categoryRequest, String username) {
         User user = userService.findUserByUsername(username);
-
-        validateCategoryNameDuplication(user, categoryRequest.getName(), CategoryType.CUSTOM_INCOME);
-
         Category category = getCategoryOrThrow(id, user);
+
+        validateCategoryNameDuplication(user, categoryRequest.getName(), category.getType());
+
         category.updateCategory(categoryRequest.getName(), categoryRequest.getColor());
 
         return CategoryResponse.MODIFY_CATEGORY_SUCCESS;

--- a/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/poortorich/expense/repository/ExpenseRepository.java
@@ -126,4 +126,6 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     Long countByUserAndBetweenDates(User user, LocalDate startDate, LocalDate endDate);
 
     void deleteByUser(User user);
+
+    List<Expense> findByUserAndCategory(User user, Category category);
 }

--- a/src/main/java/com/poortorich/income/repository/IncomeRepository.java
+++ b/src/main/java/com/poortorich/income/repository/IncomeRepository.java
@@ -126,4 +126,5 @@ public interface IncomeRepository extends JpaRepository<Income, Long> {
 
     void deleteByUser(User user);
 
+    List<Income> findByUserAndCategory(User user, Category category);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#240
 
 ## 📝작업 내용
 
- 지출 카테고리 이름 수정시 중복된 이름으로 설정되는 오류 수정
- 가계부에서 사용중인 카테고리를 삭제하는 경우에 대한 예외 처리 추가
 
 ### 스크린샷

사용중인 카테고리 이름으로 수정시 예외 발생
![image](https://github.com/user-attachments/assets/c62d3b0e-b508-4a5b-89e5-ea813229ecee)

사용중인 카테고리 삭제시 예외 발생
![image](https://github.com/user-attachments/assets/451fa1d7-c5e8-4f5b-971b-5a544cbccc53)
 
 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
