### PR TITLE
[#253] QA 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -26,8 +26,6 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -242,8 +240,12 @@ public class AccountBookService {
 
     public Long getTotalCostByCategory(User user, DateInfo dateInfo, Category category, AccountBookType type) {
         List<AccountBook> accountBooks = getAccountBookBetweenDates(
-                user, dateInfo.getStartDate(), dateInfo.getEndDate(), type
-        );
+                user,
+                dateInfo.getStartDate(),
+                dateInfo.getEndDate(),
+                type);
+        
+        accountBooks = AccountBookExtractor.extractByCategory(accountBooks, category);
 
         return AccountBookCalculator.sum(accountBooks);
     }

--- a/src/main/java/com/poortorich/auth/service/AuthService.java
+++ b/src/main/java/com/poortorich/auth/service/AuthService.java
@@ -40,7 +40,7 @@ public class AuthService {
     private final JwtTokenGenerator tokenGenerator;
     private final JwtTokenValidator tokenValidator;
     private final JwtTokenExtractor tokenExtractor;
-    private final JwtTokenManager cookieManager;
+    private final JwtTokenManager tokenManager;
 
     public AccessTokenResponse login(LoginRequest loginRequest, HttpServletResponse response) {
         if (!userRepository.existsByUsername(loginRequest.getUsername())) {
@@ -58,7 +58,7 @@ public class AuthService {
         String refreshToken = tokenGenerator.generateRefreshToken(user);
 
         refreshTokenRepository.save(user.getId(), refreshToken);
-        cookieManager.setRefreshTokens(response, refreshToken);
+        tokenManager.setRefreshTokens(response, refreshToken);
 
         return AccessTokenResponse.builder()
                 .accessToken(JwtConstants.TOKEN_PREFIX + accessToken)
@@ -66,7 +66,7 @@ public class AuthService {
     }
 
     public AccessTokenResponse refreshToken(HttpServletRequest request, HttpServletResponse response) {
-        Optional<String> refreshTokenOpt = cookieManager.extractRefreshTokenFromCookies(request);
+        Optional<String> refreshTokenOpt = tokenManager.extractRefreshTokenFromCookies(request);
 
         if (refreshTokenOpt.isEmpty()) {
             System.out.println("토큰이 없습니다.");
@@ -85,7 +85,7 @@ public class AuthService {
             refreshTokenRepository.deleteByUserIdAndToken(user.getId(), refreshToken);
             refreshTokenRepository.save(user.getId(), newRefreshToken);
 
-            cookieManager.setRefreshTokens(response, newRefreshToken);
+            tokenManager.setRefreshTokens(response, newRefreshToken);
 
             return AccessTokenResponse.builder()
                     .accessToken(JwtConstants.TOKEN_PREFIX + accessToken)
@@ -98,7 +98,7 @@ public class AuthService {
     }
 
     public Response logout(HttpServletResponse response) {
-        cookieManager.clearAuthTokens(response);
+        tokenManager.clearAuthTokens(response);
         return AuthResponse.LOGOUT_SUCCESS;
     }
 }

--- a/src/main/java/com/poortorich/chart/collector/ChartDataCollector.java
+++ b/src/main/java/com/poortorich/chart/collector/ChartDataCollector.java
@@ -116,7 +116,10 @@ public class ChartDataCollector {
     }
 
     public Long getTotalCostExcludingCategory(
-            User user, DateInfo dateInfo, Category savingCategory, AccountBookType type
+            User user,
+            DateInfo dateInfo,
+            Category savingCategory,
+            AccountBookType type
     ) {
         return accountBookService.getTotalCostExcludingCategory(user, dateInfo, savingCategory, type);
     }

--- a/src/main/java/com/poortorich/chart/collector/ChartDataCollector.java
+++ b/src/main/java/com/poortorich/chart/collector/ChartDataCollector.java
@@ -127,4 +127,13 @@ public class ChartDataCollector {
     public Long getTotalCostByCategory(User user, DateInfo dateInfo, Category savingCategory, AccountBookType type) {
         return accountBookService.getTotalCostByCategory(user, dateInfo, savingCategory, type);
     }
+
+    public Long getCountOfLogs(ChartDataContext context) {
+        return accountBookService.countByUserAndCategoryAndBetweenDates(
+                context.getUser(),
+                context.getCategory(),
+                context.getDateInfo().getStartDate(),
+                context.getDateInfo().getEndDate()
+        );
+    }
 }

--- a/src/main/java/com/poortorich/chart/facade/ChartFacade.java
+++ b/src/main/java/com/poortorich/chart/facade/ChartFacade.java
@@ -60,12 +60,14 @@ public class ChartFacade {
         List<AccountBook> accountBooks = dataCollector.getPagedAccountBooks(
                 context.getUser(), context.getCategory(), cursor, context.getDateInfo(), direction);
 
+        Long countOfLogs = dataCollector.getCountOfLogs(context);
+
         List<CategoryLog> categoryLogs = chartService.getCategoryLogs(accountBooks, direction);
 
         PaginationResult paginationResult = paginationHandler.handlePagination(
                 context.getUser(), context.getCategory(), context.getDateInfo(), accountBooks, direction);
 
-        return responseFactory.createCategorySectionResponse(categoryLogs, paginationResult);
+        return responseFactory.createCategorySectionResponse(categoryLogs, countOfLogs, paginationResult);
     }
 
     public CategoryChartResponse getCategoryChart(String username, String date, AccountBookType accountBookType) {

--- a/src/main/java/com/poortorich/chart/factory/ChartResponseFactory.java
+++ b/src/main/java/com/poortorich/chart/factory/ChartResponseFactory.java
@@ -80,14 +80,14 @@ public class ChartResponseFactory {
     }
 
     public CategorySectionResponse createCategorySectionResponse(
-            List<CategoryLog> categoryLogs, PaginationResult paginationResult
+            List<CategoryLog> categoryLogs,
+            Long countOfLog,
+            PaginationResult paginationResult
     ) {
         return CategorySectionResponse.builder()
                 .hasNext(paginationResult.getHasNext())
                 .nextCursor(paginationResult.getNextCursor())
-                .countOfLogs(categoryLogs.stream()
-                        .mapToLong(CategoryLog::getCountOfTransactions)
-                        .sum())
+                .countOfLogs(countOfLog)
                 .categoryLogs(categoryLogs)
                 .build();
     }

--- a/src/main/java/com/poortorich/chart/util/PeriodFormatter.java
+++ b/src/main/java/com/poortorich/chart/util/PeriodFormatter.java
@@ -51,7 +51,7 @@ public class PeriodFormatter {
     public static String formatByDateInfo(DateInfo dateInfo) {
         return switch (dateInfo) {
             case YearInformation yearInfo -> yearInfo.getYear().toString();
-            case MonthInformation monthInfo -> monthInfo.getYearMonth().toString();
+            case MonthInformation monthInfo -> formatMonthKorean(monthInfo.getYearMonth().getMonth());
             case WeekInformation weekInfo -> formatLocalDateRange(weekInfo.getStartDate(), weekInfo.getEndDate());
             default -> throw new BadRequestException(DateResponse.UNSUPPORTED_DATE_FORMAT);
         };

--- a/src/main/java/com/poortorich/user/controller/UserController.java
+++ b/src/main/java/com/poortorich/user/controller/UserController.java
@@ -12,6 +12,7 @@ import com.poortorich.user.request.ProfileUpdateRequest;
 import com.poortorich.user.request.UserRegistrationRequest;
 import com.poortorich.user.request.UsernameCheckRequest;
 import com.poortorich.user.response.enums.UserResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -103,9 +104,11 @@ public class UserController {
     }
 
     @DeleteMapping("/leave")
-    public ResponseEntity<BaseResponse> deleteUserAccount(@AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<BaseResponse> deleteUserAccount(
+            HttpServletResponse response,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
         userFacade.resetAllByUser(userDetails.getUsername());
-        Response response = userFacade.deleteUserAccount(userDetails.getUsername());
-        return BaseResponse.toResponseEntity(response);
+        return BaseResponse.toResponseEntity(userFacade.deleteUserAccount(userDetails.getUsername(), response));
     }
 }

--- a/src/main/java/com/poortorich/user/facade/UserFacade.java
+++ b/src/main/java/com/poortorich/user/facade/UserFacade.java
@@ -94,7 +94,7 @@ public class UserFacade {
 
     @Transactional
     public Response updateUserEmail(String username, EmailUpdateRequest emailUpdateRequest) {
-        userValidationService.validateEmail(emailUpdateRequest.getNewEmail());
+        userValidationService.validateEmail(emailUpdateRequest.getEmail());
         userService.updateEmail(username, emailUpdateRequest);
         return UserResponse.USER_EMAIL_UPDATE_SUCCESS;
     }

--- a/src/main/java/com/poortorich/user/facade/UserFacade.java
+++ b/src/main/java/com/poortorich/user/facade/UserFacade.java
@@ -1,5 +1,6 @@
 package com.poortorich.user.facade;
 
+import com.poortorich.auth.jwt.util.JwtTokenManager;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.global.response.Response;
 import com.poortorich.s3.service.FileUploadService;
@@ -17,6 +18,7 @@ import com.poortorich.user.service.RedisUserReservationService;
 import com.poortorich.user.service.UserResetService;
 import com.poortorich.user.service.UserService;
 import com.poortorich.user.service.UserValidationService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +33,7 @@ public class UserFacade {
     private final RedisUserReservationService userReservationService;
     private final UserResetService userResetService;
     private final CategoryService categoryService;
+    private final JwtTokenManager tokenManager;
 
     @Transactional
     public void registerNewUser(UserRegistrationRequest userRegistrationRequest) {
@@ -97,8 +100,9 @@ public class UserFacade {
     }
 
     @Transactional
-    public Response deleteUserAccount(String username) {
+    public Response deleteUserAccount(String username, HttpServletResponse response) {
         User user = userService.findUserByUsername(username);
+        tokenManager.clearAuthTokens(response);
         userResetService.deleteDefaultCategories(user);
         userService.deleteUserAccount(user);
         return UserResponse.DELETE_USER_ACCOUNT_SUCCESS;

--- a/src/main/java/com/poortorich/user/request/EmailUpdateRequest.java
+++ b/src/main/java/com/poortorich/user/request/EmailUpdateRequest.java
@@ -12,5 +12,5 @@ public class EmailUpdateRequest {
 
     @Email
     @NotBlank(message = UserResponseMessages.EMAIL_REQUIRED)
-    private String newEmail;
+    private String email;
 }

--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -95,7 +95,7 @@ public class UserService {
 
     public void updateEmail(String username, EmailUpdateRequest emailUpdateRequest) {
         User user = findUserByUsername(username);
-        user.updateEmail(emailUpdateRequest.getNewEmail());
+        user.updateEmail(emailUpdateRequest.getEmail());
     }
 
     public void deleteUserAccount(User user) {


### PR DESCRIPTION
## #️⃣253

 ## 📝작업 내용
이번 QA에서 발생한 각종 오류를 수정하였음

1. 차트 페이지 총 금액 및 저출/투자 총액 조회 API에서 **저축/추자 총 금액** 조회 오류 수정
2. 차트 페이지 수직형 막대그래프 조회에서 날짜 포맷팅 오류 수정
3. 카테고리 상세 내역 조회 API에서 총 내역 건수 오류 수정
4. 회원 탈퇴 시 토큰 삭제하는 로직을 추가
5. 이메일 변경 DTO 필드명을 newEmail에서 email로 수정 
 
