### PR TITLE
[#333] 내가 방장인 채팅방 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -4,6 +4,7 @@ public class ChatResponseMessage {
 
     public static final String CREATE_CHATROOM_SUCCESS = "채팅방을 성공적으로 추가했습니다.";
     public static final String GET_CHATROOM_SUCCESS = "채팅방을 성공적으로 조회했습니다.";
+    public static final String GET_HOSTED_CHATROOMS_SUCCESS = "나의 채팅방 목록 조회가 완료되었습니다.";
 
     public static final String CHATROOM_TITLE_REQUIRED = "채팅방 이름은 필수값입니다.";
     public static final String CHATROOM_TITLE_TOO_BIG

--- a/src/main/java/com/poortorich/chat/controller/ChatParticipantController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatParticipantController.java
@@ -1,0 +1,29 @@
+package com.poortorich.chat.controller;
+
+import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.global.response.BaseResponse;
+import com.poortorich.global.response.DataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class ChatParticipantController {
+
+    private final ChatFacade chatFacade;
+
+    @GetMapping("/hosted-chatrooms")
+    public ResponseEntity<BaseResponse> getHostedChatrooms(@AuthenticationPrincipal UserDetails userDetails) {
+        return DataResponse.toResponseEntity(
+                ChatResponse.GET_HOSTED_CHATROOMS_SUCCESS,
+                chatFacade.getHostedChatrooms(userDetails.getUsername())
+        );
+    }
+}

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -8,6 +8,9 @@ import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomEnterResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.chat.response.ChatroomLeaveResponse;
+import com.poortorich.chat.response.ChatroomResponse;
+import com.poortorich.chat.response.ChatroomsResponse;
+import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.util.ChatBuilder;
@@ -16,6 +19,8 @@ import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,6 +37,7 @@ public class ChatFacade {
     private final TagService tagService;
 
     private final ChatroomValidator chatroomValidator;
+    private final ChatMessageService chatMessageService;
 
     @Transactional
     public ChatroomCreateResponse createChatroom(
@@ -53,6 +59,23 @@ public class ChatFacade {
         List<String> hashtags = tagService.getTagNames(chatroom);
 
         return ChatBuilder.buildChatroomInfoResponse(chatroom, hashtags);
+    }
+
+    public ChatroomsResponse getHostedChatrooms(String username) {
+        User user = userService.findUserByUsername(username);
+        List<Chatroom> hostedChatrooms = chatroomService.getHostedChatrooms(user);
+
+        List<ChatroomResponse> chatroomResponses = hostedChatrooms.stream()
+                .map(chatroom ->
+                        ChatBuilder.buildChatroomResponse(
+                                chatroom,
+                                tagService.getTagNames(chatroom),
+                                chatParticipantService.countByChatroom(chatroom),
+                                chatMessageService.getLastMessageTime(chatroom)
+                        ))
+                .toList();
+
+        return ChatroomsResponse.builder().chatrooms(chatroomResponses).build();
     }
 
     public ChatroomEnterResponse enterChatroom(

--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -1,8 +1,12 @@
 package com.poortorich.chat.repository;
 
 import com.poortorich.chat.entity.ChatMessage;
+import com.poortorich.chat.entity.Chatroom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    
+
+    Optional<ChatMessage> findTopByChatroomOrderBySentAtDesc(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -11,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
 
     Optional<ChatParticipant> findByUserAndChatroom(User user, Chatroom chatroom);
+
+    Long countByChatroomAndIsParticipateTrue(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -1,9 +1,22 @@
 package com.poortorich.chat.repository;
 
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+
+    @Query("""
+        SELECT c
+          FROM Chatroom c
+          JOIN ChatParticipant cp
+            ON cp.chatroom = c
+         WHERE cp.user = :user
+    """)
+    List<Chatroom> findHostedChatroomByUser(User user);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -1,9 +1,11 @@
 package com.poortorich.chat.repository;
 
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,6 +19,7 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
           JOIN ChatParticipant cp
             ON cp.chatroom = c
          WHERE cp.user = :user
+           AND cp.role = :role
     """)
-    List<Chatroom> findHostedChatroomByUser(User user);
+    List<Chatroom> findChatroomByUserAndRole(@Param("user") User user, @Param("role") ChatroomRole role);
 }

--- a/src/main/java/com/poortorich/chat/response/ChatroomResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomResponse.java
@@ -1,0 +1,24 @@
+package com.poortorich.chat.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatroomResponse {
+
+    private Long chatroomId;
+    private String chatroomTitle;
+    private String chatroomImage;
+    private String description;
+    private List<String> hashtags;
+    private Long currentMemberCount;
+    private Long maxMemberCount;
+    private String lastMessageTime;
+}

--- a/src/main/java/com/poortorich/chat/response/ChatroomsResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomsResponse.java
@@ -1,0 +1,17 @@
+package com.poortorich.chat.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatroomsResponse {
+
+    List<ChatroomResponse> chatrooms;
+}

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -12,6 +12,7 @@ public enum ChatResponse implements Response {
 
     CREATE_CHATROOM_SUCCESS(HttpStatus.CREATED, ChatResponseMessage.CREATE_CHATROOM_SUCCESS, null),
     GET_CHATROOM_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_SUCCESS, null),
+    GET_HOSTED_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_HOSTED_CHATROOMS_SUCCESS, null),
 
     CHATROOM_ENTER_DENIED(HttpStatus.FORBIDDEN, ChatResponseMessage.CHATROOM_ENTER_DENIED, null),
     CHATROOM_PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_PASSWORD_DO_NOT_MATCH, null),

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -10,6 +10,8 @@ import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService {
@@ -40,5 +42,11 @@ public class ChatMessageService {
                 .content(chatMessage.getContent())
                 .sendAt(chatMessage.getSentAt())
                 .build();
+    }
+
+    public String getLastMessageTime(Chatroom chatroom) {
+        return chatMessageRepository.findTopByChatroomOrderBySentAtDesc(chatroom)
+                .map(chatMessage -> chatMessage.getSentAt().toString())
+                .orElse(null);
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -35,4 +35,8 @@ public class ChatParticipantService {
         return chatParticipantRepository.findByUserAndChatroom(user, chatroom)
                 .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND));
     }
+
+    public Long countByChatroom(Chatroom chatroom) {
+        return chatParticipantRepository.countByChatroomAndIsParticipateTrue(chatroom);
+    }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatroomService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatroomService.java
@@ -6,8 +6,11 @@ import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.chat.util.ChatBuilder;
 import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,5 +26,9 @@ public class ChatroomService {
     public Chatroom findById(Long chatroomId) {
         return chatroomRepository.findById(chatroomId)
                 .orElseThrow(() -> new NotFoundException(ChatResponse.CHATROOM_NOT_FOUND));
+    }
+
+    public List<Chatroom> getHostedChatrooms(User user) {
+        return chatroomRepository.findHostedChatroomByUser(user);
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatroomService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatroomService.java
@@ -1,6 +1,7 @@
 package com.poortorich.chat.service;
 
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.repository.ChatroomRepository;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.response.enums.ChatResponse;
@@ -29,6 +30,6 @@ public class ChatroomService {
     }
 
     public List<Chatroom> getHostedChatrooms(User user) {
-        return chatroomRepository.findHostedChatroomByUser(user);
+        return chatroomRepository.findChatroomByUserAndRole(user, ChatroomRole.HOST);
     }
 }

--- a/src/main/java/com/poortorich/chat/util/ChatBuilder.java
+++ b/src/main/java/com/poortorich/chat/util/ChatBuilder.java
@@ -7,8 +7,10 @@ import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.response.ChatroomInfoResponse;
+import com.poortorich.chat.response.ChatroomResponse;
 import com.poortorich.user.entity.User;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class ChatBuilder {
@@ -44,6 +46,24 @@ public class ChatBuilder {
                 .hashtags(hashtags)
                 .isRankingEnabled(chatroom.getIsRankingEnabled())
                 .chatroomPassword(chatroom.getPassword())
+                .build();
+    }
+
+    public static ChatroomResponse buildChatroomResponse(
+            Chatroom chatroom,
+            List<String> hashtags,
+            Long currentMemberCount,
+            String lastMessageTime
+    ) {
+        return ChatroomResponse.builder()
+                .chatroomId(chatroom.getId())
+                .chatroomTitle(chatroom.getTitle())
+                .chatroomImage(chatroom.getImage())
+                .description(chatroom.getDescription())
+                .hashtags(hashtags)
+                .currentMemberCount(currentMemberCount)
+                .maxMemberCount(chatroom.getMaxMemberCount())
+                .lastMessageTime(lastMessageTime)
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
@@ -46,7 +46,7 @@ public class ChatroomValidator {
     }
 
     public void validateCanUpdateMaxMemberCount(Chatroom chatroom, Long maxMemberCount) {
-        int currentMemberCount = chatParticipantRepository.countByChatroomAndIsParticipateTrue(chatroom);
+        Long currentMemberCount = chatParticipantRepository.countByChatroomAndIsParticipateTrue(chatroom);
         if (currentMemberCount > maxMemberCount) {
             throw new BadRequestException(ChatResponse.CHATROOM_MAX_MEMBER_COUNT_EXCEED);
         }

--- a/src/test/java/com/poortorich/chat/controller/ChatParticipantControllerTest.java
+++ b/src/test/java/com/poortorich/chat/controller/ChatParticipantControllerTest.java
@@ -1,0 +1,46 @@
+package com.poortorich.chat.controller;
+
+import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chat.response.ChatroomsResponse;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.global.config.BaseSecurityTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatParticipantController.class)
+@ExtendWith(MockitoExtension.class)
+class ChatParticipantControllerTest extends BaseSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ChatFacade chatFacade;
+
+    @Test
+    @WithMockUser(username = "test")
+    @DisplayName("내가 방장인 채팅방 조회 성공")
+    void getHostedChatroomsSuccess() throws Exception {
+        ChatroomsResponse response = ChatroomsResponse.builder().build();
+        when(chatFacade.getHostedChatrooms("test")).thenReturn(response);
+
+        mockMvc.perform(get("/users/hosted-chatrooms")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(("$.message"))
+                        .value(ChatResponse.GET_HOSTED_CHATROOMS_SUCCESS.getMessage()));
+    }
+}

--- a/src/test/java/com/poortorich/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatMessageServiceTest.java
@@ -1,0 +1,55 @@
+package com.poortorich.chat.service;
+
+import com.poortorich.chat.entity.ChatMessage;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.repository.ChatMessageRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @InjectMocks
+    private ChatMessageService chatMessageService;
+
+    @Test
+    @DisplayName("마지막 채팅 시간 조회 성공")
+    void getLastMessageTimeSuccess() {
+        Chatroom chatroom = Chatroom.builder().id(1L).build();
+        ChatMessage lastMessage = ChatMessage.builder()
+                .chatroom(chatroom)
+                .sentAt(LocalDateTime.of(2025, 7, 31, 2, 30))
+                .build();
+
+        when(chatMessageRepository.findTopByChatroomOrderBySentAtDesc(chatroom)).thenReturn(Optional.of(lastMessage));
+
+        String result = chatMessageService.getLastMessageTime(chatroom);
+
+        assertThat(result).isEqualTo(lastMessage.getSentAt().toString());
+    }
+
+    @Test
+    @DisplayName("채팅 정보가 없는 경우 null 반환")
+    void getLastMessageTimeNull() {
+        Chatroom chatroom = Chatroom.builder().id(1L).build();
+
+        when(chatMessageRepository.findTopByChatroomOrderBySentAtDesc(chatroom)).thenReturn(Optional.empty());
+
+        String result = chatMessageService.getLastMessageTime(chatroom);
+
+        assertThat(result).isEqualTo(null);
+    }
+}

--- a/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ChatParticipantServiceTest {
@@ -48,5 +49,18 @@ class ChatParticipantServiceTest {
         assertThat(savedChatParticipant.getRole()).isEqualTo(chatParticipant.getRole());
         assertThat(savedChatParticipant.getUser()).isEqualTo(user);
         assertThat(savedChatParticipant.getChatroom()).isEqualTo(chatroom);
+    }
+
+    @Test
+    @DisplayName("채팅방 참여 인원 조회 성공")
+    void countByChatroomSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        Long currentMemberCount = 5L;
+
+        when(chatParticipantRepository.countByChatroomAndIsParticipateTrue(chatroom)).thenReturn(currentMemberCount);
+
+        Long result = chatParticipantService.countByChatroom(chatroom);
+
+        assertThat(result).isEqualTo(currentMemberCount);
     }
 }

--- a/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
@@ -5,6 +5,7 @@ import com.poortorich.chat.repository.ChatroomRepository;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,5 +81,21 @@ class ChatroomServiceTest {
         assertThatThrownBy(() -> chatroomService.findById(chatroomId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining(ChatResponse.CHATROOM_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("내가 방장인 채팅방 조회 성공")
+    void getHostedChatroomsSuccess() {
+        User user = User.builder().build();
+        Chatroom chatroom1 = Chatroom.builder().build();
+        Chatroom chatroom2 = Chatroom.builder().build();
+
+        when(chatroomRepository.findHostedChatroomByUser(user)).thenReturn(List.of(chatroom1, chatroom2));
+
+        List<Chatroom> result = chatroomService.getHostedChatrooms(user);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isEqualTo(chatroom1);
+        assertThat(result.get(1)).isEqualTo(chatroom2);
     }
 }

--- a/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
@@ -1,6 +1,7 @@
 package com.poortorich.chat.service;
 
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.repository.ChatroomRepository;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.response.enums.ChatResponse;
@@ -90,7 +91,8 @@ class ChatroomServiceTest {
         Chatroom chatroom1 = Chatroom.builder().build();
         Chatroom chatroom2 = Chatroom.builder().build();
 
-        when(chatroomRepository.findHostedChatroomByUser(user)).thenReturn(List.of(chatroom1, chatroom2));
+        when(chatroomRepository.findChatroomByUserAndRole(user, ChatroomRole.HOST))
+                .thenReturn(List.of(chatroom1, chatroom2));
 
         List<Chatroom> result = chatroomService.getHostedChatrooms(user);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#333
 
 ## 📝작업 내용
 
- 내가 방장인 채팅방 목록 조회 API
  - 방장인 채팅방 목록 조회
  - 각 채팅방의 태그, 참여인원수, 마지막 채팅시간 조회
 
 ### 스크린샷

<img width="1115" height="584" alt="image" src="https://github.com/user-attachments/assets/a980857c-81ca-4854-9263-13e3d3e7bb63" />
