### PR TITLE
[#280] 차트 상세 내역 중복 데이터 조회 수정

### DIFF
--- a/src/main/java/com/poortorich/page/domain/Pagination.java
+++ b/src/main/java/com/poortorich/page/domain/Pagination.java
@@ -36,10 +36,10 @@ public class Pagination {
         if (accountBooks.isEmpty()) {
             return LocalDate.now();
         }
-        LocalDate lastDate = accountBooks.getLast().getAccountBookDate();
+
         return switch (direction) {
-            case ASC -> lastDate.plusDays(DateConstants.ONE_DAY);
-            case DESC -> lastDate.minusDays(DateConstants.ONE_DAY);
+            case ASC -> accountBooks.getLast().getAccountBookDate().plusDays(DateConstants.ONE_DAY);
+            case DESC -> accountBooks.getFirst().getAccountBookDate().minusDays(DateConstants.ONE_DAY);
         };
     }
 }


### PR DESCRIPTION
## #️⃣280
 
 > ex) #이슈번호, #이슈번호
 
 ## 📝작업 내용
 
차트 카테고리 상세 내역 조회 API에서 내역 조회가 끝났음에도
nextCursor=true로 반환되는 현상을 발견하였음

클라이언트에서 이 값을 사용하여 한 번 더 조회하여 중복 데이터가 발생

서버 내부 코드 확인 결과 날짜를 오름차순으로 정렬한 데이터의 마지막
데이터 정보에서 다음 커서 여부를 확인하여 생긴 문제 이를 수정

