### PR TITLE
[#331] 채팅방 편집 API

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -24,6 +24,11 @@ public class ChatResponseMessage {
     public static final String CHATROOM_NOT_FOUND = "채팅방을 찾을 수 없습니다.";
     public static final String CHATROOM_ENTER_SUCCESS = "채팅방 입장이 성공적으로 완료되었습니다.";
     public static final String CHATROOM_ENTER_DUPLICATED = "이미 참여중인 채팅방입니다.";
+    public static final String CHATROOM_UPDATE_SUCCESS = "채팅방을 성공적으로 편집했습니다.";
+    public static final String CHAT_PARTICIPANT_NOT_FOUND = "참여자를 찾을 수 없습니다.";
+    public static final String CHATROOM_NOT_PARTICIPATE = "채팅방에 참여하고 있지 않습니다.";
+    public static final String CHAT_PARTICIPANT_NOT_HOST = "채팅방 방장이 아닙니다.";
+    public static final String CHATROOM_MAX_MEMBER_COUNT_EXCEED = "최대 인원 수를 현재 인원보다 적게 설정할 수 없습니다.";
 
     private ChatResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -5,6 +5,7 @@ import com.poortorich.chat.realtime.facade.ChatRealTimeFacade;
 import com.poortorich.chat.realtime.payload.ResponsePayload;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.request.ChatroomEnterRequest;
+import com.poortorich.chat.request.ChatroomUpdateRequest;
 import com.poortorich.chat.response.ChatroomEnterResponse;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.response.BaseResponse;
@@ -20,6 +21,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -52,7 +54,7 @@ public class ChatController {
                 chatFacade.getChatroom(chatroomId)
         );
     }
-  
+
     @PostMapping("/{chatroomId}/enter")
     public ResponseEntity<BaseResponse> enterChatroom(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -71,5 +73,16 @@ public class ChatController {
                 ChatResponse.CHATROOM_ENTER_SUCCESS,
                 response
         );
+    }
+
+    @PutMapping(value = "/{chatroomId}/edit", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse> updateChatroom(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("chatroomId") Long chatroomId,
+            @Valid ChatroomUpdateRequest chatroomUpdateRequest
+    ) {
+        return DataResponse.toResponseEntity(
+                ChatResponse.CHATROOM_UPDATE_SUCCESS,
+                chatFacade.updateChatroom(userDetails.getUsername(), chatroomId, chatroomUpdateRequest));
     }
 }

--- a/src/main/java/com/poortorich/chat/entity/Chatroom.java
+++ b/src/main/java/com/poortorich/chat/entity/Chatroom.java
@@ -1,11 +1,13 @@
 package com.poortorich.chat.entity;
 
+import com.poortorich.chat.request.ChatroomUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +15,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -55,4 +55,12 @@ public class Chatroom {
     @UpdateTimestamp
     @Column(name = "updated_date")
     private LocalDateTime updatedDate;
+
+    public void updateChatroom(ChatroomUpdateRequest chatroomUpdateRequest, String imageUrl) {
+        this.image = imageUrl;
+        this.title = chatroomUpdateRequest.getChatroomTitle();
+        this.description = chatroomUpdateRequest.getDescription();
+        this.password = chatroomUpdateRequest.getChatroomPassword();
+        this.maxMemberCount = chatroomUpdateRequest.getMaxMemberCount();
+    }
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -11,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
 
     Optional<ChatParticipant> findByUserAndChatroom(User user, Chatroom chatroom);
+
+    int countByChatroomAndIsParticipateTrue(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chat/request/ChatroomUpdateRequest.java
+++ b/src/main/java/com/poortorich/chat/request/ChatroomUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.poortorich.chat.request;
+
+public class ChatroomUpdateRequest {
+}

--- a/src/main/java/com/poortorich/chat/request/ChatroomUpdateRequest.java
+++ b/src/main/java/com/poortorich/chat/request/ChatroomUpdateRequest.java
@@ -1,4 +1,40 @@
 package com.poortorich.chat.request;
 
+import com.poortorich.chat.constants.ChatResponseMessage;
+import com.poortorich.chat.constants.ChatValidationConstraints;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
 public class ChatroomUpdateRequest {
+
+    private final MultipartFile chatroomImage;
+
+    @NotNull(message = ChatResponseMessage.CHATROOM_TITLE_REQUIRED)
+    @Size(max = ChatValidationConstraints.CHATROOM_TITLE_MAX,
+            message = ChatResponseMessage.CHATROOM_TITLE_TOO_BIG)
+    private final String chatroomTitle;
+
+    @NotNull(message = ChatResponseMessage.CHATROOM_MAX_MEMBER_COUNT_REQUIRED)
+    @Min(value = ChatValidationConstraints.CHATROOM_MAX_MEMBER_COUNT_MIN,
+            message = ChatResponseMessage.CHATROOM_MAX_MEMBER_COUNT_TOO_SMALL)
+    @Max(value = ChatValidationConstraints.CHATROOM_MAX_MEMBER_COUNT_MAX,
+            message = ChatResponseMessage.CHATROOM_MAX_MEMBER_COUNT_TOO_BIG)
+    private final Long maxMemberCount;
+
+    @NotNull(message = ChatResponseMessage.CHATROOM_DESCRIPTION_REQUIRED)
+    @Size(max = ChatValidationConstraints.CHATROOM_DESCRIPTION_MAX,
+            message = ChatResponseMessage.CHATROOM_DESCRIPTION_TOO_BIG)
+    private final String description;
+
+    private final List<String> hashtags;
+    private final Boolean isRankingEnabled;
+    private final String chatroomPassword;
 }

--- a/src/main/java/com/poortorich/chat/response/ChatroomUpdateResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomUpdateResponse.java
@@ -1,0 +1,4 @@
+package com.poortorich.chat.response;
+
+public class ChatroomUpdateResponse {
+}

--- a/src/main/java/com/poortorich/chat/response/ChatroomUpdateResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomUpdateResponse.java
@@ -1,4 +1,11 @@
 package com.poortorich.chat.response;
 
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
 public class ChatroomUpdateResponse {
+
+    private final Long chatroomId;
 }

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -17,7 +17,17 @@ public enum ChatResponse implements Response {
     CHATROOM_PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_PASSWORD_DO_NOT_MATCH, null),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, ChatResponseMessage.CHATROOM_NOT_FOUND, "chatroomId"),
     CHATROOM_ENTER_SUCCESS(HttpStatus.OK, ChatResponseMessage.CHATROOM_ENTER_SUCCESS, null),
-    CHATROOM_ENTER_DUPLICATED(HttpStatus.CONFLICT, ChatResponseMessage.CHATROOM_ENTER_DUPLICATED, null);
+    CHATROOM_ENTER_DUPLICATED(HttpStatus.CONFLICT, ChatResponseMessage.CHATROOM_ENTER_DUPLICATED, null),
+    CHATROOM_UPDATE_SUCCESS(HttpStatus.OK, ChatResponseMessage.CHATROOM_UPDATE_SUCCESS, null),
+    CHAT_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, ChatResponseMessage.CHAT_PARTICIPANT_NOT_FOUND, null),
+    CHATROOM_NOT_PARTICIPATE(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_NOT_PARTICIPATE, null),
+    CHAT_PARTICIPANT_NOT_HOST(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHAT_PARTICIPANT_NOT_HOST, null),
+
+    CHATROOM_MAX_MEMBER_COUNT_EXCEED(
+            HttpStatus.BAD_REQUEST,
+            ChatResponseMessage.CHATROOM_MAX_MEMBER_COUNT_EXCEED,
+            null
+    );
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
@@ -1,4 +1,53 @@
 package com.poortorich.chat.validator;
 
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.repository.ChatParticipantRepository;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class ChatParticipantValidator {
+
+    private final ChatParticipantRepository chatParticipantRepository;
+
+    public void validateIsParticipate(User user, Chatroom chatroom) {
+        if (!chatParticipant(user, chatroom).getIsParticipate()) {
+            throw new BadRequestException(ChatResponse.CHATROOM_NOT_PARTICIPATE);
+        }
+    }
+
+    public void validateIsHost(User user, Chatroom chatroom) {
+        ChatParticipant chatParticipant = chatParticipant(user, chatroom);
+        validateIsParticipate(chatParticipant);
+        if (!ChatroomRole.HOST.equals(chatParticipant.getRole())) {
+            throw new BadRequestException(ChatResponse.CHAT_PARTICIPANT_NOT_HOST);
+        }
+    }
+
+    public void validateIsMember(User user, Chatroom chatroom) {
+    }
+
+    public void validateIsBanned(User user, Chatroom chatroom) {
+    }
+
+    public void validateHasLeft(User user, Chatroom chatroom) {
+    }
+
+    private ChatParticipant chatParticipant(User user, Chatroom chatroom) {
+        return chatParticipantRepository.findByUserAndChatroom(user, chatroom)
+                .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND));
+    }
+
+    private void validateIsParticipate(ChatParticipant chatParticipant) {
+        if (!chatParticipant.getIsParticipate()) {
+            throw new BadRequestException(ChatResponse.CHATROOM_NOT_PARTICIPATE);
+        }
+    }
 }

