### PR TITLE
[#344] 채팅방 검색 목록 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -5,6 +5,7 @@ public class ChatResponseMessage {
     public static final String CREATE_CHATROOM_SUCCESS = "채팅방을 성공적으로 추가했습니다.";
     public static final String GET_CHATROOM_SUCCESS = "채팅방을 성공적으로 조회했습니다.";
     public static final String GET_ALL_CHATROOMS_SUCCESS = "전체 채팅방 목록 조회가 완료되었습니다.";
+    public static final String GET_SEARCH_CHATROOMS_SUCCESS = "채팅방 검색이 완료되었습니다.";
     public static final String GET_HOSTED_CHATROOMS_SUCCESS = "나의 채팅방 목록 조회가 완료되었습니다.";
 
     public static final String CHATROOM_TITLE_REQUIRED = "채팅방 이름은 필수값입니다.";

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -66,6 +66,14 @@ public class ChatController {
         return DataResponse.toResponseEntity(HttpStatus.OK, message, chatFacade.getAllChatrooms(sortBy, cursor));
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<BaseResponse> searchChatrooms(@RequestParam String keyword) {
+        return DataResponse.toResponseEntity(
+                ChatResponse.GET_SEARCH_CHATROOMS_SUCCESS,
+                chatFacade.searchChatrooms(keyword.trim())
+        );
+    }
+
     @GetMapping("/{chatroomId}/edit")
     public ResponseEntity<BaseResponse> getChatroom(@PathVariable Long chatroomId) {
         return DataResponse.toResponseEntity(ChatResponse.GET_CHATROOM_SUCCESS, chatFacade.getChatroom(chatroomId));

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -77,6 +77,14 @@ public class ChatFacade {
                 .build();
     }
 
+    public ChatroomsResponse searchChatrooms(String keyword) {
+        List<Chatroom> chatrooms = chatroomService.searchChatrooms(keyword);
+
+        return ChatroomsResponse.builder()
+                .chatrooms(getChatroomResponses(chatrooms))
+                .build();
+    }
+
     public ChatroomsResponse getHostedChatrooms(String username) {
         User user = userService.findUserByUsername(username);
         List<Chatroom> hostedChatrooms = chatroomService.getHostedChatrooms(user);

--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -57,4 +57,20 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
                  c.id ASC
     """)
     List<Chatroom> findChatroomsSortByLike();
+
+    @Query("""
+        SELECT DISTINCT c
+          FROM Chatroom c
+          INNER JOIN Tag t ON t.chatroom = c
+          INNER JOIN ChatParticipant cp ON cp.chatroom = c AND cp.role = 'HOST'
+        WHERE :keyword <> ''
+          AND (
+                 c.title LIKE CONCAT('%', :keyword, '%')
+              OR c.description LIKE CONCAT('%', :keyword, '%')
+              OR cp.user.nickname LIKE CONCAT('%', :keyword, '%')
+              OR (t.name IS NOT NULL AND t.name LIKE CONCAT('%', :keyword, '%'))
+          )
+        GROUP BY c.id
+    """)
+    List<Chatroom> searchChatrooms(String keyword);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -61,8 +61,8 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
     @Query("""
         SELECT DISTINCT c
           FROM Chatroom c
-          INNER JOIN Tag t ON t.chatroom = c
-          INNER JOIN ChatParticipant cp ON cp.chatroom = c AND cp.role = 'HOST'
+          LEFT JOIN Tag t ON t.chatroom = c
+         INNER JOIN ChatParticipant cp ON cp.chatroom = c AND cp.role = 'HOST'
         WHERE :keyword <> ''
           AND (
                  c.title LIKE CONCAT('%', :keyword, '%')

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -13,6 +13,7 @@ public enum ChatResponse implements Response {
     CREATE_CHATROOM_SUCCESS(HttpStatus.CREATED, ChatResponseMessage.CREATE_CHATROOM_SUCCESS, null),
     GET_CHATROOM_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_SUCCESS, null),
     GET_HOSTED_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_HOSTED_CHATROOMS_SUCCESS, null),
+    GET_SEARCH_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_SEARCH_CHATROOMS_SUCCESS, null),
 
     CHATROOM_ENTER_DENIED(HttpStatus.FORBIDDEN, ChatResponseMessage.CHATROOM_ENTER_DENIED, null),
     CHATROOM_PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_PASSWORD_DO_NOT_MATCH, null),

--- a/src/main/java/com/poortorich/chat/service/ChatroomService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatroomService.java
@@ -71,6 +71,10 @@ public class ChatroomService {
                 .orElseThrow(() -> new NotFoundException(ChatResponse.CHATROOM_NOT_FOUND));
     }
 
+    public List<Chatroom> searchChatrooms(String keyword) {
+        return chatroomRepository.searchChatrooms(keyword);
+    }
+
     public List<Chatroom> getHostedChatrooms(User user) {
         return chatroomRepository.findChatroomByUserAndRole(user, ChatroomRole.HOST);
     }

--- a/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
@@ -8,6 +8,7 @@ import com.poortorich.chat.request.enums.SortBy;
 import com.poortorich.chat.response.AllChatroomsResponse;
 import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
+import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.config.BaseSecurityTest;
 import com.poortorich.s3.util.S3TestFileGenerator;
@@ -143,5 +144,22 @@ public class ChatControllerTest extends BaseSecurityTest {
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value(message));
+    }
+
+    @Test
+    @WithMockUser(username = "test")
+    @DisplayName("채팅방 검색 목록 조회 성공")
+    void searchChatroomsSuccess() throws Exception {
+        String keyword = "부자";
+
+        when(chatFacade.searchChatrooms(eq(keyword))).thenReturn(ChatroomsResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/search")
+                        .param("keyword", keyword)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(ChatResponse.GET_SEARCH_CHATROOMS_SUCCESS.getMessage())
+                );
     }
 }

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -160,4 +160,24 @@ class ChatFacadeTest {
         assertThat(response.getChatrooms().get(0).getChatroomId()).isEqualTo(chatroom1.getId());
         assertThat(response.getChatrooms().get(1).getChatroomId()).isEqualTo(chatroom2.getId());
     }
