### PR TITLE
[#316] 채팅방 추가 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -1,0 +1,23 @@
+package com.poortorich.chat.constants;
+
+public class ChatResponseMessage {
+
+    public static final String CREATE_CHATROOM_SUCCESS = "채팅방을 성공적으로 추가했습니다.";
+
+    public static final String CHATROOM_TITLE_REQUIRED = "채팅방 이름은 필수값입니다.";
+    public static final String CHATROOM_TITLE_TOO_BIG
+            = "채팅방 이름은 " + ChatValidationConstraints.CHATROOM_TITLE_MAX + "자 이하여야 합니다.";
+
+    public static final String CHATROOM_MAX_MEMBER_COUNT_REQUIRED = "채팅방 최대 인원은 필수값입니다.";
+    public static final String CHATROOM_MAX_MEMBER_COUNT_TOO_SMALL
+            = "채팅방 최대 인원은 " + ChatValidationConstraints.CHATROOM_MAX_MEMBER_COUNT_MIN + "명 이상이어야 합니다.";
+    public static final String CHATROOM_MAX_MEMBER_COUNT_TOO_BIG
+            = "채팅방 최대 인원은 " + ChatValidationConstraints.CHATROOM_MAX_MEMBER_COUNT_MAX + "명 이하여야 합니다.";
+
+    public static final String CHATROOM_DESCRIPTION_REQUIRED = "채팅방 소개는 필수값입니다.";
+    public static final String CHATROOM_DESCRIPTION_TOO_BIG
+            = "채팅방 소개는 " + ChatValidationConstraints.CHATROOM_DESCRIPTION_MAX + "자 이하여야 합니다.";
+
+    private ChatResponseMessage() {
+    }
+}

--- a/src/main/java/com/poortorich/chat/constants/ChatValidationConstraints.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatValidationConstraints.java
@@ -1,0 +1,14 @@
+package com.poortorich.chat.constants;
+
+public class ChatValidationConstraints {
+    
+    public static final int CHATROOM_TITLE_MAX = 30;
+    
+    public static final int CHATROOM_MAX_MEMBER_COUNT_MIN = 10;
+    public static final int CHATROOM_MAX_MEMBER_COUNT_MAX = 100;
+
+    public static final int CHATROOM_DESCRIPTION_MAX = 100;
+    
+    private ChatValidationConstraints() {
+    }
+}

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -1,0 +1,38 @@
+package com.poortorich.chat.controller;
+
+import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.global.response.BaseResponse;
+import com.poortorich.global.response.DataResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/chatrooms")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatFacade chatFacade;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse> createChatroom(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestPart(value = "chatroomImage", required = false) MultipartFile chatroomImage,
+            @RequestPart("request") @Valid ChatroomCreateRequest request
+    ) {
+        return DataResponse.toResponseEntity(
+                ChatResponse.CREATE_CHATROOM_SUCCESS,
+                chatFacade.createChatroom(userDetails.getUsername(), chatroomImage, request)
+        );
+    }
+}

--- a/src/main/java/com/poortorich/chat/entity/ChatMessage.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatMessage.java
@@ -1,0 +1,66 @@
+package com.poortorich.chat.entity;
+
+import com.poortorich.chat.entity.enums.ChatMessageType;
+import com.poortorich.chat.entity.enums.MessageType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "chat_message")
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_type")
+    private MessageType messageType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    private ChatMessageType type;
+
+    @Column(name = "ranking_id")
+    private Long rankingId;
+
+    @Column(name = "photo_id")
+    private Long photoId;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "is_ranking_enabled")
+    private Boolean isRankingEnabled;
+
+    @CreationTimestamp
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private Chatroom chatroom;
+}

