### PR TITLE
[#325] 채팅방 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -3,6 +3,7 @@ package com.poortorich.chat.constants;
 public class ChatResponseMessage {
 
     public static final String CREATE_CHATROOM_SUCCESS = "채팅방을 성공적으로 추가했습니다.";
+    public static final String GET_CHATROOM_SUCCESS = "채팅방을 성공적으로 조회했습니다.";
 
     public static final String CHATROOM_TITLE_REQUIRED = "채팅방 이름은 필수값입니다.";
     public static final String CHATROOM_TITLE_TOO_BIG
@@ -17,6 +18,8 @@ public class ChatResponseMessage {
     public static final String CHATROOM_DESCRIPTION_REQUIRED = "채팅방 소개는 필수값입니다.";
     public static final String CHATROOM_DESCRIPTION_TOO_BIG
             = "채팅방 소개는 " + ChatValidationConstraints.CHATROOM_DESCRIPTION_MAX + "자 이하여야 합니다.";
+
+    public static final String CHATROOM_NON_EXISTENT = "존재하지 않는 채팅방입니다.";
 
     private ChatResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -33,6 +35,14 @@ public class ChatController {
         return DataResponse.toResponseEntity(
                 ChatResponse.CREATE_CHATROOM_SUCCESS,
                 chatFacade.createChatroom(userDetails.getUsername(), chatroomImage, request)
+        );
+    }
+
+    @GetMapping("/{chatroomId}/edit")
+    public ResponseEntity<BaseResponse> getChatroom(@PathVariable Long chatroomId) {
+        return DataResponse.toResponseEntity(
+                ChatResponse.GET_CHATROOM_SUCCESS,
+                chatFacade.getChatroom(chatroomId)
         );
     }
 }

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -15,9 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/chatrooms")

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -3,8 +3,10 @@ package com.poortorich.chat.facade;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.response.ChatroomCreateResponse;
+import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.chat.util.ChatBuilder;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
 import com.poortorich.user.entity.User;
@@ -13,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -38,5 +42,12 @@ public class ChatFacade {
         tagService.createTag(request.getHashtags(), chatroom);
 
         return ChatroomCreateResponse.builder().newChatroomId(chatroom.getId()).build();
+    }
+
+    public ChatroomInfoResponse getChatroom(Long chatroomId) {
+        Chatroom chatroom = chatroomService.findChatroomById(chatroomId);
+        List<String> hashtags = tagService.getTagNames(chatroom);
+
+        return ChatBuilder.buildChatroomInfoResponse(chatroom, hashtags);
     }
 }

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -48,7 +48,7 @@ public class ChatFacade {
     }
 
     public ChatroomInfoResponse getChatroom(Long chatroomId) {
-        Chatroom chatroom = chatroomService.findChatroomById(chatroomId);
+        Chatroom chatroom = chatroomService.findById(chatroomId);
         List<String> hashtags = tagService.getTagNames(chatroom);
 
         return ChatBuilder.buildChatroomInfoResponse(chatroom, hashtags);
@@ -59,7 +59,7 @@ public class ChatFacade {
             Long chatroomId,
             ChatroomEnterRequest chatroomEnterRequest
     ) {
-        Chatroom chatroom = chatroomService.findByChatroomId(chatroomId);
+        Chatroom chatroom = chatroomService.findById(chatroomId);
         User user = userService.findUserByUsername(username);
 
         chatroomValidator.validateEnter(user, chatroom);

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -21,7 +21,7 @@ public class ChatRealTimeFacade {
 
     public ResponsePayload createUserEnterSystemMessage(String username, Long chatroomId) {
         User user = userService.findUserByUsername(username);
-        Chatroom chatroom = chatroomService.findByChatroomId(chatroomId);
+        Chatroom chatroom = chatroomService.findById(chatroomId);
 
         UserEnterResponsePayload payload = chatMessageService.saveUserEnterMessage(user, chatroom);
 

--- a/src/main/java/com/poortorich/chat/response/ChatroomInfoResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomInfoResponse.java
@@ -1,0 +1,23 @@
+package com.poortorich.chat.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatroomInfoResponse {
+
+    private String chatroomImage;
+    private String chatroomTitle;
+    private Long maxMemberCount;
+    private String description;
+    private List<String> hashtags;
+    private Boolean isRankingEnabled;
+    private String chatroomPassword;
+}

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ChatResponse implements Response {
 
-    CREATE_CHATROOM_SUCCESS(HttpStatus.CREATED, ChatResponseMessage.CREATE_CHATROOM_SUCCESS, null);
+    CREATE_CHATROOM_SUCCESS(HttpStatus.CREATED, ChatResponseMessage.CREATE_CHATROOM_SUCCESS, null),
+    GET_CHATROOM_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_SUCCESS, null),
+
+    CHATROOM_NON_EXISTENT(HttpStatus.NOT_FOUND, ChatResponseMessage.CHATROOM_NON_EXISTENT, "chatroomId");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chat/service/ChatroomService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatroomService.java
@@ -3,7 +3,9 @@ package com.poortorich.chat.service;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.repository.ChatroomRepository;
 import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.chat.util.ChatBuilder;
+import com.poortorich.global.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,5 +18,10 @@ public class ChatroomService {
     public Chatroom createChatroom(String imageUrl, ChatroomCreateRequest request) {
         Chatroom chatroom = ChatBuilder.buildChatroom(imageUrl, request);
         return chatroomRepository.save(chatroom);
+    }
+
+    public Chatroom findChatroomById(Long chatroomId) {
+        return chatroomRepository.findById(chatroomId)
+                .orElseThrow(() -> new NotFoundException(ChatResponse.CHATROOM_NON_EXISTENT));
     }
 }

--- a/src/main/java/com/poortorich/chat/util/ChatBuilder.java
+++ b/src/main/java/com/poortorich/chat/util/ChatBuilder.java
@@ -6,7 +6,10 @@ import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.user.entity.User;
+
+import java.util.List;
 
 public class ChatBuilder {
 
@@ -29,6 +32,18 @@ public class ChatBuilder {
                 .noticeStatus(NoticeStatus.DEFAULT)
                 .user(user)
                 .chatroom(chatroom)
+                .build();
+    }
+
+    public static ChatroomInfoResponse buildChatroomInfoResponse(Chatroom chatroom, List<String> hashtags) {
+        return ChatroomInfoResponse.builder()
+                .chatroomImage(chatroom.getImage())
+                .chatroomTitle(chatroom.getTitle())
+                .description(chatroom.getDescription())
+                .maxMemberCount(chatroom.getMaxMemberCount())
+                .hashtags(hashtags)
+                .isRankingEnabled(chatroom.getIsRankingEnabled())
+                .chatroomPassword(chatroom.getPassword())
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/tag/repository/TagRepository.java
+++ b/src/main/java/com/poortorich/tag/repository/TagRepository.java
@@ -1,9 +1,14 @@
 package com.poortorich.tag.repository;
 
+import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.tag.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    List<Tag> findByChatroom(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/tag/service/TagService.java
+++ b/src/main/java/com/poortorich/tag/service/TagService.java
@@ -38,4 +38,10 @@ public class TagService {
 
         return tagName;
     }
+
+    public List<String> getTagNames(Chatroom chatroom) {
+        return tagRepository.findByChatroom(chatroom).stream()
+                .map(Tag::getName)
+                .toList();
+    }
 }

--- a/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
@@ -1,0 +1,51 @@
+package com.poortorich.chat.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chat.response.ChatroomInfoResponse;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.global.config.BaseSecurityTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatController.class)
+@ExtendWith(MockitoExtension.class)
+public class ChatControllerTest extends BaseSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ChatFacade chatFacade;
+
+    @Test
+    @WithMockUser(username = "test")
+    @DisplayName("채팅방 정보 조회 성공")
+    void getChatroomSuccess() throws Exception {
+        Long chatroomId = 1L;
+        when(chatFacade.getChatroom(chatroomId)).thenReturn(ChatroomInfoResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/edit")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(ChatResponse.GET_CHATROOM_SUCCESS.getMessage())
+                );
+    }
+}

--- a/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
@@ -1,16 +1,13 @@
 package com.poortorich.chat.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chat.realtime.facade.ChatRealTimeFacade;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.config.BaseSecurityTest;
 import com.poortorich.s3.util.S3TestFileGenerator;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -25,7 +23,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -42,6 +39,10 @@ public class ChatControllerTest extends BaseSecurityTest {
 
     @MockitoBean
     private ChatFacade chatFacade;
+    @MockitoBean
+    private SimpMessagingTemplate simpMessagingTemplate;
+    @MockitoBean
+    private ChatRealTimeFacade chatRealTimeFacade;
 
     @Test
     @WithMockUser(username = "test")

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -90,7 +90,7 @@ class ChatFacadeTest {
     @Test
     @DisplayName("채팅방 정보 조회 성공")
     void getChatroomSuccess() {
-        when(chatroomService.findChatroomById(chatroomId)).thenReturn(chatroom);
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
         when(tagService.getTagNames(chatroom)).thenReturn(hashtags);
 
         ChatroomInfoResponse response = chatFacade.getChatroom(chatroomId);

--- a/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
@@ -3,6 +3,8 @@ package com.poortorich.chat.service;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.repository.ChatroomRepository;
 import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.global.exceptions.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,8 +14,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ChatroomServiceTest {
@@ -49,5 +55,29 @@ class ChatroomServiceTest {
         assertThat(savedChatroom.getMaxMemberCount()).isEqualTo(maxMemberCount);
         assertThat(savedChatroom.getIsRankingEnabled()).isEqualTo(isRankingEnabled);
         assertThat(savedChatroom.getPassword()).isEqualTo(chatroomPassword);
+    }
+
+    @Test
+    @DisplayName("아이디 값으로 채팅방 조회 성공")
+    void findChatroomByIdSuccess() {
+        Long chatroomId = 1L;
+        Chatroom chatroom = Chatroom.builder().id(chatroomId).build();
+
+        when(chatroomRepository.findById(chatroomId)).thenReturn(Optional.of(chatroom));
+
+        Chatroom result = chatroomService.findChatroomById(chatroomId);
+
+        assertThat(result).isEqualTo(chatroom);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 아이디 값으로 조회시 예외 발생")
+    void findChatroomByIdNotFound() {
+        Long chatroomId = 1L;
+        when(chatroomRepository.findById(chatroomId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chatroomService.findChatroomById(chatroomId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining(ChatResponse.CHATROOM_NON_EXISTENT.getMessage());
     }
 }

--- a/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
@@ -65,7 +65,7 @@ class ChatroomServiceTest {
 
         when(chatroomRepository.findById(chatroomId)).thenReturn(Optional.of(chatroom));
 
-        Chatroom result = chatroomService.findChatroomById(chatroomId);
+        Chatroom result = chatroomService.findById(chatroomId);
 
         assertThat(result).isEqualTo(chatroom);
     }
@@ -76,8 +76,8 @@ class ChatroomServiceTest {
         Long chatroomId = 1L;
         when(chatroomRepository.findById(chatroomId)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> chatroomService.findChatroomById(chatroomId))
+        assertThatThrownBy(() -> chatroomService.findById(chatroomId))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining(ChatResponse.CHATROOM_NON_EXISTENT.getMessage());
+                .hasMessageContaining(ChatResponse.CHATROOM_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#325
 
 ## 📝작업 내용

- 채팅방 조회 API
   - `chatroomId`로 `Chatroom`과 `Tag`를 조회한 뒤 필요한 정보를 반환
 
 ### 스크린샷

<img width="1111" height="463" alt="image" src="https://github.com/user-attachments/assets/68518aa6-dcc0-404e-9ba1-455abf7d4ede" />
