### PR TITLE
[#316] 채팅방 추가 API 수정사항

### DIFF
--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -27,12 +27,11 @@ public class ChatController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BaseResponse> createChatroom(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestPart(value = "chatroomImage", required = false) MultipartFile chatroomImage,
-            @RequestPart("request") @Valid ChatroomCreateRequest request
+            @Valid ChatroomCreateRequest request
     ) {
         return DataResponse.toResponseEntity(
                 ChatResponse.CREATE_CHATROOM_SUCCESS,
-                chatFacade.createChatroom(userDetails.getUsername(), chatroomImage, request)
+                chatFacade.createChatroom(userDetails.getUsername(), request)
         );
     }
 }

--- a/src/main/java/com/poortorich/chat/entity/ChatMessage.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatMessage.java
@@ -50,6 +50,9 @@ public class ChatMessage {
     @Column(name = "photo_id")
     private Long photoId;
 
+    @Column(name = "user_id")
+    private Long userId;
+
     @Column(name = "content")
     private String content;
 

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -27,11 +27,10 @@ public class ChatFacade {
     @Transactional
     public ChatroomCreateResponse createChatroom(
             String username,
-            MultipartFile chatroomImage,
             ChatroomCreateRequest request
     ) {
         User user = userService.findUserByUsername(username);
-        String imageUrl = fileUploadService.uploadImage(chatroomImage);
+        String imageUrl = fileUploadService.uploadImage(request.getChatroomImage());
 
         Chatroom chatroom = chatroomService.createChatroom(imageUrl, request);
         chatParticipantService.createChatroomHost(user, chatroom);

--- a/src/main/java/com/poortorich/chat/request/ChatroomCreateRequest.java
+++ b/src/main/java/com/poortorich/chat/request/ChatroomCreateRequest.java
@@ -7,13 +7,18 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@Getter
+@Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class ChatroomCreateRequest {
+
+    private MultipartFile chatroomImage;
 
     @NotNull(message = ChatResponseMessage.CHATROOM_TITLE_REQUIRED)
     @Size(max = ChatValidationConstraints.CHATROOM_TITLE_MAX,

--- a/src/main/java/com/poortorich/tag/service/TagService.java
+++ b/src/main/java/com/poortorich/tag/service/TagService.java
@@ -9,7 +9,6 @@ import com.poortorich.tag.response.enums.TagResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -19,16 +18,18 @@ public class TagService {
     private final TagRepository tagRepository;
 
     public void createTag(List<String> hashtags, Chatroom chatroom) {
-        List<Tag> tag = new ArrayList<>();
-        for (String tagName : hashtags) {
-            tag.add(Tag.builder()
-                    .name(validateTagName(tagName))
-                    .chatroom(chatroom)
-                    .build()
-            );
-        }
+        List<Tag> tag = hashtags.stream()
+                .map(tagName -> buildTag(tagName, chatroom))
+                .toList();
 
         tagRepository.saveAll(tag);
+    }
+
+    private Tag buildTag(String tagName, Chatroom chatroom) {
+        return Tag.builder()
+                .name(validateTagName(tagName))
+                .chatroom(chatroom)
+                .build();
     }
 
     private String validateTagName(String tagName) {

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -53,7 +53,7 @@ class ChatFacadeTest {
         Boolean isRankingEnabled = false;
         String chatroomPassword = "부자12";
         ChatroomCreateRequest request = new ChatroomCreateRequest(
-                chatroomTitle, maxMemberCount, null, hashtags, isRankingEnabled, chatroomPassword
+                image, chatroomTitle, maxMemberCount, null, hashtags, isRankingEnabled, chatroomPassword
         );
         User user = User.builder().username(username).build();
         Chatroom chatroom = Chatroom.builder().id(1L).title(chatroomTitle).build();
@@ -62,7 +62,7 @@ class ChatFacadeTest {
         when(fileUploadService.uploadImage(image)).thenReturn(imageUrl);
         when(chatroomService.createChatroom(imageUrl, request)).thenReturn(chatroom);
 
-        ChatroomCreateResponse response = chatFacade.createChatroom(username, image, request);
+        ChatroomCreateResponse response = chatFacade.createChatroom(username, request);
 
         verify(chatParticipantService).createChatroomHost(user, chatroom);
         verify(tagService).createTag(hashtags, chatroom);

--- a/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
@@ -36,7 +36,7 @@ class ChatroomServiceTest {
         Boolean isRankingEnabled = false;
         String chatroomPassword = "부자12";
         ChatroomCreateRequest request = new ChatroomCreateRequest(
-                chatroomTitle, maxMemberCount, null, null, isRankingEnabled, chatroomPassword
+                null, chatroomTitle, maxMemberCount, null, null, isRankingEnabled, chatroomPassword
         );
 
         chatroomService.createChatroom(imageUrl, request);


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#316
 
 ## 📝작업 내용

#318 과 이어지는 PR입니다.
 
- 채팅메세지 누락 필드 추가
- 하나의 Request를 사용하도록 로직 수정
  > 현재 추가 로직은 정상적으로 작동하나, webp 변경 부분에서 문제가 있는 것으로 확인됩니다 
  > <img width="840" height="253" alt="image" src="https://github.com/user-attachments/assets/d8eeddfc-f842-4ad4-83d7-cd3066c7740c" />
  > 이 문제 발생 시 response 필드 값이 `proflieImage`로 전송되고 있어서, field 값을 지정해주는 방식의 변경이 필요할 거 같습니다
  > <img width="798" height="434" alt="image" src="https://github.com/user-attachments/assets/04b8c1f8-4829-4fb9-882e-f15936d2a2f5" />

 
 ### 스크린샷

<img width="1114" height="407" alt="image" src="https://github.com/user-attachments/assets/fee76be3-d248-4089-b457-846f91a5d442" />
 
 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