--- a/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
@@ -1,0 +1,75 @@
+package com.poortorich.chat.entity;
+
+import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chat.entity.enums.RankingStatus;
+import com.poortorich.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "chat_participant")
+public class ChatParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private ChatroomRole role;
+
+    @Column(name = "is_participate", nullable = false)
+    private Boolean isParticipate;
+
+    @Column(name = "leave_time")
+    private LocalDateTime leaveTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ranking_status", nullable = false)
+    private RankingStatus rankingStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notice_status", nullable = false)
+    private NoticeStatus noticeStatus;
+
+    @CreationTimestamp
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @UpdateTimestamp
+    @Column(name = "updated_date")
+    private LocalDateTime updatedDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private Chatroom chatroom;
+}

--- a/src/main/java/com/poortorich/chat/entity/Chatroom.java
+++ b/src/main/java/com/poortorich/chat/entity/Chatroom.java
@@ -1,0 +1,58 @@
+package com.poortorich.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "chatroom")
+public class Chatroom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "image", nullable = false)
+    private String image;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "max_member_count", nullable = false)
+    private Long maxMemberCount;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "is_ranking_enabled", nullable = false)
+    private Boolean isRankingEnabled;
+
+    @CreationTimestamp
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @UpdateTimestamp
+    @Column(name = "updated_date")
+    private LocalDateTime updatedDate;
+}

--- a/src/main/java/com/poortorich/chat/entity/UnreadChatMessage.java
+++ b/src/main/java/com/poortorich/chat/entity/UnreadChatMessage.java
@@ -1,0 +1,56 @@
+package com.poortorich.chat.entity;
+
+import com.poortorich.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "unread_chat_message")
+public class UnreadChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private Chatroom chatroom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_message_id")
+    private ChatMessage chatMessage;
+
+    @CreationTimestamp
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @UpdateTimestamp
+    @Column(name = "updated_date")
+    private LocalDateTime updatedDate;
+}

--- a/src/main/java/com/poortorich/chat/entity/enums/ChatMessageType.java
+++ b/src/main/java/com/poortorich/chat/entity/enums/ChatMessageType.java
@@ -1,0 +1,14 @@
+package com.poortorich.chat.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatMessageType {
+
+    CHAT_MESSAGE,
+    SYSTEM_MESSAGE,
+    RANKING_STATUS,
+    RANKING_MESSAGE
+}

--- a/src/main/java/com/poortorich/chat/entity/enums/ChatroomRole.java
+++ b/src/main/java/com/poortorich/chat/entity/enums/ChatroomRole.java
@@ -1,0 +1,13 @@
+package com.poortorich.chat.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatroomRole {
+
+    HOST,
+    MEMBER,
+    BANNED
+}

--- a/src/main/java/com/poortorich/chat/entity/enums/MessageType.java
+++ b/src/main/java/com/poortorich/chat/entity/enums/MessageType.java
@@ -1,0 +1,14 @@
+package com.poortorich.chat.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MessageType {
+
+    TEXT,
+    PHOTO,
+    RANKING,
+    SYSTEM
+}

--- a/src/main/java/com/poortorich/chat/entity/enums/NoticeStatus.java
+++ b/src/main/java/com/poortorich/chat/entity/enums/NoticeStatus.java
@@ -1,0 +1,13 @@
+package com.poortorich.chat.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeStatus {
+
+    DEFAULT,
+    TEMP_HIDDEN,        // 접어두기
+    PERMANENT_HIDDEN    // 다신 열지 않음
+}

--- a/src/main/java/com/poortorich/chat/entity/enums/RankingStatus.java
+++ b/src/main/java/com/poortorich/chat/entity/enums/RankingStatus.java
@@ -1,0 +1,13 @@
+package com.poortorich.chat.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RankingStatus {
+
+    NONE,
+    SAVER,
+    FLEXER
+}

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -1,0 +1,42 @@
+package com.poortorich.chat.facade;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.chat.response.ChatroomCreateResponse;
+import com.poortorich.chat.service.ChatParticipantService;
+import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.s3.service.FileUploadService;
+import com.poortorich.tag.service.TagService;
+import com.poortorich.user.entity.User;
+import com.poortorich.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ChatFacade {
+
+    private final UserService userService;
+    private final ChatroomService chatroomService;
+    private final ChatParticipantService chatParticipantService;
+    private final FileUploadService fileUploadService;
+    private final TagService tagService;
+
+    @Transactional
+    public ChatroomCreateResponse createChatroom(
+            String username,
+            MultipartFile chatroomImage,
+            ChatroomCreateRequest request
+    ) {
+        User user = userService.findUserByUsername(username);
+        String imageUrl = fileUploadService.uploadImage(chatroomImage);
+
+        Chatroom chatroom = chatroomService.createChatroom(imageUrl, request);
+        chatParticipantService.createChatroomHost(user, chatroom);
+        tagService.createTag(request.getHashtags(), chatroom);
+
+        return ChatroomCreateResponse.builder().newChatroomId(chatroom.getId()).build();
+    }
+}

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -1,0 +1,9 @@
+package com.poortorich.chat.repository;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+}

