### PR TITLE
[#265] 회원 역할 조회 및 수정 API

### DIFF
--- a/src/main/java/com/poortorich/admin/constants/AdminResponseMessage.java
+++ b/src/main/java/com/poortorich/admin/constants/AdminResponseMessage.java
@@ -1,0 +1,4 @@
+package com.poortorich.admin.constants;
+
+public class AdminResponseMessage {
+}

--- a/src/main/java/com/poortorich/admin/constants/AdminResponseMessage.java
+++ b/src/main/java/com/poortorich/admin/constants/AdminResponseMessage.java
@@ -1,4 +1,7 @@
 package com.poortorich.admin.constants;
 
 public class AdminResponseMessage {
+
+    public static final String ROLE_UPDATE_SUCCESS = "사용자 역할 변경 성공";
+    public static final String ROLE_INVALID = "유효하지 않은 역할입니다.";
 }

--- a/src/main/java/com/poortorich/admin/constants/AdminResponseMessage.java
+++ b/src/main/java/com/poortorich/admin/constants/AdminResponseMessage.java
@@ -3,5 +3,4 @@ package com.poortorich.admin.constants;
 public class AdminResponseMessage {
 
     public static final String ROLE_UPDATE_SUCCESS = "사용자 역할 변경 성공";
-    public static final String ROLE_INVALID = "유효하지 않은 역할입니다.";
 }

--- a/src/main/java/com/poortorich/admin/controller/AdminController.java
+++ b/src/main/java/com/poortorich/admin/controller/AdminController.java
@@ -1,0 +1,34 @@
+package com.poortorich.admin.controller;
+
+import com.poortorich.admin.facade.AdminFacade;
+import com.poortorich.admin.request.UserRoleUpdateRequest;
+import com.poortorich.admin.response.enums.AdminResponse;
+import com.poortorich.global.response.BaseResponse;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final AdminFacade adminFacade;
+
+    @PutMapping("/{userId}/role")
+    public ResponseEntity<BaseResponse> updateUserRole(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable @Nullable Long userId,
+            @RequestBody UserRoleUpdateRequest userRoleUpdateRequest
+    ) {
+        adminFacade.updateUserRole(userId, userRoleUpdateRequest);
+        return BaseResponse.toResponseEntity(AdminResponse.ROLE_UPDATE_SUCCESS);
+    }
+}

--- a/src/main/java/com/poortorich/admin/controller/AdminController.java
+++ b/src/main/java/com/poortorich/admin/controller/AdminController.java
@@ -22,7 +22,7 @@ public class AdminController {
 
     private final AdminFacade adminFacade;
 
-    @PutMapping("/{userId}/role")
+    @PutMapping("/user/{userId}/role")
     public ResponseEntity<BaseResponse> updateUserRole(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable @Nullable Long userId,

--- a/src/main/java/com/poortorich/admin/facade/AdminFacade.java
+++ b/src/main/java/com/poortorich/admin/facade/AdminFacade.java
@@ -1,0 +1,17 @@
+package com.poortorich.admin.facade;
+
+import com.poortorich.admin.request.UserRoleUpdateRequest;
+import com.poortorich.admin.service.UserManagementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminFacade {
+
+    private final UserManagementService userManagementService;
+
+    public void updateUserRole(Long userId, UserRoleUpdateRequest userRoleUpdateRequest) {
+        userManagementService.updateUserRole(userId, userRoleUpdateRequest);
+    }
+}

--- a/src/main/java/com/poortorich/admin/request/UserRoleUpdateRequest.java
+++ b/src/main/java/com/poortorich/admin/request/UserRoleUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.poortorich.admin.request;
+
+public class UserRoleUpdateRequest {
+}

--- a/src/main/java/com/poortorich/admin/request/UserRoleUpdateRequest.java
+++ b/src/main/java/com/poortorich/admin/request/UserRoleUpdateRequest.java
@@ -1,4 +1,11 @@
 package com.poortorich.admin.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class UserRoleUpdateRequest {
+
+    private String role;
 }

--- a/src/main/java/com/poortorich/admin/response/enums/AdminResponse.java
+++ b/src/main/java/com/poortorich/admin/response/enums/AdminResponse.java
@@ -1,0 +1,4 @@
+package com.poortorich.admin.response.enums;
+
+public enum AdminResponse {
+}

--- a/src/main/java/com/poortorich/admin/response/enums/AdminResponse.java
+++ b/src/main/java/com/poortorich/admin/response/enums/AdminResponse.java
@@ -1,4 +1,31 @@
 package com.poortorich.admin.response.enums;
 
-public enum AdminResponse {
+import com.poortorich.admin.constants.AdminResponseMessage;
+import com.poortorich.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AdminResponse implements Response {
+
+    ROLE_UPDATE_SUCCESS(HttpStatus.OK, AdminResponseMessage.ROLE_UPDATE_SUCCESS, null);
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String field;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
 }

--- a/src/main/java/com/poortorich/admin/service/UserManagementService.java
+++ b/src/main/java/com/poortorich/admin/service/UserManagementService.java
@@ -1,0 +1,26 @@
+package com.poortorich.admin.service;
+
+import com.poortorich.admin.request.UserRoleUpdateRequest;
+import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.user.entity.User;
+import com.poortorich.user.entity.enums.Role;
+import com.poortorich.user.repository.UserRepository;
+import com.poortorich.user.response.enums.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserManagementService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void updateUserRole(Long userId, UserRoleUpdateRequest userRoleUpdateRequest) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
+        Role role = Role.from(userRoleUpdateRequest.getRole());
+        user.updateRole(role);
+    }
+}

--- a/src/main/java/com/poortorich/security/config/SecurityConfig.java
+++ b/src/main/java/com/poortorich/security/config/SecurityConfig.java
@@ -43,9 +43,11 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(SecurityConstants.PERMIT_ALL_ENDPOINTS).permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/user/role").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/user/email", "/user/password").hasRole("USER")
                         .requestMatchers(HttpMethod.DELETE, "/user/reset", "/user/leave").hasRole("USER")
