### PR TITLE
[#309] 회원탈퇴 시 카카오 연결 해제 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       REDIS_PORT: ${REDIS_PORT}
       KAKAO_KEY: ${KAKAO_KEY}
       KAKAO_SECRET: ${KAKAO_SECRET}
+      KAKAO_ADMIN: ${KAKAO_ADMIN}
     env_file:
       - .env
 volumes:

--- a/src/main/java/com/poortorich/auth/kakao/service/KakaoService.java
+++ b/src/main/java/com/poortorich/auth/kakao/service/KakaoService.java
@@ -1,0 +1,55 @@
+package com.poortorich.auth.kakao.service;
+
+import com.poortorich.global.exceptions.InternalServerErrorException;
+import com.poortorich.global.response.enums.GlobalResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private static final String USER_SUFFIX = "kakao_";
+
+    private final WebClient webClient = WebClient.builder()
+            .baseUrl("https://kapi.kakao.com")
+            .build();
+
+    @Value("${kakao.admin.key}")
+    private String KAKAO_ADMIN_KEY;
+
+    public Mono<String> callUnlinkAPI(String username) {
+        System.out.println(KAKAO_ADMIN_KEY);
+        if (isKakaoUser(username)) {
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add("target_id_type", "user_id");
+            formData.add("target_id", username.substring(USER_SUFFIX.length()));
+
+            return webClient.post()
+                    .uri("/v1/user/unlink")
+                    .header("Authorization", "KakaoAK " + KAKAO_ADMIN_KEY)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(formData))
+                    .retrieve()
+                    .onStatus(
+                            status -> status.is4xxClientError() || status.is5xxServerError(),
+                            response -> response.bodyToMono(String.class)
+                                    .flatMap(errorBody -> Mono.error(
+                                            new InternalServerErrorException(GlobalResponse.INTERNAL_SERVER_EXCEPTION)))
+                    )
+                    .bodyToMono(String.class);
+        }
+        return Mono.empty();
+    }
+
+    private boolean isKakaoUser(String username) {
+        return username.contains(USER_SUFFIX);
+    }
+}

--- a/src/main/java/com/poortorich/user/facade/UserFacade.java
+++ b/src/main/java/com/poortorich/user/facade/UserFacade.java
@@ -1,6 +1,7 @@
 package com.poortorich.user.facade;
 
 import com.poortorich.auth.jwt.util.JwtTokenManager;
+import com.poortorich.auth.kakao.service.KakaoService;
 import com.poortorich.category.service.CategoryService;
 import com.poortorich.global.response.Response;
 import com.poortorich.s3.service.FileUploadService;
@@ -39,6 +40,7 @@ public class UserFacade {
     private final RedisUserReservationService userReservationService;
     private final UserResetService userResetService;
     private final CategoryService categoryService;
+    private final KakaoService kakaoService;
     private final JwtTokenManager tokenManager;
 
     @Transactional
@@ -109,6 +111,7 @@ public class UserFacade {
     public Response deleteUserAccount(String username, HttpServletResponse response) {
         User user = userService.findUserByUsername(username);
         tokenManager.clearAuthTokensTest(response);
+        kakaoService.callUnlinkAPI(username);
         userResetService.deleteDefaultCategories(user);
         userService.deleteUserAccount(user);
         return UserResponse.DELETE_USER_ACCOUNT_SUCCESS;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,6 +38,7 @@ spring.auth-code-expiration-millis=600000
 # JWT
 jwt.secret.key=${JWT_SECRET_KEY}
 # Kakao
+kakao.admin.key=${KAKAO_ADMIN}
 spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
 #registration
 spring.security.oauth2.client.registration.kakao.client-name=Kakao


### PR DESCRIPTION
## #️⃣309
 
 ## 📝작업 내용
 카카오 회원이 탈퇴하는 경우 동의 정보 내역 파기를 위해 카카오와 연결을 해제하는 로직을 추가했습니다.

