### PR TITLE
[#274] 카테고리 생성 개수 제한 추가

### DIFF
--- a/src/main/java/com/poortorich/category/constants/CategoryResponseMessage.java
+++ b/src/main/java/com/poortorich/category/constants/CategoryResponseMessage.java
@@ -18,7 +18,8 @@ public class CategoryResponseMessage {
     public static final String MODIFY_CATEGORY_SUCCESS = "카테고리를 성공적으로 편집하였습니다.";
     public static final String DELETE_CATEGORY_SUCCESS = "카테고리를 성공적으로 삭제하였습니다.";
 
-    public static final String NOT_DELETE_USED_CATEGORY = "사용중인 카테고리는 삭제할 수 없습니다.";
+    public static final String CATEGORY_COUNT_LIMIT_EXCEEDED
+            = "생성할 수 있는 사용자 지정 카테고리 개수는 최대 " + CategoryValidationConstraints.CATEGORY_LIMIT_COUNT + "개입니다.";
 
     public static final String CATEGORY_NON_EXISTENT = "존재하지 않는 카테고리입니다.";
 

--- a/src/main/java/com/poortorich/category/constants/CategoryValidationConstraints.java
+++ b/src/main/java/com/poortorich/category/constants/CategoryValidationConstraints.java
@@ -1,0 +1,8 @@
+package com.poortorich.category.constants;
+
+public class CategoryValidationConstraints {
+
+    public static final int CATEGORY_LIMIT_COUNT = 10;
+
+    private CategoryValidationConstraints() {}
+}

--- a/src/main/java/com/poortorich/category/repository/CategoryRepository.java
+++ b/src/main/java/com/poortorich/category/repository/CategoryRepository.java
@@ -38,4 +38,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findByUserAndTypeInAndIsDeletedFalse(User user, List<CategoryType> types);
 
     void deleteByUserAndType(User user, CategoryType type);
+
+    int countByUserAndTypeAndIsDeletedFalse(User user, CategoryType type);
 }

--- a/src/main/java/com/poortorich/category/response/enums/CategoryResponse.java
+++ b/src/main/java/com/poortorich/category/response/enums/CategoryResponse.java
@@ -22,6 +22,7 @@ public enum CategoryResponse implements Response {
     MODIFY_CATEGORY_SUCCESS(HttpStatus.CREATED, CategoryResponseMessage.MODIFY_CATEGORY_SUCCESS, null),
     DELETE_CATEGORY_SUCCESS(HttpStatus.OK, CategoryResponseMessage.DELETE_CATEGORY_SUCCESS, null),
 
+    CATEGORY_COUNT_LIMIT_EXCEEDED(HttpStatus.CONFLICT, CategoryResponseMessage.CATEGORY_COUNT_LIMIT_EXCEEDED, null),
     CATEGORY_NAME_DUPLICATE(HttpStatus.CONFLICT, CategoryResponseMessage.CATEGORY_NAME_DUPLICATE, "name"),
     CATEGORY_NON_EXISTENT(HttpStatus.NOT_FOUND, CategoryResponseMessage.CATEGORY_NON_EXISTENT, "categoryId"),
     CATEGORY_TYPE_INVALID(HttpStatus.BAD_REQUEST,CategoryResponseMessage.CATEGORY_TYPE_INVALID, "categoryType"),


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#274 
 
 ## 📝작업 내용
 
- 사용자화 카테고리 타입별로 생성 개수에 제한을 추가

 ### 스크린샷

<img width="870" height="385" alt="image" src="https://github.com/user-attachments/assets/a3daa826-048a-4aaf-80dd-fc0e39cd8b4c" />
