### PR TITLE
[#272] 반복데이터 무한루프 방지 횟수 조절

### DIFF
--- a/src/main/java/com/poortorich/iteration/entity/enums/IterationRuleType.java
+++ b/src/main/java/com/poortorich/iteration/entity/enums/IterationRuleType.java
@@ -10,10 +10,10 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public enum IterationRuleType {
 
-    DAILY("daily", 10000),
-    WEEKLY("weekly", 10000),
-    MONTHLY("monthly", 10000),
-    YEARLY("yearly", 10000);
+    DAILY("daily", 50000),
+    WEEKLY("weekly", 50000),
+    MONTHLY("monthly", 50000),
+    YEARLY("yearly", 50000);
 
     private final String type;
     public final int maxIterations;


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#272 
 ## 📝작업 내용
 
- 반복데이터의 무한루프 방지 횟수를 10000회에서 50000회로 조절하였습니다.
> 논리상 매일 반복 시 136년, 매주 반복 시 961년, 매월 반복 시 4166년, 매년 반복 시 10000년까지 입력 가능
 
 ### 스크린샷 (선택)
 
 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