--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -1,0 +1,9 @@
+package com.poortorich.chat.repository;
+
+import com.poortorich.chat.entity.Chatroom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+}

--- a/src/main/java/com/poortorich/chat/request/ChatroomCreateRequest.java
+++ b/src/main/java/com/poortorich/chat/request/ChatroomCreateRequest.java
@@ -1,0 +1,38 @@
+package com.poortorich.chat.request;
+
+import com.poortorich.chat.constants.ChatResponseMessage;
+import com.poortorich.chat.constants.ChatValidationConstraints;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatroomCreateRequest {
+
+    @NotNull(message = ChatResponseMessage.CHATROOM_TITLE_REQUIRED)
+    @Max(value = ChatValidationConstraints.CHATROOM_TITLE_MAX,
+            message = ChatResponseMessage.CHATROOM_TITLE_TOO_BIG)
+    private String chatroomTitle;
+
+    @NotNull(message = ChatResponseMessage.CHATROOM_MAX_MEMBER_COUNT_REQUIRED)
+    @Min(value = ChatValidationConstraints.CHATROOM_MAX_MEMBER_COUNT_MIN,
+            message = ChatResponseMessage.CHATROOM_MAX_MEMBER_COUNT_TOO_SMALL)
+    @Max(value = ChatValidationConstraints.CHATROOM_MAX_MEMBER_COUNT_MAX,
+            message = ChatResponseMessage.CHATROOM_MAX_MEMBER_COUNT_TOO_BIG)
+    private Long maxMemberCount;
+
+    @NotNull(message = ChatResponseMessage.CHATROOM_DESCRIPTION_REQUIRED)
+    @Max(value = ChatValidationConstraints.CHATROOM_DESCRIPTION_MAX,
+            message = ChatResponseMessage.CHATROOM_DESCRIPTION_TOO_BIG)
+    private String description;
+
+    // 각 태그당 50자 제한
+    private List<String> hashtags;
+    private Boolean isRankingEnabled;
+    private String chatroomPassword;
+}

