### PR TITLE
[#288] 가계부 편집 응답 필드 추가

### DIFF
--- a/src/main/java/com/poortorich/accountbook/response/AccountBookDeleteResponse.java
+++ b/src/main/java/com/poortorich/accountbook/response/AccountBookDeleteResponse.java
@@ -1,0 +1,15 @@
+package com.poortorich.accountbook.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountBookDeleteResponse {
+
+    private Long categoryId;
+}

--- a/src/main/java/com/poortorich/accountbook/response/AccountBookModifyResponse.java
+++ b/src/main/java/com/poortorich/accountbook/response/AccountBookModifyResponse.java
@@ -11,5 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AccountBookModifyResponse {
 
+    private Long prevCategoryId;
     private Long categoryId;
 }

--- a/src/main/java/com/poortorich/accountbook/response/AccountBookModifyResponse.java
+++ b/src/main/java/com/poortorich/accountbook/response/AccountBookModifyResponse.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class AccountBookActionResponse {
+public class AccountBookModifyResponse {
 
     private Long categoryId;
 }

--- a/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/poortorich/accountbook/service/AccountBookService.java
@@ -295,4 +295,10 @@ public class AccountBookService {
                 )
                 .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT));
     }
+
+    public Category getCurrentCategory(User user, Long expenseId, AccountBookType type) {
+        return accountBookRepository.findByIdAndUser(expenseId, user, type)
+                .orElseThrow(() -> new NotFoundException(ExpenseResponse.EXPENSE_NON_EXISTENT))
+                .getCategory();
+    }
 }

--- a/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
+++ b/src/main/java/com/poortorich/accountbook/util/AccountBookBuilder.java
@@ -3,6 +3,7 @@ package com.poortorich.accountbook.util;
 import com.poortorich.accountbook.entity.AccountBook;
 import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.AccountBookRequest;
+import com.poortorich.accountbook.response.AccountBookModifyResponse;
 import com.poortorich.accountbook.response.AccountBookInfoResponse;
 import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.category.entity.Category;
@@ -148,5 +149,21 @@ public class AccountBookBuilder {
         }
 
         return memo;
+    }
+
+    public static AccountBookModifyResponse buildAccountBookModifyResponse(
+            Long currentCategoryId,
+            Long changeCategoryId
+    ) {
+        if (currentCategoryId.equals(changeCategoryId)) {
+            return AccountBookModifyResponse.builder()
+                    .categoryId(changeCategoryId)
+                    .build();
+        }
+
+        return AccountBookModifyResponse.builder()
+                .prevCategoryId(currentCategoryId)
+                .categoryId(changeCategoryId)
+                .build();
     }
 }

--- a/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
+++ b/src/main/java/com/poortorich/expense/facade/ExpenseFacade.java
@@ -6,9 +6,11 @@ import com.poortorich.accountbook.enums.AccountBookType;
 import com.poortorich.accountbook.request.enums.IterationAction;
 import com.poortorich.accountbook.response.AccountBookActionResponse;
 import com.poortorich.accountbook.response.AccountBookCreateResponse;
+import com.poortorich.accountbook.response.AccountBookDeleteResponse;
 import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.response.IterationDetailsResponse;
 import com.poortorich.accountbook.service.AccountBookService;
+import com.poortorich.accountbook.util.AccountBookBuilder;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.category.service.CategoryService;
@@ -77,7 +79,7 @@ public class ExpenseFacade {
     }
 
     @Transactional
-    public AccountBookActionResponse deleteExpense(Long expenseId, AccountBookDeleteRequest accountBookDeleteRequest, String username) {
+    public AccountBookDeleteResponse deleteExpense(Long expenseId, AccountBookDeleteRequest accountBookDeleteRequest, String username) {
         User user = userService.findUserByUsername(username);
         AccountBook expense = accountBookService.getAccountBookOrThrow(expenseId, user, accountBookType);
         Long categoryId = expense.getCategory().getId();
@@ -98,7 +100,7 @@ public class ExpenseFacade {
             );
         }
 
-        return AccountBookActionResponse.builder()
+        return AccountBookDeleteResponse.builder()
                 .categoryId(categoryId)
                 .build();
     }

--- a/src/main/java/com/poortorich/income/facade/IncomeFacade.java
+++ b/src/main/java/com/poortorich/income/facade/IncomeFacade.java
@@ -7,15 +7,16 @@ import com.poortorich.accountbook.request.AccountBookDeleteRequest;
 import com.poortorich.accountbook.request.enums.IterationAction;
 import com.poortorich.accountbook.response.AccountBookActionResponse;
 import com.poortorich.accountbook.response.AccountBookCreateResponse;
+import com.poortorich.accountbook.response.AccountBookDeleteResponse;
 import com.poortorich.accountbook.response.InfoResponse;
 import com.poortorich.accountbook.response.IterationDetailsResponse;
 import com.poortorich.accountbook.service.AccountBookService;
+import com.poortorich.accountbook.util.AccountBookBuilder;
 import com.poortorich.category.entity.Category;
 import com.poortorich.category.entity.enums.CategoryType;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.income.entity.Income;
 import com.poortorich.income.request.IncomeRequest;
-import com.poortorich.income.response.enums.IncomeResponse;
 import com.poortorich.income.service.IncomeService;
 import com.poortorich.iteration.entity.Iteration;
 import com.poortorich.iteration.response.CustomIterationInfoResponse;
@@ -80,7 +81,7 @@ public class IncomeFacade {
     }
 
     @Transactional
-    public AccountBookActionResponse deleteIncome(String username, Long incomeId, AccountBookDeleteRequest accountBookDeleteRequest) {
+    public AccountBookDeleteResponse deleteIncome(String username, Long incomeId, AccountBookDeleteRequest accountBookDeleteRequest) {
         User user = userService.findUserByUsername(username);
         AccountBook income = accountBookService.getAccountBookOrThrow(incomeId, user, accountBookType);
         Long categoryId = income.getCategory().getId();
@@ -101,7 +102,7 @@ public class IncomeFacade {
             );
         }
 
-        return AccountBookActionResponse.builder()
+        return AccountBookDeleteResponse.builder()
                 .categoryId(categoryId)
                 .build();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#288 

 ## 📝작업 내용
 
-  가계부 편집 시 카테고리를 변경하는 경우 변경 전 카테고리 아이디를 보내도록 응답 추가
   > 원래 가계부 편집, 삭제할 때 같은 Response DTO를 사용하고 있었는데, 가계부 편집 응답 필드를 추가하면서 가계부 삭제 Response DTO를 추가했습니다.

 ### 스크린샷

<img width="809" height="315" alt="image" src="https://github.com/user-attachments/assets/53028378-56f6-4f55-9831-04bdaeb8f402" />