--- a/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
@@ -1,0 +1,4 @@
+package com.poortorich.chat.validator;
+
+public class ChatParticipantValidator {
+}

--- a/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
@@ -44,4 +44,11 @@ public class ChatroomValidator {
             throw new ForbiddenException(ChatResponse.CHATROOM_ENTER_DENIED);
         }
     }
+
+    public void validateCanUpdateMaxMemberCount(Chatroom chatroom, Long maxMemberCount) {
+        int currentMemberCount = chatParticipantRepository.countByChatroomAndIsParticipateTrue(chatroom);
+        if (currentMemberCount > maxMemberCount) {
+            throw new BadRequestException(ChatResponse.CHATROOM_MAX_MEMBER_COUNT_EXCEED);
+        }
+    }
 }

--- a/src/main/java/com/poortorich/tag/repository/TagRepository.java
+++ b/src/main/java/com/poortorich/tag/repository/TagRepository.java
@@ -2,13 +2,14 @@ package com.poortorich.tag.repository;
 
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.tag.entity.Tag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     List<Tag> findByChatroom(Chatroom chatroom);
+
+    void deleteAllByChatroom(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/tag/service/TagService.java
+++ b/src/main/java/com/poortorich/tag/service/TagService.java
@@ -6,10 +6,9 @@ import com.poortorich.tag.constants.TagValidationConstraints;
 import com.poortorich.tag.entity.Tag;
 import com.poortorich.tag.repository.TagRepository;
 import com.poortorich.tag.response.enums.TagResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +43,10 @@ public class TagService {
         return tagRepository.findByChatroom(chatroom).stream()
                 .map(Tag::getName)
                 .toList();
+    }
+
+    public void updateTag(List<String> hashtags, Chatroom chatroom) {
+        tagRepository.deleteAllByChatroom(chatroom);
+        createTag(hashtags, chatroom);
     }
 }


### PR DESCRIPTION
## #️⃣331
 ## 📝작업 내용
 - 채팅방 편집 API를 구현했습니다.
 - 구현된 로직 흐름은 다음과 같습니다.
  *   최대 인원 갱신 가능 검증
  *  편집 API를 호출한 사용자가 방장인지 검증
  * 채팅방 데이터 편집
  * 태그 편집

 **채팅방 정보 갱신에 따른 브로드캐스트는 이후 구현할 예정**
 ### 스크린샷 (선택)
<img width="462" height="733" alt="image" src="https://github.com/user-attachments/assets/e32db3b8-78a6-4285-bdd4-1c1fb23e248d" />

 ## 💬리뷰 요구사항(선택)
 
> 빼먹은 검증 로직이 있을까요?