--- a/src/main/java/com/poortorich/chat/request/ChatroomCreateRequest.java
+++ b/src/main/java/com/poortorich/chat/request/ChatroomCreateRequest.java
@@ -5,6 +5,7 @@ import com.poortorich.chat.constants.ChatValidationConstraints;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -15,7 +16,7 @@ import java.util.List;
 public class ChatroomCreateRequest {
 
     @NotNull(message = ChatResponseMessage.CHATROOM_TITLE_REQUIRED)
-    @Max(value = ChatValidationConstraints.CHATROOM_TITLE_MAX,
+    @Size(max = ChatValidationConstraints.CHATROOM_TITLE_MAX,
             message = ChatResponseMessage.CHATROOM_TITLE_TOO_BIG)
     private String chatroomTitle;
 
@@ -27,11 +28,10 @@ public class ChatroomCreateRequest {
     private Long maxMemberCount;
 
     @NotNull(message = ChatResponseMessage.CHATROOM_DESCRIPTION_REQUIRED)
-    @Max(value = ChatValidationConstraints.CHATROOM_DESCRIPTION_MAX,
+    @Size(max = ChatValidationConstraints.CHATROOM_DESCRIPTION_MAX,
             message = ChatResponseMessage.CHATROOM_DESCRIPTION_TOO_BIG)
     private String description;
 
-    // 각 태그당 50자 제한
     private List<String> hashtags;
     private Boolean isRankingEnabled;
     private String chatroomPassword;

--- a/src/main/java/com/poortorich/chat/response/ChatroomCreateResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomCreateResponse.java
@@ -1,0 +1,15 @@
+package com.poortorich.chat.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatroomCreateResponse {
+
+    private Long newChatroomId;
+}

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -1,0 +1,33 @@
+package com.poortorich.chat.response.enums;
+
+import com.poortorich.chat.constants.ChatResponseMessage;
+import com.poortorich.global.response.Response;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatResponse implements Response {
+
+    CREATE_CHATROOM_SUCCESS(HttpStatus.CREATED, ChatResponseMessage.CREATE_CHATROOM_SUCCESS, null);
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String field;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
+}

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -1,0 +1,24 @@
+package com.poortorich.chat.service;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chat.entity.enums.RankingStatus;
+import com.poortorich.chat.repository.ChatParticipantRepository;
+import com.poortorich.chat.util.ChatBuilder;
+import com.poortorich.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatParticipantService {
+
+    private final ChatParticipantRepository chatParticipantRepository;
+
+    public void createChatroomHost(User user, Chatroom chatroom) {
+        ChatParticipant chatParticipant = ChatBuilder.buildChatParticipant(user, ChatroomRole.HOST, chatroom);
+        chatParticipantRepository.save(chatParticipant);
+    }
+}

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -3,8 +3,6 @@ package com.poortorich.chat.service;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatroomRole;
-import com.poortorich.chat.entity.enums.NoticeStatus;
-import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.chat.repository.ChatParticipantRepository;
 import com.poortorich.chat.util.ChatBuilder;
 import com.poortorich.user.entity.User;

--- a/src/main/java/com/poortorich/chat/service/ChatroomService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatroomService.java
@@ -1,0 +1,20 @@
+package com.poortorich.chat.service;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.repository.ChatroomRepository;
+import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.chat.util.ChatBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatroomService {
+
+    private final ChatroomRepository chatroomRepository;
+
+    public Chatroom createChatroom(String imageUrl, ChatroomCreateRequest request) {
+        Chatroom chatroom = ChatBuilder.buildChatroom(imageUrl, request);
+        return chatroomRepository.save(chatroom);
+    }
+}

--- a/src/main/java/com/poortorich/chat/util/ChatBuilder.java
+++ b/src/main/java/com/poortorich/chat/util/ChatBuilder.java
@@ -1,0 +1,34 @@
+package com.poortorich.chat.util;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chat.entity.enums.RankingStatus;
+import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.user.entity.User;
+
+public class ChatBuilder {
+
+    public static Chatroom buildChatroom(String imageUrl, ChatroomCreateRequest request) {
+        return Chatroom.builder()
+                .image(imageUrl)
+                .title(request.getChatroomTitle())
+                .description(request.getDescription())
+                .maxMemberCount(request.getMaxMemberCount())
+                .password(request.getChatroomPassword())
+                .isRankingEnabled(request.getIsRankingEnabled())
+                .build();
+    }
+
+    public static ChatParticipant buildChatParticipant(User user, ChatroomRole role, Chatroom chatroom) {
+        return ChatParticipant.builder()
+                .role(role)
+                .isParticipate(true)
+                .rankingStatus(RankingStatus.NONE)
+                .noticeStatus(NoticeStatus.DEFAULT)
+                .user(user)
+                .chatroom(chatroom)
+                .build();
+    }
+}

--- a/src/main/java/com/poortorich/like/entity/Like.java
+++ b/src/main/java/com/poortorich/like/entity/Like.java
@@ -1,0 +1,56 @@
+package com.poortorich.like.entity;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "like")
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "like_status", nullable = false)
+    private Boolean likeStatus;
+
+    @CreationTimestamp
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @UpdateTimestamp
+    @Column(name = "updated_date")
+    private LocalDateTime updatedDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private Chatroom chatroom;
+}

--- a/src/main/java/com/poortorich/tag/constants/TagResponseMessage.java
+++ b/src/main/java/com/poortorich/tag/constants/TagResponseMessage.java
@@ -1,0 +1,9 @@
+package com.poortorich.tag.constants;
+
+public class TagResponseMessage {
+
+    public static final String TAG_NAME_TOO_LONG = "태그는 " + TagValidationConstraints.TAG_NAME_MAX + "자 이하여야 합니다.";
+
+    private TagResponseMessage() {
+    }
+}

--- a/src/main/java/com/poortorich/tag/constants/TagValidationConstraints.java
+++ b/src/main/java/com/poortorich/tag/constants/TagValidationConstraints.java
@@ -1,0 +1,9 @@
+package com.poortorich.tag.constants;
+
+public class TagValidationConstraints {
+
+    public static final int TAG_NAME_MAX = 50;
+
+    private TagValidationConstraints() {
+    }
+}

--- a/src/main/java/com/poortorich/tag/entity/Tag.java
+++ b/src/main/java/com/poortorich/tag/entity/Tag.java
@@ -1,0 +1,51 @@
+package com.poortorich.tag.entity;
+
+import com.poortorich.chat.entity.Chatroom;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "tag")
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @CreationTimestamp
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @UpdateTimestamp
+    @Column(name = "updated_date")
+    private LocalDateTime updatedDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private Chatroom chatroom;
+}

