### PR TITLE
[#261] 카테고리 편집 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/category/repository/CategoryRepository.java
+++ b/src/main/java/com/poortorich/category/repository/CategoryRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -20,6 +21,17 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByNameAndUser(String name, User user);
 
     Optional<Category> findByUserAndNameAndTypeInAndIsDeletedFalse(User user, String name, List<CategoryType> type);
+
+    @Query("""
+        SELECT c
+         FROM Category c
+        WHERE c.user = :user
+          AND c.name = :name
+          AND c.type IN :type
+          AND c.isDeleted = false
+          AND c.id <> :id
+    """)
+    Optional<Category> findByNameExcludingId(User user, String name, List<CategoryType> type, Long id);
 
     List<Category> findByUserAndTypeAndIsDeletedFalse(User user, CategoryType type);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#261
 
 ## 📝작업 내용
 
- 카테고리 편집시 이름을 변경하지 않았을 때 (ex. 색상만 변경한 경우) 잘못된 오류 수정
   - 카테고리 편집시 같은 아이디인 경우 조회되지 않는 새로운 Repository 메서드 추가
>  ![image](https://github.com/user-attachments/assets/e120c8c6-db3f-4163-9f3f-82fc83511b1b)
 
 ### 스크린샷

> 색상만 변경한 경우 잘 변경됨
![image](https://github.com/user-attachments/assets/0ad6cbc8-a89a-422f-9ad4-bcbedbe0cf01)
 
 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
