### PR TITLE
[#259] 회원 역할 필드 추가

### DIFF
--- a/src/main/java/com/poortorich/auth/jwt/util/JwtTokenExtractor.java
+++ b/src/main/java/com/poortorich/auth/jwt/util/JwtTokenExtractor.java
@@ -29,6 +29,10 @@ public class JwtTokenExtractor {
         return extractAllClaims(token).get("email", String.class);
     }
 
+    public String extractRole(String token) {
+        return extractAllClaims(token).get("role", String.class);
+    }
+
     public Date extractExpirationDate(String token) {
         return extractAllClaims(token).getExpiration();
     }

--- a/src/main/java/com/poortorich/auth/jwt/util/JwtTokenGenerator.java
+++ b/src/main/java/com/poortorich/auth/jwt/util/JwtTokenGenerator.java
@@ -26,6 +26,7 @@ public class JwtTokenGenerator {
                 .subject(user.getUsername())
                 .claim("userId", user.getId())
                 .claim("email", user.getEmail())
+                .claim("role", user.getRole())
                 .issuedAt(now)
                 .expiration(expiryDate)
                 .issuer(JwtConstants.TOKEN_ISSUER)

--- a/src/main/java/com/poortorich/security/config/SecurityConfig.java
+++ b/src/main/java/com/poortorich/security/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(SecurityConstants.PERMIT_ALL_ENDPOINTS).permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().hasRole("USER")
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/poortorich/user/entity/User.java
+++ b/src/main/java/com/poortorich/user/entity/User.java
@@ -2,6 +2,7 @@ package com.poortorich.user.entity;
 
 import com.poortorich.user.constants.UserValidationRules;
 import com.poortorich.user.entity.enums.Gender;
+import com.poortorich.user.entity.enums.Role;
 import com.poortorich.user.request.ProfileUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -24,6 +25,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
@@ -68,6 +70,11 @@ public class User implements UserDetails {
     @Column(name = "job")
     private String job;
 
+    @Column(name = "role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private Role role = Role.USER;
+
     @Column(name = "createdDate", nullable = false)
     @CreationTimestamp
     private LocalDateTime createdDate;
@@ -78,7 +85,7 @@ public class User implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
     }
 
     @Override

--- a/src/main/java/com/poortorich/user/entity/enums/Role.java
+++ b/src/main/java/com/poortorich/user/entity/enums/Role.java
@@ -1,0 +1,18 @@
+package com.poortorich.user.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    ADMIN("관리자"),
+    USER("일반회원");
+
+    private final String description;
+
+    public static Role from(String role) {
+        return Role.valueOf(role.toUpperCase());
+    }
+}


### PR DESCRIPTION
## #️⃣259
 
 ## 📝작업 내용
1. JWT 토큰에 회원 역할 정보 삽입
2. 회원 역할에 API 호출 허용 로직 추가
 
회원 역할 정보가 실제로 API 호출을 차단하는지 확인해보았습니다. 
테스트 코드와 실행 결과는 아래와 같습니다.

그리고 로컬테스트 환경에서 ROLE이 `null`일 때 `ADMIN`으로 추가되는 현상을 찾았습니다.
-> DB 초기화 후 회원가입하는 경우 `USER`로 잘 들어갔습니다.

![ROLE 추가](https://github.com/user-attachments/assets/fd882e3d-4b0d-45fd-84e2-68b72e9127cf)
![ROLE 추가2](https://github.com/user-attachments/assets/aca52a31-178b-48f0-b0f6-0f270710288c)