+
+    @Test
+    @DisplayName("채팅방 검색 목록 조회 성공")
+    void searchChatroomsSuccess() {
+        String keyword = "부자";
+        Chatroom chatroom1 = Chatroom.builder().id(1L).title("부자되자").build();
+        Chatroom chatroom2 = Chatroom.builder().id(2L).title("부자될거야").build();
+        List<Chatroom> chatrooms = List.of(chatroom1, chatroom2);
+
+        when(chatroomService.searchChatrooms(keyword)).thenReturn(chatrooms);
+        when(tagService.getTagNames(any())).thenReturn(hashtags);
+        when(chatParticipantService.countByChatroom(any())).thenReturn(3L);
+        when(chatMessageService.getLastMessageTime(any())).thenReturn("2025-07-31T02:30");
+
+        ChatroomsResponse response = chatFacade.searchChatrooms(keyword);
+
+        assertThat(response.getChatrooms()).hasSize(2);
+        assertThat(response.getChatrooms().get(0).getChatroomTitle()).isEqualTo(chatroom1.getTitle());
+        assertThat(response.getChatrooms().get(1).getChatroomTitle()).isEqualTo(chatroom2.getTitle());
+    }
 }

--- a/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatroomServiceTest.java
@@ -224,4 +224,21 @@ class ChatroomServiceTest {
 
         assertThat(result).isEqualTo(expectedNextCursor);
     }
+
+    @Test
+    @DisplayName("채팅방 검색 목록 조회 성공")
+    void searchChatroomsSuccess() {
+        String keyword = "부자";
+        Chatroom chatroom1 = Chatroom.builder().id(1L).title("부자되자").build();
+        Chatroom chatroom2 = Chatroom.builder().id(2L).title("부자될거야").build();
+        List<Chatroom> expected = List.of(chatroom1, chatroom2);
+
+        when(chatroomRepository.searchChatrooms(keyword)).thenReturn(expected);
+
+        List<Chatroom> result = chatroomService.searchChatrooms(keyword);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isEqualTo(chatroom1);
+        assertThat(result.get(1)).isEqualTo(chatroom2);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#344
 
 ## 📝작업 내용
 
- 채팅방 검색 목록 API
  - 채팅방 이름, 채팅방 소개, 채팅방 해시태그, 채팅방 방장 별명에 keyword가 들어간 결과 목록 조회
 
 ### 스크린샷

<img width="1363" height="936" alt="image" src="https://github.com/user-attachments/assets/8e9aee44-203a-473e-ab05-31f72eb5dcd9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채팅방을 키워드로 검색할 수 있는 기능이 추가되었습니다. 이제 채팅방 제목, 설명, 호스트 닉네임, 태그명으로 채팅방을 검색할 수 있습니다.

* **버그 수정**
  * 해당 기능과 관련된 테스트가 추가되어 검색 결과의 정확성이 보장됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->