--- a/src/main/java/com/poortorich/tag/repository/TagRepository.java
+++ b/src/main/java/com/poortorich/tag/repository/TagRepository.java
@@ -1,0 +1,9 @@
+package com.poortorich.tag.repository;
+
+import com.poortorich.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/poortorich/tag/response/enums/TagResponse.java
+++ b/src/main/java/com/poortorich/tag/response/enums/TagResponse.java
@@ -1,0 +1,33 @@
+package com.poortorich.tag.response.enums;
+
+import com.poortorich.global.response.Response;
+import com.poortorich.tag.constants.TagResponseMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TagResponse implements Response {
+
+    TAG_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, TagResponseMessage.TAG_NAME_TOO_LONG, "hashtags");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String field;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
+}

--- a/src/main/java/com/poortorich/tag/service/TagService.java
+++ b/src/main/java/com/poortorich/tag/service/TagService.java
@@ -1,0 +1,41 @@
+package com.poortorich.tag.service;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.global.exceptions.BadRequestException;
+import com.poortorich.tag.constants.TagValidationConstraints;
+import com.poortorich.tag.entity.Tag;
+import com.poortorich.tag.repository.TagRepository;
+import com.poortorich.tag.response.enums.TagResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    public void createTag(List<String> hashtags, Chatroom chatroom) {
+        List<Tag> tag = new ArrayList<>();
+        for (String tagName : hashtags) {
+            tag.add(Tag.builder()
+                    .name(validateTagName(tagName))
+                    .chatroom(chatroom)
+                    .build()
+            );
+        }
+
+        tagRepository.saveAll(tag);
+    }
+
+    private String validateTagName(String tagName) {
+        if (tagName.length() > TagValidationConstraints.TAG_NAME_MAX) {
+            throw new BadRequestException(TagResponse.TAG_NAME_TOO_LONG);
+        }
+
+        return tagName;
+    }
+}

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -1,0 +1,72 @@
+package com.poortorich.chat.facade;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.chat.response.ChatroomCreateResponse;
+import com.poortorich.chat.service.ChatParticipantService;
+import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.s3.service.FileUploadService;
+import com.poortorich.tag.service.TagService;
+import com.poortorich.user.entity.User;
+import com.poortorich.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChatFacadeTest {
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private ChatroomService chatroomService;
+    @Mock
+    private ChatParticipantService chatParticipantService;
+    @Mock
+    private FileUploadService fileUploadService;
+    @Mock
+    private TagService tagService;
+
+    @InjectMocks
+    private ChatFacade chatFacade;
+
+    @Test
+    @DisplayName("채팅방 추가 성공")
+    void createChatroomSuccess() {
+        String username = "test";
+        MultipartFile image = Mockito.mock(MultipartFile.class);
+        String imageUrl = "https://image.com";
+        String chatroomTitle = "채팅방";
+        Long maxMemberCount = 10L;
+        List<String> hashtags = List.of("부자", "거지");
+        Boolean isRankingEnabled = false;
+        String chatroomPassword = "부자12";
+        ChatroomCreateRequest request = new ChatroomCreateRequest(
+                chatroomTitle, maxMemberCount, null, hashtags, isRankingEnabled, chatroomPassword
+        );
+        User user = User.builder().username(username).build();
+        Chatroom chatroom = Chatroom.builder().id(1L).title(chatroomTitle).build();
+
+        when(userService.findUserByUsername(username)).thenReturn(user);
+        when(fileUploadService.uploadImage(image)).thenReturn(imageUrl);
+        when(chatroomService.createChatroom(imageUrl, request)).thenReturn(chatroom);
+
+        ChatroomCreateResponse response = chatFacade.createChatroom(username, image, request);
+
+        verify(chatParticipantService).createChatroomHost(user, chatroom);
+        verify(tagService).createTag(hashtags, chatroom);
+
+        assertThat(response.getNewChatroomId()).isEqualTo(chatroom.getId());
+    }
+}

