### PR TITLE
[#282] 가계부 정보 응답에 메모 필드 추가

### DIFF
--- a/src/main/java/com/poortorich/accountbook/response/AccountBookInfoResponse.java
+++ b/src/main/java/com/poortorich/accountbook/response/AccountBookInfoResponse.java
@@ -19,4 +19,5 @@ public class AccountBookInfoResponse {
     private Boolean isIteration;
     private String type;
     private Long cost;
+    private String memo;
 }

--- a/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
+++ b/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
@@ -134,6 +134,19 @@ public class AccountBookBuilder {
                 .isIteration(accountBook.getIterationType().isIteration())
                 .type(accountBook.getType().toString())
                 .cost(accountBook.getCost())
+                .memo(truncateMemo(accountBook.getMemo()))
                 .build();
+    }
+
+    private static String truncateMemo(String memo) {
+        if (memo == null) {
+            return "";
+        }
+
+        if (memo.length() > 20) {
+            return memo.substring(0, 20);
+        }
+
+        return memo;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#282
 
 ## 📝작업 내용
 
- 가계부 정보 응답에 메모 필드를 추가했습니다.
  > 메모는 20자까지 전달합니다.
 
 ### 스크린샷

<img width="629" height="324" alt="스크린샷 2025-07-17 오전 2 34 47" src="https://github.com/user-attachments/assets/235883f9-1be1-4624-9655-f34aa85d3344" />

<img width="631" height="355" alt="스크린샷 2025-07-17 오전 2 35 02" src="https://github.com/user-attachments/assets/f9c8eb8a-f3fc-4691-8b40-2ceb42e81e6f" />

 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