-                        .anyRequest().hasAnyRole("USER", "TEST")
+                        .anyRequest().hasAnyRole("USER", "TEST", "ADMIN")
                 )
                 .exceptionHandling(exception -> exception.accessDeniedHandler(accessDeniedHandler))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/poortorich/user/constants/UserResponseMessages.java
+++ b/src/main/java/com/poortorich/user/constants/UserResponseMessages.java
@@ -61,7 +61,9 @@ public class UserResponseMessages {
     public static final String USER_EMAIL_FIND_SUCCESS = "회원 이메일 조회 성공";
     public static final String RESET_SUCCESS = "모든 데이터를 삭제하였습니다.";
     public static final String DELETE_USER_ACCOUNT_SUCCESS = "성공적으로 탈퇴되었습니다.";
+    
     public static final String USER_ROLE_FIND_SUCCESS = "사용자 역할 조회 성공";
+    public static final String USER_ROLE_INVALID = "유효하지 않은 역할입니다.";
 
     private UserResponseMessages() {
     }

--- a/src/main/java/com/poortorich/user/constants/UserResponseMessages.java
+++ b/src/main/java/com/poortorich/user/constants/UserResponseMessages.java
@@ -61,6 +61,7 @@ public class UserResponseMessages {
     public static final String USER_EMAIL_FIND_SUCCESS = "회원 이메일 조회 성공";
     public static final String RESET_SUCCESS = "모든 데이터를 삭제하였습니다.";
     public static final String DELETE_USER_ACCOUNT_SUCCESS = "성공적으로 탈퇴되었습니다.";
+    public static final String USER_ROLE_FIND_SUCCESS = "사용자 역할 조회 성공";
 
     private UserResponseMessages() {
     }

--- a/src/main/java/com/poortorich/user/controller/UserController.java
+++ b/src/main/java/com/poortorich/user/controller/UserController.java
@@ -111,4 +111,11 @@ public class UserController {
         userFacade.resetAllByUser(userDetails.getUsername());
         return BaseResponse.toResponseEntity(userFacade.deleteUserAccount(userDetails.getUsername(), response));
     }
+
+    @GetMapping("/role")
+    public ResponseEntity<BaseResponse> getUserRole(@AuthenticationPrincipal UserDetails userDetails) {
+        return DataResponse.toResponseEntity(
+                UserResponse.USER_ROLE_FIND_SUCCESS,
+                userFacade.getUserRole(userDetails.getUsername()));
+    }
 }

--- a/src/main/java/com/poortorich/user/entity/User.java
+++ b/src/main/java/com/poortorich/user/entity/User.java
@@ -126,4 +126,8 @@ public class User implements UserDetails {
     public void updateEmail(String newEmail) {
         this.email = newEmail;
     }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/poortorich/user/entity/enums/Role.java
+++ b/src/main/java/com/poortorich/user/entity/enums/Role.java
@@ -1,5 +1,7 @@
 package com.poortorich.user.entity.enums;
 
+import com.poortorich.global.exceptions.BadRequestException;
+import com.poortorich.user.response.enums.UserResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +16,10 @@ public enum Role {
     private final String description;
 
     public static Role from(String role) {
-        return Role.valueOf(role.toUpperCase());
+        try {
+            return Role.valueOf(role.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            throw new BadRequestException(UserResponse.USER_ROLE_INVALID);
+        }
     }
 }

--- a/src/main/java/com/poortorich/user/facade/UserFacade.java
+++ b/src/main/java/com/poortorich/user/facade/UserFacade.java
@@ -13,6 +13,7 @@ import com.poortorich.user.request.UserRegistrationRequest;
 import com.poortorich.user.request.UsernameCheckRequest;
 import com.poortorich.user.response.UserDetailResponse;
 import com.poortorich.user.response.UserEmailResponse;
+import com.poortorich.user.response.UserRoleResponse;
 import com.poortorich.user.response.enums.UserResponse;
 import com.poortorich.user.service.RedisUserReservationService;
 import com.poortorich.user.service.UserResetService;
@@ -106,5 +107,12 @@ public class UserFacade {
         userResetService.deleteDefaultCategories(user);
         userService.deleteUserAccount(user);
         return UserResponse.DELETE_USER_ACCOUNT_SUCCESS;
+    }
+
+    public UserRoleResponse getUserRole(String username) {
+        User user = userService.findUserByUsername(username);
+        return UserRoleResponse.builder()
+                .role(user.getRole().name())
+                .build();
     }
 }

--- a/src/main/java/com/poortorich/user/response/UserRoleResponse.java
+++ b/src/main/java/com/poortorich/user/response/UserRoleResponse.java
@@ -1,0 +1,4 @@
+package com.poortorich.user.response;
+
+public class UserRoleResponse {
+}

--- a/src/main/java/com/poortorich/user/response/UserRoleResponse.java
+++ b/src/main/java/com/poortorich/user/response/UserRoleResponse.java
@@ -1,4 +1,11 @@
 package com.poortorich.user.response;
 
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
 public class UserRoleResponse {
+    
+    private final String role;
 }

--- a/src/main/java/com/poortorich/user/response/enums/UserResponse.java
+++ b/src/main/java/com/poortorich/user/response/enums/UserResponse.java
@@ -37,6 +37,7 @@ public enum UserResponse implements Response {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, UserResponseMessages.USER_NOT_FOUND, null),
     USER_DETAIL_FIND_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_DETAIL_FIND_SUCCESS, null),
     USER_EMAIL_FIND_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_EMAIL_FIND_SUCCESS, null),