--- a/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
@@ -1,0 +1,52 @@
+package com.poortorich.chat.service;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.repository.ChatParticipantRepository;
+import com.poortorich.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatParticipantServiceTest {
+
+    @Mock
+    private ChatParticipantRepository chatParticipantRepository;
+
+    @InjectMocks
+    private ChatParticipantService chatParticipantService;
+
+    @Captor
+    private ArgumentCaptor<ChatParticipant> chatParticipantCaptor;
+
+    @Test
+    @DisplayName("채팅 참여자 저장 성공")
+    void createChatroomHostSuccess() {
+        User user = User.builder().build();
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatParticipant chatParticipant = ChatParticipant.builder()
+                .role(ChatroomRole.HOST)
+                .user(user)
+                .chatroom(chatroom)
+                .build();
+
+        chatParticipantService.createChatroomHost(user, chatroom);
+
+        verify(chatParticipantRepository).save(chatParticipantCaptor.capture());
+        ChatParticipant savedChatParticipant = chatParticipantCaptor.getValue();
+
+        assertThat(savedChatParticipant.getRole()).isEqualTo(chatParticipant.getRole());
+        assertThat(savedChatParticipant.getUser()).isEqualTo(user);
+        assertThat(savedChatParticipant.getChatroom()).isEqualTo(chatroom);
+    }
+}

--- a/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
@@ -1,0 +1,53 @@
+package com.poortorich.chat.service;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.repository.ChatroomRepository;
+import com.poortorich.chat.request.ChatroomCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatroomServiceTest {
+
+    @Mock
+    private ChatroomRepository chatroomRepository;
+
+    @InjectMocks
+    private ChatroomService chatroomService;
+
+    @Captor
+    private ArgumentCaptor<Chatroom> chatroomCaptor;
+
+    @Test
+    @DisplayName("채팅방 저장 성공")
+    void createChatroomSuccess() {
+        String imageUrl = "https://image.com";
+        String chatroomTitle = "채팅방";
+        Long maxMemberCount = 10L;
+        Boolean isRankingEnabled = false;
+        String chatroomPassword = "부자12";
+        ChatroomCreateRequest request = new ChatroomCreateRequest(
+                chatroomTitle, maxMemberCount, null, null, isRankingEnabled, chatroomPassword
+        );
+
+        chatroomService.createChatroom(imageUrl, request);
+
+        verify(chatroomRepository).save(chatroomCaptor.capture());
+        Chatroom savedChatroom = chatroomCaptor.getValue();
+
+        assertThat(savedChatroom.getImage()).isEqualTo(imageUrl);
+        assertThat(savedChatroom.getTitle()).isEqualTo(chatroomTitle);
+        assertThat(savedChatroom.getMaxMemberCount()).isEqualTo(maxMemberCount);
+        assertThat(savedChatroom.getIsRankingEnabled()).isEqualTo(isRankingEnabled);
+        assertThat(savedChatroom.getPassword()).isEqualTo(chatroomPassword);
+    }
+}

