### PR TITLE
[#242] 반복데이터 리팩토링

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-### 배포 환경
-#FROM openjdk:21-jdk-slim
-#
-#ARG JAR_FILE=./build/libs/*.jar
-#
-#COPY ${JAR_FILE} /app.jar
-#
-#ENTRYPOINT ["java", "-jar", "/app.jar" ]
-
-## 개발 환경
+## 배포 환경
 FROM openjdk:21-jdk-slim
 
-WORKDIR /app
+ARG JAR_FILE=./build/libs/*.jar
 
-COPY . .
+COPY ${JAR_FILE} /app.jar
 
-RUN chmod +x ./gradlew
+ENTRYPOINT ["java", "-jar", "/app.jar" ]
 
-ENTRYPOINT ["./gradlew", "bootRun"]
+### 개발 환경
+#FROM openjdk:21-jdk-slim
+#
+#WORKDIR /app
+#
+#COPY . .
+#
+#RUN chmod +x ./gradlew
+#
+#ENTRYPOINT ["./gradlew", "bootRun"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-## 배포 환경
-FROM openjdk:21-jdk-slim
-
-ARG JAR_FILE=./build/libs/*.jar
-
-COPY ${JAR_FILE} /app.jar
-
-ENTRYPOINT ["java", "-jar", "/app.jar" ]
-
-### 개발 환경
+### 배포 환경
 #FROM openjdk:21-jdk-slim
 #
-#WORKDIR /app
+#ARG JAR_FILE=./build/libs/*.jar
 #
-#COPY . .
+#COPY ${JAR_FILE} /app.jar
 #
-#RUN chmod +x ./gradlew
-#
-#ENTRYPOINT ["./gradlew", "bootRun"]
+#ENTRYPOINT ["java", "-jar", "/app.jar" ]
+
+## 개발 환경
+FROM openjdk:21-jdk-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN chmod +x ./gradlew
+
+ENTRYPOINT ["./gradlew", "bootRun"]

--- a/src/main/java/com/poortorich/iteration/constants/IterationResponseMessages.java
+++ b/src/main/java/com/poortorich/iteration/constants/IterationResponseMessages.java
@@ -14,9 +14,9 @@ public class IterationResponseMessages {
     public static final String MONTHLY_MODE_INVALID = "매달 타입이 적절하지 않습니다.";
     public static final String MONTHLY_OPTION_REQUIRED_MONTHLY_TYPE = "매달 반복하는 경우 옵션은 필수입니다.";
 
-    public static final String MONTHLY_OPTION_DAY_REQUIRED = "매달 날짜 옵션을 선택한 경우 날짜 값은 필수입니다.";
-    public static final String MONTHLY_OPTION_WEEK_REQUIRED = "매달 요일 옵션을 선택한 경우 주차 값은 필수입니다.";
-    public static final String MONTHLY_OPTION_DAY_OF_WEEK_REQUIRED = "매달 요일 옵션을 선택한 경우 요일 옵션은 필수입니다.";
+    public static final String MONTHLY_OPTION_DAY_REQUIRED = "매달 옵션을 선택한 경우 날짜 값은 필수입니다.";
+    public static final String MONTHLY_OPTION_WEEK_REQUIRED = "매달 옵션을 선택한 경우 주차 값은 필수입니다.";
+    public static final String MONTHLY_OPTION_DAY_OF_WEEK_REQUIRED = "매달 옵션을 선택한 경우 요일 옵션은 필수입니다.";
 
     public static final String CYCLE_REQUIRED = "반복 주기는 필수입니다.";
     public static final String CYCLE_TOO_SMALL = "반복 주기는 " + IterationValidationConstraints.CYCLE_MIN + " 이상이어야 합니다.";

--- a/src/main/java/com/poortorich/iteration/entity/IterationExpenses.java
+++ b/src/main/java/com/poortorich/iteration/entity/IterationExpenses.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +29,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @DynamicUpdate
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "iterationExpenses")
 public class IterationExpenses implements Iteration {

--- a/src/main/java/com/poortorich/iteration/entity/IterationIncomes.java
+++ b/src/main/java/com/poortorich/iteration/entity/IterationIncomes.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +29,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @DynamicUpdate
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "iterationIncomes")
 public class IterationIncomes implements Iteration{

--- a/src/main/java/com/poortorich/iteration/entity/info/DailyIterationRule.java
+++ b/src/main/java/com/poortorich/iteration/entity/info/DailyIterationRule.java
@@ -2,6 +2,7 @@ package com.poortorich.iteration.entity.info;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -11,7 +12,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Getter
 @SuperBuilder
 @DynamicUpdate
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue("DAILY")
 public class DailyIterationRule extends IterationInfo {
 }

--- a/src/main/java/com/poortorich/iteration/entity/info/IterationInfo.java
+++ b/src/main/java/com/poortorich/iteration/entity/info/IterationInfo.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,7 +29,7 @@ import java.time.LocalDateTime;
 @Getter
 @SuperBuilder
 @DynamicUpdate
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "iterationType", discriminatorType = DiscriminatorType.STRING)

--- a/src/main/java/com/poortorich/iteration/entity/info/MonthlyIterationRule.java
+++ b/src/main/java/com/poortorich/iteration/entity/info/MonthlyIterationRule.java
@@ -7,6 +7,7 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Getter
 @SuperBuilder
 @DynamicUpdate
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @DiscriminatorValue("MONTHLY")
 public class MonthlyIterationRule extends IterationInfo {

--- a/src/main/java/com/poortorich/iteration/entity/info/WeeklyIterationRule.java
+++ b/src/main/java/com/poortorich/iteration/entity/info/WeeklyIterationRule.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Transient;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +19,7 @@ import java.util.List;
 @Getter
 @SuperBuilder
 @DynamicUpdate
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @DiscriminatorValue("WEEKLY")
 public class WeeklyIterationRule extends IterationInfo {

--- a/src/main/java/com/poortorich/iteration/entity/info/YearlyIterationRule.java
+++ b/src/main/java/com/poortorich/iteration/entity/info/YearlyIterationRule.java
@@ -2,6 +2,7 @@ package com.poortorich.iteration.entity.info;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -11,7 +12,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Getter
 @SuperBuilder
 @DynamicUpdate
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue("YEARLY")
 public class YearlyIterationRule extends IterationInfo {
 }

--- a/src/main/java/com/poortorich/iteration/mapper/IterationMapper.java
+++ b/src/main/java/com/poortorich/iteration/mapper/IterationMapper.java
@@ -1,0 +1,64 @@
+package com.poortorich.iteration.mapper;
+
+import com.poortorich.iteration.entity.enums.EndType;
+import com.poortorich.iteration.entity.info.IterationInfo;
+import com.poortorich.iteration.entity.info.MonthlyIterationRule;
+import com.poortorich.iteration.entity.info.WeeklyIterationRule;
+import com.poortorich.iteration.response.EndInfoResponse;
+import com.poortorich.iteration.response.IterationRuleInfoResponse;
+import com.poortorich.iteration.response.MonthlyOptionInfoResponse;
+import org.hibernate.Hibernate;
+
+public class IterationMapper {
+
+    public static IterationRuleInfoResponse toIterationRuleInfo(IterationInfo info) {
+        IterationInfo unproxiedInfo = (IterationInfo) Hibernate.unproxy(info);
+
+        if (unproxiedInfo instanceof WeeklyIterationRule weekly) {
+            return IterationRuleInfoResponse.builder()
+                    .type(weekly.getIterationTypeLowerCase())
+                    .daysOfWeek(weekly.getDaysOfWeekList())
+                    .build();
+        }
+
+        if (unproxiedInfo instanceof MonthlyIterationRule monthly) {
+            return IterationRuleInfoResponse.builder()
+                    .type(monthly.getIterationTypeLowerCase())
+                    .monthlyOption(toMonthlyOptionInfo(monthly))
+                    .build();
+        }
+
+        return IterationRuleInfoResponse.builder()
+                .type(info.getIterationTypeLowerCase())
+                .build();
+    }
+
+    private static MonthlyOptionInfoResponse toMonthlyOptionInfo(MonthlyIterationRule monthly) {
+        return MonthlyOptionInfoResponse.builder()
+                .mode(monthly.getMonthlyMode().toString())
+                .day(monthly.getMonthlyDay())
+                .week(monthly.getMonthlyWeek())
+                .dayOfWeek(monthly.getMonthlyDayOfWeek().toString())
+                .build();
+    }
+
+    public static EndInfoResponse toEndInfo(IterationInfo info) {
+        if (info.getEndType() == EndType.AFTER) {
+            return EndInfoResponse.builder()
+                    .type(info.getEndType().toString())
+                    .count(info.getEndCount())
+                    .build();
+        }
+
+        if (info.getEndType() == EndType.UNTIL) {
+            return EndInfoResponse.builder()
+                    .type(info.getEndType().toString())
+                    .date(info.getEndDate())
+                    .build();
+        }
+
+        return EndInfoResponse.builder()
+                .type(info.getEndType().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/poortorich/iteration/provider/IterationCalculatorProvider.java
+++ b/src/main/java/com/poortorich/iteration/provider/IterationCalculatorProvider.java
@@ -1,0 +1,134 @@
+package com.poortorich.iteration.provider;
+
+import com.poortorich.accountbook.entity.AccountBook;
+import com.poortorich.accountbook.entity.enums.IterationType;
+import com.poortorich.iteration.entity.enums.EndType;
+import com.poortorich.iteration.entity.enums.IterationRuleType;
+import com.poortorich.iteration.entity.enums.MonthlyMode;
+import com.poortorich.iteration.entity.enums.Weekday;
+import com.poortorich.iteration.request.CustomIteration;
+import com.poortorich.iteration.request.End;
+import com.poortorich.iteration.request.IterationRule;
+import com.poortorich.iteration.request.MonthlyOption;
+import com.poortorich.iteration.util.IterationDateCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class IterationCalculatorProvider {
+
+    private final IterationDateCalculator dateCalculator;
+
+    public LocalDate calculateDateByRuleType(
+            int cycle, LocalDate date, LocalDate startDate, IterationRule rule, MonthlyOption monthlyOption) {
+        if (rule.parseIterationType() == IterationRuleType.DAILY) {
+            return dateCalculator.dailyTypeDate(date, cycle);
+        }
+
+        if (rule.parseIterationType() == IterationRuleType.WEEKLY) {
+            return dateCalculator.weeklyTypeDate(date, cycle, rule.daysOfWeekToList());
+        }
+
+        if (rule.parseIterationType() == IterationRuleType.MONTHLY) {
+            return calculateDateByMonthlyMode(
+                    date, cycle, monthlyOption, monthlyOption.parseMonthlyMode());
+        }
+
+        return dateCalculator.yearlyTypeDate(date, cycle, startDate);
+    }
+
+    private LocalDate calculateDateByMonthlyMode(
+            LocalDate date, int cycle, MonthlyOption option, MonthlyMode mode) {
+        LocalDate targetDate = date.plusMonths(cycle);
+
+        if (mode == MonthlyMode.DAY) {
+            return dateCalculator.monthlyTypeDayModeDate(targetDate, option.getDay());
+        }
+
+        if (mode == MonthlyMode.WEEKDAY) {
+            return dateCalculator.monthlyTypeWeekDayModeDate(targetDate, option.getWeek(), option.parseDayOfWeek());
+        }
+
+        if (mode == MonthlyMode.END) {
+            return dateCalculator.monthlyTypeEndModeDate(targetDate);
+        }
+
+        return targetDate;
+    }
+
+    public LocalDate calculateEndDateByType(CustomIteration customIteration, AccountBook accountBook, LocalDate startDate) {
+        if (accountBook.getIterationType() == IterationType.CUSTOM) {
+            return calculateEndDateByEnd(customIteration.getEnd(), customIteration, startDate);
+        }
+
+        if (accountBook.getIterationType() == IterationType.DAILY || accountBook.getIterationType() == IterationType.WEEKDAY) {
+            return dateCalculator.yearlyTypeDate(startDate, 3, startDate);
+        }
+
+        return dateCalculator.yearlyTypeDate(startDate, 10, startDate);
+    }
+
+    private LocalDate calculateEndDateByEnd(End end, CustomIteration customIteration, LocalDate startDate) {
+        if (end.parseEndType() == EndType.NEVER) {
+            return defaultEndDateByRule(customIteration.getIterationRule().parseIterationType(), startDate);
+        }
+
+        if (end.parseEndType() == EndType.AFTER) {
+            IterationRule rule = customIteration.getIterationRule();
+
+            if (rule.parseIterationType() == IterationRuleType.WEEKLY) {
+                return dateCalculator.weeklyEndDate(
+                        startDate, end.getCount() * customIteration.getCycle() - 1, rule.daysOfWeekToList());
+            }
+
+            return calculateDateByRuleType(
+                    end.getCount() * customIteration.getCycle() - 1, startDate, startDate, rule, rule.getMonthlyOption()
+            );
+        }
+
+        return end.parseDate();
+    }
+
+    private LocalDate defaultEndDateByRule(IterationRuleType rule, LocalDate startDate) {
+        if (rule == IterationRuleType.DAILY) {
+            return dateCalculator.yearlyTypeDate(startDate, 3, startDate);
+        }
+
+        if (rule == IterationRuleType.WEEKLY) {
+            return dateCalculator.yearlyTypeDate(startDate, 5, startDate);
+        }
+
+        return dateCalculator.yearlyTypeDate(startDate, 10, startDate);
+    }
+
+    public LocalDate defaultCalculateDateByType(IterationType type, LocalDate date, LocalDate startDate) {
+        if (type == IterationType.DAILY) {
+            return dateCalculator.dailyTypeDate(date, 1);
+        }
+
+        if (type == IterationType.WEEKLY) {
+            return dateCalculator.weeklyTypeDate(date, 1);
+        }
+
+        if (type == IterationType.MONTHLY) {
+            return dateCalculator.monthlyTypeDate(date, 1);
+        }
+
+        if (type == IterationType.YEARLY) {
+            return dateCalculator.yearlyTypeDate(date, 1, startDate);
+        }
+
+        if (type == IterationType.WEEKDAY) {
+            List<Weekday> allWeekdays = new ArrayList<>(EnumSet.allOf(Weekday.class));
+            return dateCalculator.weeklyTypeDate(date, 1, allWeekdays);
+        }
+
+        return dateCalculator.monthlyTypeEndModeDate(date);
+    }
+}

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -87,7 +87,10 @@ public class IterationService {
         if (type == IterationType.CUSTOM) {
             IterationRule rule = customIteration.getIterationRule();
             return calculatorProvider.calculateDateByRuleType(
-                    customIteration.getCycle(), date, startDate, rule, rule.getMonthlyOption()
+                    customIteration.getCycle(),
+                    date, startDate,
+                    rule,
+                    rule.getMonthlyOption()
             );
         }
 
@@ -132,7 +135,10 @@ public class IterationService {
             return IterationBuilder.buildWeeklyIterationInfo(customIteration);
         }
         if (ruleType == IterationRuleType.MONTHLY) {
-            return IterationBuilder.buildMonthlyIterationInfo(customIteration, customIteration.getIterationRule().getMonthlyOption());
+            return IterationBuilder.buildMonthlyIterationInfo(
+                    customIteration,
+                    customIteration.getIterationRule().getMonthlyOption()
+            );
         }
         if (ruleType == IterationRuleType.YEARLY) {
             return IterationBuilder.buildYearlyIterationInfo(customIteration);
@@ -178,7 +184,14 @@ public class IterationService {
                 = iterationRepository.findAllByOriginalAccountBookAndUser(user, originalAccountBook, type);
 
         List<Iteration> deleteIterations = resolveIterations(
-                iterationAction, originalAccountBook, accountBookToDelete, iteration, allIterations, user, DELETE_TYPE, type
+                iterationAction,
+                originalAccountBook,
+                accountBookToDelete,
+                iteration,
+                allIterations,
+                user,
+                DELETE_TYPE,
+                type
         );
 
         iterationRepository.deleteAll(deleteIterations, type);

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -186,14 +186,14 @@ public class IterationService {
 
         if (rule.parseIterationType() == IterationRuleType.MONTHLY) {
             return processCalculatorByMonthlyRule(
-                    date, cycle, startDate, monthlyOption, monthlyOption.parseMonthlyMode());
+                    date, cycle, monthlyOption, monthlyOption.parseMonthlyMode());
         }
 
         return dateCalculator.yearlyTypeDate(date, cycle, startDate);
     }
 
     private LocalDate processCalculatorByMonthlyRule(
-            LocalDate date, int cycle, LocalDate startDate, MonthlyOption option, MonthlyMode mode) {
+            LocalDate date, int cycle, MonthlyOption option, MonthlyMode mode) {
         LocalDate targetDate = date.plusMonths(cycle);
 
         if (mode == MonthlyMode.DAY) {

--- a/src/main/java/com/poortorich/iteration/service/IterationService.java
+++ b/src/main/java/com/poortorich/iteration/service/IterationService.java
@@ -9,28 +9,23 @@ import com.poortorich.accountbook.entity.enums.IterationType;
 import com.poortorich.accountbook.request.enums.IterationAction;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.iteration.entity.Iteration;
-import com.poortorich.iteration.entity.enums.Weekday;
-import com.poortorich.iteration.entity.enums.EndType;
 import com.poortorich.iteration.entity.enums.IterationRuleType;
-import com.poortorich.iteration.entity.enums.MonthlyMode;
 import com.poortorich.iteration.entity.info.IterationInfo;
+import com.poortorich.iteration.mapper.IterationMapper;
+import com.poortorich.iteration.provider.IterationCalculatorProvider;
 import com.poortorich.iteration.repository.IterationInfoRepository;
 import com.poortorich.iteration.repository.IterationRepository;
 import com.poortorich.iteration.request.CustomIteration;
-import com.poortorich.iteration.request.End;
 import com.poortorich.iteration.request.IterationRule;
-import com.poortorich.iteration.request.MonthlyOption;
 import com.poortorich.iteration.response.CustomIterationInfoResponse;
 import com.poortorich.iteration.response.IterationResponse;
 import com.poortorich.iteration.util.IterationBuilder;
-import com.poortorich.iteration.util.IterationDateCalculator;
 import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 
 @Service
@@ -40,7 +35,7 @@ public class IterationService {
     private static final String MODIFY_TYPE = "modify";
     private static final String DELETE_TYPE = "delete";
 
-    private final IterationDateCalculator dateCalculator;
+    private final IterationCalculatorProvider calculatorProvider;
     private final IterationRepository iterationRepository;
     private final IterationInfoRepository iterationInfoRepository;
 
@@ -69,7 +64,7 @@ public class IterationService {
     ) {
         List<AccountBook> iterations = new ArrayList<>();
         LocalDate date = getDateByIterationType(customIteration, startDate, startDate, accountBook.getIterationType());
-        LocalDate endDate = calculateEndDate(customIteration, accountBook, startDate);
+        LocalDate endDate = calculatorProvider.calculateEndDateByType(customIteration, accountBook, startDate);
         int maxIterations = 0;
         int allowedIterations = getAllowedIterations(accountBook.getIterationType(), customIteration);
 
@@ -91,54 +86,12 @@ public class IterationService {
             CustomIteration customIteration, LocalDate date, LocalDate startDate, IterationType type) {
         if (type == IterationType.CUSTOM) {
             IterationRule rule = customIteration.getIterationRule();
-            return calculateDateByRuleType(customIteration.getCycle(), date, startDate, rule, rule.getMonthlyOption());
+            return calculatorProvider.calculateDateByRuleType(
+                    customIteration.getCycle(), date, startDate, rule, rule.getMonthlyOption()
+            );
         }
 
-        return calculateDateByIterationType(type, date, startDate);
-    }
-
-    private LocalDate calculateEndDate(CustomIteration customIteration, AccountBook accountBook, LocalDate startDate) {
-        if (accountBook.getIterationType() == IterationType.CUSTOM) {
-            return calculateEndDate(customIteration.getEnd(), customIteration, startDate);
-        }
-
-        if (accountBook.getIterationType() == IterationType.DAILY || accountBook.getIterationType() == IterationType.WEEKDAY) {
-            return dateCalculator.yearlyTypeDate(startDate, 3, startDate);
-        }
-
-        return dateCalculator.yearlyTypeDate(startDate, 10, startDate);
-    }
-
-    private LocalDate calculateEndDate(End end, CustomIteration customIteration, LocalDate startDate) {
-        if (end.parseEndType() == EndType.NEVER) {
-            return calculateEndDateByIterationRule(customIteration.getIterationRule().parseIterationType(), startDate);
-        }
-
-        if (end.parseEndType() == EndType.AFTER) {
-            IterationRule rule = customIteration.getIterationRule();
-
-            if (rule.parseIterationType() == IterationRuleType.WEEKLY) {
-                return dateCalculator.weeklyEndDate(
-                        startDate, end.getCount() * customIteration.getCycle() - 1, rule.daysOfWeekToList());
-            }
-
-            return calculateDateByRuleType(
-                    end.getCount() * customIteration.getCycle() - 1, startDate, startDate, rule, rule.getMonthlyOption());
-        }
-
-        return end.parseDate();
-    }
-
-    private LocalDate calculateEndDateByIterationRule(IterationRuleType rule, LocalDate startDate) {
-        if (rule == IterationRuleType.DAILY) {
-            return dateCalculator.yearlyTypeDate(startDate, 3, startDate);
-        }
-
-        if (rule == IterationRuleType.WEEKLY) {
-            return dateCalculator.yearlyTypeDate(startDate, 5, startDate);
-        }
-
-        return dateCalculator.yearlyTypeDate(startDate, 10, startDate);
+        return calculatorProvider.defaultCalculateDateByType(type, date, startDate);
     }
 
     private int getAllowedIterations(IterationType type, CustomIteration customIteration) {
@@ -147,68 +100,6 @@ public class IterationService {
         }
 
         return IterationRuleType.DAILY.maxIterations;
-    }
-
-    private LocalDate calculateDateByIterationType(IterationType type, LocalDate date, LocalDate startDate) {
-        if (type == IterationType.DAILY) {
-            return dateCalculator.dailyTypeDate(date, 1);
-        }
-
-        if (type == IterationType.WEEKLY) {
-            return dateCalculator.weeklyTypeDate(date, 1);
-        }
-
-        if (type == IterationType.MONTHLY) {
-            return dateCalculator.monthlyTypeDate(date, 1);
-        }
-
-        if (type == IterationType.YEARLY) {
-            return dateCalculator.yearlyTypeDate(date, 1, startDate);
-        }
-
-        if (type == IterationType.WEEKDAY) {
-            List<Weekday> allWeekdays = new ArrayList<>(EnumSet.allOf(Weekday.class));
-            return dateCalculator.weeklyTypeDate(date, 1, allWeekdays);
-        }
-
-        return dateCalculator.monthlyTypeEndModeDate(date);
-    }
-
-    private LocalDate calculateDateByRuleType(
-            int cycle, LocalDate date, LocalDate startDate, IterationRule rule, MonthlyOption monthlyOption) {
-        if (rule.parseIterationType() == IterationRuleType.DAILY) {
-            return dateCalculator.dailyTypeDate(date, cycle);
-        }
-
-        if (rule.parseIterationType() == IterationRuleType.WEEKLY) {
-            return dateCalculator.weeklyTypeDate(date, cycle, rule.daysOfWeekToList());
-        }
-
-        if (rule.parseIterationType() == IterationRuleType.MONTHLY) {
-            return processCalculatorByMonthlyRule(
-                    date, cycle, monthlyOption, monthlyOption.parseMonthlyMode());
-        }
-
-        return dateCalculator.yearlyTypeDate(date, cycle, startDate);
-    }
-
-    private LocalDate processCalculatorByMonthlyRule(
-            LocalDate date, int cycle, MonthlyOption option, MonthlyMode mode) {
-        LocalDate targetDate = date.plusMonths(cycle);
-
-        if (mode == MonthlyMode.DAY) {
-            return dateCalculator.monthlyTypeDayModeDate(targetDate, option.getDay());
-        }
-
-        if (mode == MonthlyMode.WEEKDAY) {
-            return dateCalculator.monthlyTypeWeekDayModeDate(targetDate, option.getWeek(), option.parseDayOfWeek());
-        }
-
-        if (mode == MonthlyMode.END) {
-            return dateCalculator.monthlyTypeEndModeDate(targetDate);
-        }
-
-        return targetDate;
     }
 
     public void createIterationInfo(
@@ -253,9 +144,9 @@ public class IterationService {
     public CustomIterationInfoResponse getCustomIteration(Iteration iteration) {
         IterationInfo iterationInfo = iteration.getIterationInfo();
         return CustomIterationInfoResponse.builder()
-                .iterationRule(IterationBuilder.buildIterationRuleByRuleType(iterationInfo))
+                .iterationRule(IterationMapper.toIterationRuleInfo(iterationInfo))
                 .cycle(iterationInfo.getCycle())
-                .end(IterationBuilder.buildEndInfoResponseByEndType(iterationInfo))
+                .end(IterationMapper.toEndInfo(iterationInfo))
                 .build();
     }
 

--- a/src/main/java/com/poortorich/iteration/util/IterationBuilder.java
+++ b/src/main/java/com/poortorich/iteration/util/IterationBuilder.java
@@ -132,23 +132,11 @@ public class IterationBuilder {
     }
 
     public static MonthlyOptionInfoResponse buildMonthlyOptionInfoResponseByMonthlyMode(MonthlyIterationRule monthly) {
-        if (monthly.getMonthlyMode() == MonthlyMode.DAY) {
-            return MonthlyOptionInfoResponse.builder()
-                    .mode(monthly.getMonthlyMode().toString())
-                    .day(monthly.getMonthlyDay())
-                    .week(monthly.getMonthlyWeek())
-                    .build();
-        }
-
-        if (monthly.getMonthlyMode() == MonthlyMode.WEEKDAY) {
-            return MonthlyOptionInfoResponse.builder()
-                    .mode(monthly.getMonthlyMode().toString())
-                    .dayOfWeek(monthly.getMonthlyDayOfWeek().toString())
-                    .build();
-        }
-
         return MonthlyOptionInfoResponse.builder()
                 .mode(monthly.getMonthlyMode().toString())
+                .day(monthly.getMonthlyDay())
+                .week(monthly.getMonthlyWeek())
+                .dayOfWeek(monthly.getMonthlyDayOfWeek().toString())
                 .build();
     }
 

--- a/src/main/java/com/poortorich/iteration/util/IterationBuilder.java
+++ b/src/main/java/com/poortorich/iteration/util/IterationBuilder.java
@@ -7,8 +7,6 @@ import com.poortorich.income.entity.Income;
 import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.iteration.entity.IterationIncomes;
-import com.poortorich.iteration.entity.enums.EndType;
-import com.poortorich.iteration.entity.enums.MonthlyMode;
 import com.poortorich.iteration.entity.info.DailyIterationRule;
 import com.poortorich.iteration.entity.info.IterationInfo;
 import com.poortorich.iteration.entity.info.MonthlyIterationRule;
@@ -16,11 +14,7 @@ import com.poortorich.iteration.entity.info.WeeklyIterationRule;
 import com.poortorich.iteration.entity.info.YearlyIterationRule;
 import com.poortorich.iteration.request.CustomIteration;
 import com.poortorich.iteration.request.MonthlyOption;
-import com.poortorich.iteration.response.EndInfoResponse;
-import com.poortorich.iteration.response.IterationRuleInfoResponse;
-import com.poortorich.iteration.response.MonthlyOptionInfoResponse;
 import com.poortorich.user.entity.User;
-import org.hibernate.Hibernate;
 
 public class IterationBuilder {
 
@@ -106,57 +100,6 @@ public class IterationBuilder {
                 .endType(customIteration.getEnd().parseEndType())
                 .endCount(customIteration.getEnd().getCount())
                 .endDate(customIteration.getEnd().parseDate())
-                .build();
-    }
-
-    public static IterationRuleInfoResponse buildIterationRuleByRuleType(IterationInfo info) {
-        IterationInfo unproxiedInfo = (IterationInfo) Hibernate.unproxy(info);
-
-        if (unproxiedInfo instanceof WeeklyIterationRule weekly) {
-            return IterationRuleInfoResponse.builder()
-                    .type(weekly.getIterationTypeLowerCase())
-                    .daysOfWeek(weekly.getDaysOfWeekList())
-                    .build();
-        }
-
-        if (unproxiedInfo instanceof MonthlyIterationRule monthly) {
-            return IterationRuleInfoResponse.builder()
-                    .type(monthly.getIterationTypeLowerCase())
-                    .monthlyOption(buildMonthlyOptionInfoResponseByMonthlyMode(monthly))
-                    .build();
-        }
-
-        return IterationRuleInfoResponse.builder()
-                .type(info.getIterationTypeLowerCase())
-                .build();
-    }
-
-    public static MonthlyOptionInfoResponse buildMonthlyOptionInfoResponseByMonthlyMode(MonthlyIterationRule monthly) {
-        return MonthlyOptionInfoResponse.builder()
-                .mode(monthly.getMonthlyMode().toString())
-                .day(monthly.getMonthlyDay())
-                .week(monthly.getMonthlyWeek())
-                .dayOfWeek(monthly.getMonthlyDayOfWeek().toString())
-                .build();
-    }
-
-    public static EndInfoResponse buildEndInfoResponseByEndType(IterationInfo info) {
-        if (info.getEndType() == EndType.AFTER) {
-            return EndInfoResponse.builder()
-                    .type(info.getEndType().toString())
-                    .count(info.getEndCount())
-                    .build();
-        }
-
-        if (info.getEndType() == EndType.UNTIL) {
-            return EndInfoResponse.builder()
-                    .type(info.getEndType().toString())
-                    .date(info.getEndDate())
-                    .build();
-        }
-
-        return EndInfoResponse.builder()
-                .type(info.getEndType().toString())
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/iteration/util/IterationBuilder.java
+++ b/src/main/java/com/poortorich/iteration/util/IterationBuilder.java
@@ -7,8 +7,20 @@ import com.poortorich.income.entity.Income;
 import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.entity.IterationExpenses;
 import com.poortorich.iteration.entity.IterationIncomes;
+import com.poortorich.iteration.entity.enums.EndType;
+import com.poortorich.iteration.entity.enums.MonthlyMode;
+import com.poortorich.iteration.entity.info.DailyIterationRule;
 import com.poortorich.iteration.entity.info.IterationInfo;
+import com.poortorich.iteration.entity.info.MonthlyIterationRule;
+import com.poortorich.iteration.entity.info.WeeklyIterationRule;
+import com.poortorich.iteration.entity.info.YearlyIterationRule;
+import com.poortorich.iteration.request.CustomIteration;
+import com.poortorich.iteration.request.MonthlyOption;
+import com.poortorich.iteration.response.EndInfoResponse;
+import com.poortorich.iteration.response.IterationRuleInfoResponse;
+import com.poortorich.iteration.response.MonthlyOptionInfoResponse;
 import com.poortorich.user.entity.User;
+import org.hibernate.Hibernate;
 
 public class IterationBuilder {
 
@@ -52,6 +64,111 @@ public class IterationBuilder {
                 .generatedIncome(generatedIncome)
                 .iterationInfo(iterationInfo)
                 .user(user)
+                .build();
+    }
+
+    public static DailyIterationRule buildDailyIterationInfo(CustomIteration customIteration) {
+        return DailyIterationRule.builder()
+                .cycle(customIteration.getCycle())
+                .endType(customIteration.getEnd().parseEndType())
+                .endCount(customIteration.getEnd().getCount())
+                .endDate(customIteration.getEnd().parseDate())
+                .build();
+    }
+
+    public static WeeklyIterationRule buildWeeklyIterationInfo(CustomIteration customIteration) {
+        return WeeklyIterationRule.builder()
+                .daysOfWeek(customIteration.getIterationRule().parseDaysOfWeek())
+                .cycle(customIteration.getCycle())
+                .endType(customIteration.getEnd().parseEndType())
+                .endCount(customIteration.getEnd().getCount())
+                .endDate(customIteration.getEnd().parseDate())
+                .build();
+    }
+
+    public static MonthlyIterationRule buildMonthlyIterationInfo(CustomIteration customIteration,
+                                                           MonthlyOption monthlyOption) {
+        return MonthlyIterationRule.builder()
+                .monthlyMode(monthlyOption.parseMonthlyMode())
+                .monthlyDay(monthlyOption.getDay())
+                .monthlyWeek(monthlyOption.getWeek())
+                .monthlyDayOfWeek(monthlyOption.parseDayOfWeek())
+                .cycle(customIteration.getCycle())
+                .endType(customIteration.getEnd().parseEndType())
+                .endCount(customIteration.getEnd().getCount())
+                .endDate(customIteration.getEnd().parseDate())
+                .build();
+    }
+
+    public static YearlyIterationRule buildYearlyIterationInfo(CustomIteration customIteration) {
+        return YearlyIterationRule.builder()
+                .cycle(customIteration.getCycle())
+                .endType(customIteration.getEnd().parseEndType())
+                .endCount(customIteration.getEnd().getCount())
+                .endDate(customIteration.getEnd().parseDate())
+                .build();
+    }
+
+    public static IterationRuleInfoResponse buildIterationRuleByRuleType(IterationInfo info) {
+        IterationInfo unproxiedInfo = (IterationInfo) Hibernate.unproxy(info);
+
+        if (unproxiedInfo instanceof WeeklyIterationRule weekly) {
+            return IterationRuleInfoResponse.builder()
+                    .type(weekly.getIterationTypeLowerCase())
+                    .daysOfWeek(weekly.getDaysOfWeekList())
+                    .build();
+        }
+
+        if (unproxiedInfo instanceof MonthlyIterationRule monthly) {
+            return IterationRuleInfoResponse.builder()
+                    .type(monthly.getIterationTypeLowerCase())
+                    .monthlyOption(buildMonthlyOptionInfoResponseByMonthlyMode(monthly))
+                    .build();
+        }
+
+        return IterationRuleInfoResponse.builder()
+                .type(info.getIterationTypeLowerCase())
+                .build();
+    }
+
+    public static MonthlyOptionInfoResponse buildMonthlyOptionInfoResponseByMonthlyMode(MonthlyIterationRule monthly) {
+        if (monthly.getMonthlyMode() == MonthlyMode.DAY) {
+            return MonthlyOptionInfoResponse.builder()
+                    .mode(monthly.getMonthlyMode().toString())
+                    .day(monthly.getMonthlyDay())
+                    .week(monthly.getMonthlyWeek())
+                    .build();
+        }
+
+        if (monthly.getMonthlyMode() == MonthlyMode.WEEKDAY) {
+            return MonthlyOptionInfoResponse.builder()
+                    .mode(monthly.getMonthlyMode().toString())
+                    .dayOfWeek(monthly.getMonthlyDayOfWeek().toString())
+                    .build();
+        }
+
+        return MonthlyOptionInfoResponse.builder()
+                .mode(monthly.getMonthlyMode().toString())
+                .build();
+    }
+
+    public static EndInfoResponse buildEndInfoResponseByEndType(IterationInfo info) {
+        if (info.getEndType() == EndType.AFTER) {
+            return EndInfoResponse.builder()
+                    .type(info.getEndType().toString())
+                    .count(info.getEndCount())
+                    .build();
+        }
+
+        if (info.getEndType() == EndType.UNTIL) {
+            return EndInfoResponse.builder()
+                    .type(info.getEndType().toString())
+                    .date(info.getEndDate())
+                    .build();
+        }
+
+        return EndInfoResponse.builder()
+                .type(info.getEndType().toString())
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/iteration/validator/MonthlyOptionValidator.java
+++ b/src/main/java/com/poortorich/iteration/validator/MonthlyOptionValidator.java
@@ -11,68 +11,30 @@ public class MonthlyOptionValidator implements ConstraintValidator<MonthlyOption
 
     @Override
     public boolean isValid(MonthlyOption monthlyOption, ConstraintValidatorContext context) {
-        MonthlyMode mode = monthlyOption.parseMonthlyMode();
+        boolean dayValid = validateNotNull(monthlyOption.getDay(), context,
+                IterationResponseMessages.MONTHLY_OPTION_DAY_REQUIRED,
+                IterationValidationConstraints.MONTHLY_OPTION_DAY_FIELD_NAME);
 
-        boolean dayOfMonthValid = dayOfMonthValid(mode, monthlyOption.getDay(), context);
-        boolean weekdayOfMonthValid = weekdayOfMonthValid(mode, monthlyOption.getWeek(), monthlyOption.getDayOfWeek(), context);
+        boolean weekValid = validateNotNull(monthlyOption.getWeek(), context,
+                IterationResponseMessages.MONTHLY_OPTION_WEEK_REQUIRED,
+                IterationValidationConstraints.MONTHLY_OPTION_WEEK_FIELD_NAME);
 
-        return dayOfMonthValid && weekdayOfMonthValid;
+        boolean dayOfWeekValid = validateNotNull(monthlyOption.getDayOfWeek(), context,
+                IterationResponseMessages.MONTHLY_OPTION_DAY_OF_WEEK_REQUIRED,
+                IterationValidationConstraints.MONTHLY_OPTION_DAY_OF_WEEK_FIELD_NAME);
+
+        return dayValid && weekValid && dayOfWeekValid;
     }
 
-    private boolean dayOfMonthValid(MonthlyMode mode, Integer day, ConstraintValidatorContext context) {
-        if (mode == MonthlyMode.DAY && day == null) {
-            buildCustomMessage(
-                    context,
-                    IterationResponseMessages.MONTHLY_OPTION_DAY_REQUIRED,
-                    IterationValidationConstraints.MONTHLY_OPTION_DAY_FIELD_NAME
-            );
+    private boolean validateNotNull(Object value, ConstraintValidatorContext context, String message, String fieldName) {
+        if (value == null) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(message)
+                    .addPropertyNode(fieldName)
+                    .addConstraintViolation();
             return false;
         }
 
         return true;
-    }
-
-    private boolean weekdayOfMonthValid(MonthlyMode mode, Integer week, String dayOfWeek, ConstraintValidatorContext context) {
-        if (mode == MonthlyMode.WEEKDAY) {
-            boolean weekValid = weekValid(week, context);
-            boolean dayOfWeekValid = dayOfWeekValid(dayOfWeek, context);
-
-            return weekValid && dayOfWeekValid;
-        }
-
-        return true;
-    }
-
-    private boolean weekValid(Integer week, ConstraintValidatorContext context) {
-        if (week == null) {
-            buildCustomMessage(
-                    context,
-                    IterationResponseMessages.MONTHLY_OPTION_WEEK_REQUIRED,
-                    IterationValidationConstraints.MONTHLY_OPTION_WEEK_FIELD_NAME
-            );
-            return false;
-        }
-
-        return true;
-    }
-
-    private boolean dayOfWeekValid(String dayOfWeek, ConstraintValidatorContext context) {
-        if (dayOfWeek == null) {
-            buildCustomMessage(
-                    context,
-                    IterationResponseMessages.MONTHLY_OPTION_DAY_OF_WEEK_REQUIRED,
-                    IterationValidationConstraints.MONTHLY_OPTION_DAY_OF_WEEK_FIELD_NAME
-            );
-            return false;
-        }
-
-        return true;
-    }
-
-    private void buildCustomMessage(ConstraintValidatorContext context, String message, String fieldName) {
-        context.disableDefaultConstraintViolation();
-        context.buildConstraintViolationWithTemplate(message)
-                .addPropertyNode(fieldName)
-                .addConstraintViolation();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#242
 
 ## 📝작업 내용
 
- 프론트엔드의 요청에 따라 반복데이터 매달 옵션일 때의 모든 값을 요청으로 받고 응답으로 반환하도록 수정
- Entity의 `@NoArgsConstructor`의 access level을 `PROTECTED`로 변경

### `IterationCalculatorProvider`

- 반복데이터 중 날짜 계산을 하는 로직의 분기문들을 모아둔 클래스

### `IterationBuilder`

- Entity와 관련된 Builder를 모아둔 클래스

### `IterationMapper`

- DTO와 관련된 Builder를 모아둔 클래스
 
 ### 스크린샷 (선택)
 
 ## 💬리뷰 요구사항

- 클래스 이름 네이밍
- 반복데이터 관련 더 필요한 리팩토링