+    USER_ROLE_FIND_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_ROLE_FIND_SUCCESS, null),
     USER_PROFILE_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS, null),
     USER_EMAIL_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_EMAIL_UPDATE_SUCCESS, null),
     RESET_SUCCESS(HttpStatus.OK, UserResponseMessages.RESET_SUCCESS, null),

--- a/src/main/java/com/poortorich/user/response/enums/UserResponse.java
+++ b/src/main/java/com/poortorich/user/response/enums/UserResponse.java
@@ -41,7 +41,8 @@ public enum UserResponse implements Response {
     USER_PROFILE_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_PROFILE_UPDATE_SUCCESS, null),
     USER_EMAIL_UPDATE_SUCCESS(HttpStatus.OK, UserResponseMessages.USER_EMAIL_UPDATE_SUCCESS, null),
     RESET_SUCCESS(HttpStatus.OK, UserResponseMessages.RESET_SUCCESS, null),
-    DELETE_USER_ACCOUNT_SUCCESS(HttpStatus.OK, UserResponseMessages.DELETE_USER_ACCOUNT_SUCCESS, null);
+    DELETE_USER_ACCOUNT_SUCCESS(HttpStatus.OK, UserResponseMessages.DELETE_USER_ACCOUNT_SUCCESS, null),
+    USER_ROLE_INVALID(HttpStatus.BAD_REQUEST, UserResponseMessages.USER_ROLE_INVALID, "role");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## #️⃣265
 
 ## 📝작업 내용
 ### 회원 역할 조회 API
 - 프론트에서 현재 회원의 역할을 확인하기 위한 API입니다.
### 회원 역할 변경 API
 - `ADMIN` 역할에서만 호출할 수 있으며 임의로 특정 회원의 역할을 변경할 수 있습니다.
 
 ### 스크린샷 (선택)
<img width="918" height="694" alt="image" src="https://github.com/user-attachments/assets/93f4a512-fdec-4244-8132-9fa63972b9f8" />


