### PR TITLE
[#302] OAuth 회원 상세 조회 API 요구사항 적용

### DIFF
--- a/src/main/java/com/poortorich/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/poortorich/auth/oauth2/service/CustomOAuth2UserService.java
@@ -42,14 +42,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         User user = User.builder()
                 .username(username)
                 .password(username)
-                .name(UUID.randomUUID().toString().replace("-", "").substring(0, 8)
+                .name(response.getName())
+                .nickname(UUID.randomUUID().toString().replace("-", "").substring(0, 8)
                         + response.getProviderId())
-                .nickname(response.getName())
                 .email(response.getEmail())
-                .gender(Gender.MALE)
+                .gender(Gender.FEMALE)
                 .birth(LocalDate.now())
                 .profileImage(response.getProfileImage())
                 .role(Role.PENDING)
+                .job("선택안함")
                 .build();
 
         userRepository.save(user);

--- a/src/main/java/com/poortorich/s3/constants/S3Constants.java
+++ b/src/main/java/com/poortorich/s3/constants/S3Constants.java
@@ -1,6 +1,14 @@
 package com.poortorich.s3.constants;
 
+import java.util.List;
+
 public class S3Constants {
 
     public static final String DEFAULT_PROFILE_IMAGE = "https://poor-to-rich.s3.ap-northeast-2.amazonaws.com/poortorich_profileImage.png";
+    public static final String KAKAO_DEFAULT_PROFILE = "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg";
+
+    public static final List<String> DEFAULT_PROFILES = List.of(
+            DEFAULT_PROFILE_IMAGE,
+            KAKAO_DEFAULT_PROFILE
+    );
 }

--- a/src/main/java/com/poortorich/user/controller/UserController.java
+++ b/src/main/java/com/poortorich/user/controller/UserController.java
@@ -140,7 +140,7 @@ public class UserController {
     public ResponseEntity<BaseResponse> getOAuthUserProfile(@AuthenticationPrincipal UserDetails userDetails) {
         return DataResponse.toResponseEntity(
                 UserResponse.USER_DETAIL_FIND_SUCCESS,
-                userFacade.getUserDetails(userDetails.getUsername())
+                userFacade.getOAuthUserDetails(userDetails.getUsername())
         );
     }
 

--- a/src/main/java/com/poortorich/user/facade/UserFacade.java
+++ b/src/main/java/com/poortorich/user/facade/UserFacade.java
@@ -14,6 +14,7 @@ import com.poortorich.user.request.PasswordUpdateRequest;
 import com.poortorich.user.request.ProfileUpdateRequest;
 import com.poortorich.user.request.UserRegistrationRequest;
 import com.poortorich.user.request.UsernameCheckRequest;
+import com.poortorich.user.response.OAuthUserDetailResponse;
 import com.poortorich.user.response.UserDetailResponse;
 import com.poortorich.user.response.UserEmailResponse;
 import com.poortorich.user.response.UserRoleResponse;
@@ -134,5 +135,17 @@ public class UserFacade {
     @Transactional
     public void updateUserRole(String username, Role role) {
         userService.updateRole(username, role);
+    }
+
+    public OAuthUserDetailResponse getOAuthUserDetails(String username) {
+        UserDetailResponse response = userService.findUserDetailByUsername(username);
+
+        return OAuthUserDetailResponse.builder()
+                .profileImage(response.getProfileImage())
+                .isDefaultProfile(response.getIsDefaultProfile())
+                .name(response.getName())
+                .gender(response.getGender())
+                .job(response.getJob())
+                .build();
     }
 }

--- a/src/main/java/com/poortorich/user/response/OAuthUserDetailResponse.java
+++ b/src/main/java/com/poortorich/user/response/OAuthUserDetailResponse.java
@@ -1,0 +1,4 @@
+package com.poortorich.user.response;
+
+public class OAuthUserDetailResponse {
+}

--- a/src/main/java/com/poortorich/user/response/OAuthUserDetailResponse.java
+++ b/src/main/java/com/poortorich/user/response/OAuthUserDetailResponse.java
@@ -1,4 +1,15 @@
 package com.poortorich.user.response;
 
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
 public class OAuthUserDetailResponse {
+
+    private String profileImage;
+    private Boolean isDefaultProfile;
+    private String name;
+    private String gender;
+    private String job;
 }

--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -52,7 +52,7 @@ public class UserService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
 
-        boolean isDefaultProfile = user.getProfileImage().equals(S3Constants.DEFAULT_PROFILE_IMAGE);
+        boolean isDefaultProfile = S3Constants.DEFAULT_PROFILES.contains(user.getProfileImage());
         String profileImage = null;
         if (!isDefaultProfile) {
             profileImage = user.getProfileImage();


### PR DESCRIPTION
## #️⃣302
 
 ## 📝작업 내용
 프론트 요청에 따라 OAuth 회원 상세 조회 API를 수정했습니다.

- profileImage 필드
    - 카카오 기본 프로필일 경우
    ```jsx
    profileImage: null 
    isDefaultProfile: true
    ```
    
- nickname 필드
    - 현재 카카오 닉네임 값을 가져옴
    - 요청 사항 : 카카오 닉네임값은 name 필드 매칭해주세요
        
        => 닉네임 중복 검사 문제 때문에 카카오 닉네임을 이름필드값으로 사용하는게 좋을 것 같다고 판단
        
    - nickname 필드 빼고 repsonse 보내기
- name 필드
    - 카카오 닉네임값 매칭
- birth 필드
    - birth  필드 빼고 repsonse 보내기
- gender 필드
    - 현재 기본값 :  MALE
    - 요청 기본 값: FEMALE
- job 필드
    - 현재 기본 값 : null
    - 요청 기본 값 : 선택안함
 
 ### 스크린샷 (선택)
 
<img width="564" height="760" alt="image" src="https://github.com/user-attachments/assets/6767e724-4444-41e6-95d1-71e092f69355" />