--- a/src/test/java/com/poortorich/tag/service/TagServiceTest.java
+++ b/src/test/java/com/poortorich/tag/service/TagServiceTest.java
@@ -1,0 +1,68 @@
+package com.poortorich.tag.service;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.global.exceptions.BadRequestException;
+import com.poortorich.tag.constants.TagValidationConstraints;
+import com.poortorich.tag.entity.Tag;
+import com.poortorich.tag.repository.TagRepository;
+import com.poortorich.tag.response.enums.TagResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @InjectMocks
+    private TagService tagService;
+
+    @Captor
+    private ArgumentCaptor<List<Tag>> tagsCaptor;
+
+    @Test
+    @DisplayName("태그 리스트 저장 성공")
+    void createTagSuccess() {
+        List<String> tagNames = List.of("태그1", "태그2", "태그3");
+        Chatroom chatroom = Chatroom.builder().build();
+        Tag tag1 = Tag.builder().name("태그1").chatroom(chatroom).build();
+        Tag tag2 = Tag.builder().name("태그2").chatroom(chatroom).build();
+        Tag tag3 = Tag.builder().name("태그3").chatroom(chatroom).build();
+        List<Tag> tags = List.of(tag1, tag2, tag3);
+
+        tagService.createTag(tagNames, chatroom);
+
+        verify(tagRepository).saveAll(tagsCaptor.capture());
+        List<Tag> savedTags = tagsCaptor.getValue();
+
+        assertThat(savedTags.size()).isEqualTo(3);
+        assertThat(savedTags.get(0).getName()).isEqualTo(tags.get(0).getName());
+        assertThat(savedTags.get(1).getName()).isEqualTo(tags.get(1).getName());
+        assertThat(savedTags.get(2).getName()).isEqualTo(tags.get(2).getName());
+    }
+
+    @Test
+    @DisplayName("태그 이름이 최대 길이가 넘어가는 경우 예외 발생")
+    void createTagNameTooLong() {
+        String tooLongName = "A".repeat(TagValidationConstraints.TAG_NAME_MAX + 1);
+        List<String> tagNames = List.of(tooLongName);
+        Chatroom chatroom = Chatroom.builder().build();
+
+        assertThatThrownBy(() -> tagService.createTag(tagNames, chatroom))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(TagResponse.TAG_NAME_TOO_LONG.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#316
 
## 📝작업 내용

- Entity를 추가하는 작업을 같이 진행하여 양이 많아졌습니다 ...

### Entity 추가
  - `Chatroom`, `ChatParticipant`, `Like`, `Tag`, `ChatMessage`, `UnreadChatMessage`
 
### 채팅방 추가 API

- `ChatController`
   - 이미지 파일을 받기 위해 form-data 형식으로 구현
- `ChatFacade`
   - 채팅방 추가를 위해 필요한 Service 로직 적절히 조회
- `ChatroomService`
   - 채팅방 생성 로직 추가
- `ChatParticipantService`
   - 채팅참여자 중 방장 생성 로직 추가
- `TagService`
   - 채팅방 태그들 생성 로직 추가
- 채팅방 추가 API와 관련된 테스트 로직 추가
   > `ChatControllerTest`는 form-data 관련 테스트 로직을 어떻게 설계해야할지 몰라서 (+ 자꾸 오류가 나서) 일단 제외하고 구현해두었습니다

 ### 스크린샷

<img width="1114" height="554" alt="스크린샷 2025-07-28 오전 2 23 39" src="https://github.com/user-attachments/assets/cbd6591f-0971-482b-ba85-78ad1e8883c5" />
 
 ## 💬리뷰 요구사항

- entity간 연관관계
