### PR TITLE
[#348] 채팅방 커버 페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -7,6 +7,7 @@ public class ChatResponseMessage {
     public static final String GET_ALL_CHATROOMS_SUCCESS = "전체 채팅방 목록 조회가 완료되었습니다.";
     public static final String GET_SEARCH_CHATROOMS_SUCCESS = "채팅방 검색이 완료되었습니다.";
     public static final String GET_HOSTED_CHATROOMS_SUCCESS = "나의 채팅방 목록 조회가 완료되었습니다.";
+    public static final String GET_CHATROOM_COVER_INFO_SUCCESS = "채팅방 커버 정보 조회를 완료했습니다.";
 
     public static final String CHATROOM_TITLE_REQUIRED = "채팅방 이름은 필수값입니다.";
     public static final String CHATROOM_TITLE_TOO_BIG

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -74,6 +74,17 @@ public class ChatController {
         );
     }
 
+    @GetMapping("/{chatroomId}")
+    public ResponseEntity<BaseResponse> getChatroomCoverInfo(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId
+    ) {
+        return DataResponse.toResponseEntity(
+                ChatResponse.GET_CHATROOM_COVER_INFO_SUCCESS,
+                chatFacade.getChatroomCoverInfo(userDetails.getUsername(), chatroomId)
+        );
+    }
+
     @GetMapping("/{chatroomId}/edit")
     public ResponseEntity<BaseResponse> getChatroom(@PathVariable Long chatroomId) {
         return DataResponse.toResponseEntity(ChatResponse.GET_CHATROOM_SUCCESS, chatFacade.getChatroom(chatroomId));

--- a/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
@@ -42,8 +42,8 @@ public class ChatParticipant {
     @Column(name = "role", nullable = false)
     private ChatroomRole role;
 
-    @Column(name = "is_participate", nullable = false)
-    private Boolean isParticipate;
+    @Column(name = "is_participated", nullable = false)
+    private Boolean isParticipated;
 
     @Column(name = "leave_time")
     private LocalDateTime leaveTime;
@@ -73,12 +73,12 @@ public class ChatParticipant {
     private Chatroom chatroom;
 
     public void restoreParticipation() {
-        this.isParticipate = Boolean.TRUE;
+        this.isParticipated = Boolean.TRUE;
         this.leaveTime = null;
     }
 
     public void softDelete() {
-        this.isParticipate = Boolean.FALSE;
+        this.isParticipated = Boolean.FALSE;
         this.leaveTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/poortorich/chat/entity/Chatroom.java
+++ b/src/main/java/com/poortorich/chat/entity/Chatroom.java
@@ -42,7 +42,7 @@ public class Chatroom {
     @Column(name = "max_member_count", nullable = false)
     private Long maxMemberCount;
 
-    @Column(name = "password", nullable = false)
+    @Column(name = "password")
     private String password;
 
     @Column(name = "is_ranking_enabled", nullable = false)

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -8,6 +8,7 @@ import com.poortorich.chat.request.ChatroomLeaveAllRequest;
 import com.poortorich.chat.request.ChatroomUpdateRequest;
 import com.poortorich.chat.request.enums.SortBy;
 import com.poortorich.chat.response.AllChatroomsResponse;
+import com.poortorich.chat.response.ChatroomCoverInfoResponse;
 import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomEnterResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
@@ -104,6 +105,19 @@ public class ChatFacade {
                                 chatMessageService.getLastMessageTime(chatroom)
                         ))
                 .toList();
+    }
+
+    public ChatroomCoverInfoResponse getChatroomCoverInfo(String username, Long chatroomId) {
+        User user = userService.findUserByUsername(username);
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+
+        return ChatBuilder.buildChatroomCoverInfoResponse(
+                chatroom,
+                tagService.getTagNames(chatroom),
+                chatParticipantService.countByChatroom(chatroom),
+                chatParticipantService.isJoined(user, chatroom),
+                chatParticipantService.getChatroomHost(chatroom)
+        );
     }
 
     public ChatroomEnterResponse enterChatroom(

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -5,6 +5,8 @@ import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +15,12 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     Optional<ChatParticipant> findByUserAndChatroom(User user, Chatroom chatroom);
 
     Long countByChatroomAndIsParticipatedTrue(Chatroom chatroom);
+
+    @Query("""
+        SELECT cp
+          FROM ChatParticipant cp
+         WHERE cp.chatroom = :chatroom
+           AND cp.role = 'HOST'
+    """)
+    ChatParticipant getChatroomHost(@Param("chatroom") Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -12,5 +12,5 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
     Optional<ChatParticipant> findByUserAndChatroom(User user, Chatroom chatroom);
 
-    Long countByChatroomAndIsParticipateTrue(Chatroom chatroom);
+    Long countByChatroomAndIsParticipatedTrue(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -28,7 +28,7 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
           FROM Chatroom c
           LEFT JOIN ChatMessage cm ON cm.chatroom = c
           LEFT JOIN Like l ON l.chatroom = c AND l.likeStatus = true
-          LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipate = true
+          LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipated = true
         GROUP BY c.id
         ORDER BY MAX(cm.sentAt) DESC,
                  COUNT(DISTINCT l.id) DESC,
@@ -49,7 +49,7 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
         SELECT c
           FROM Chatroom c
           LEFT JOIN Like l ON l.chatroom = c AND l.likeStatus = true
-          LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipate = true
+          LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipated = true
         GROUP BY c.id
         ORDER BY COUNT(DISTINCT l.id) DESC,
                  COUNT(DISTINCT cp.id) DESC,

--- a/src/main/java/com/poortorich/chat/response/AllChatroomsResponse.java
+++ b/src/main/java/com/poortorich/chat/response/AllChatroomsResponse.java
@@ -3,11 +3,13 @@ package com.poortorich.chat.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class AllChatroomsResponse {
 

--- a/src/main/java/com/poortorich/chat/response/ChatroomCoverInfoResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomCoverInfoResponse.java
@@ -3,11 +3,13 @@ package com.poortorich.chat.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class ChatroomCoverInfoResponse {
 

--- a/src/main/java/com/poortorich/chat/response/ChatroomCoverInfoResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomCoverInfoResponse.java
@@ -1,0 +1,25 @@
+package com.poortorich.chat.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ChatroomCoverInfoResponse {
+
+    private Long chatroomId;
+    private String chatroomTitle;
+    private String chatroomImage;
+    private String description;
+    private List<String> hashtags;
+    private Long currentMemberCount;
+    private Long maxMemberCount;
+    private String createdAt;
+    private Boolean isJoined;
+    private Boolean hasPassword;
+    private ProfileResponse hostProfile;
+}

--- a/src/main/java/com/poortorich/chat/response/ProfileResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ProfileResponse.java
@@ -1,0 +1,17 @@
+package com.poortorich.chat.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProfileResponse {
+
+    private Long userId;
+    private String profileImage;
+    private String nickname;
+    private Boolean isHost;
+    private String rankingType;
+}

--- a/src/main/java/com/poortorich/chat/response/ProfileResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ProfileResponse.java
@@ -3,9 +3,11 @@ package com.poortorich.chat.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class ProfileResponse {
 

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -14,6 +14,7 @@ public enum ChatResponse implements Response {
     GET_CHATROOM_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_SUCCESS, null),
     GET_HOSTED_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_HOSTED_CHATROOMS_SUCCESS, null),
     GET_SEARCH_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_SEARCH_CHATROOMS_SUCCESS, null),
+    GET_CHATROOM_COVER_INFO_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_COVER_INFO_SUCCESS, null),
 
     CHATROOM_ENTER_DENIED(HttpStatus.FORBIDDEN, ChatResponseMessage.CHATROOM_ENTER_DENIED, null),
     CHATROOM_PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_PASSWORD_DO_NOT_MATCH, null),

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -39,4 +39,14 @@ public class ChatParticipantService {
     public Long countByChatroom(Chatroom chatroom) {
         return chatParticipantRepository.countByChatroomAndIsParticipatedTrue(chatroom);
     }
+
+    public Boolean isJoined(User user, Chatroom chatroom) {
+        return chatParticipantRepository.findByUserAndChatroom(user, chatroom)
+                .map(ChatParticipant::getIsParticipated)
+                .orElse(false);
+    }
+
+    public ChatParticipant getChatroomHost(Chatroom chatroom) {
+        return chatParticipantRepository.getChatroomHost(chatroom);
+    }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -37,6 +37,6 @@ public class ChatParticipantService {
     }
 
     public Long countByChatroom(Chatroom chatroom) {
-        return chatParticipantRepository.countByChatroomAndIsParticipateTrue(chatroom);
+        return chatParticipantRepository.countByChatroomAndIsParticipatedTrue(chatroom);
     }
 }

--- a/src/main/java/com/poortorich/chat/util/ChatBuilder.java
+++ b/src/main/java/com/poortorich/chat/util/ChatBuilder.java
@@ -6,8 +6,10 @@ import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.chat.response.ChatroomCoverInfoResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.chat.response.ChatroomResponse;
+import com.poortorich.chat.response.ProfileResponse;
 import com.poortorich.s3.constants.S3Constants;
 import com.poortorich.user.entity.User;
 import java.util.List;
@@ -28,7 +30,7 @@ public class ChatBuilder {
     public static ChatParticipant buildChatParticipant(User user, ChatroomRole role, Chatroom chatroom) {
         return ChatParticipant.builder()
                 .role(role)
-                .isParticipate(true)
+                .isParticipated(true)
                 .rankingStatus(RankingStatus.NONE)
                 .noticeStatus(NoticeStatus.DEFAULT)
                 .user(user)
@@ -71,6 +73,38 @@ public class ChatBuilder {
                 .currentMemberCount(currentMemberCount)
                 .maxMemberCount(chatroom.getMaxMemberCount())
                 .lastMessageTime(lastMessageTime)
+                .build();
+    }
+
+    public static ChatroomCoverInfoResponse buildChatroomCoverInfoResponse(
+            Chatroom chatroom,
+            List<String> hashtags,
+            Long currentMemberCount,
+            Boolean isJoined,
+            ChatParticipant hostInfo
+    ) {
+        return ChatroomCoverInfoResponse.builder()
+                .chatroomId(chatroom.getId())
+                .chatroomTitle(chatroom.getTitle())
+                .chatroomImage(chatroom.getImage())
+                .description(chatroom.getDescription())
+                .hashtags(hashtags)
+                .currentMemberCount(currentMemberCount)
+                .maxMemberCount(chatroom.getMaxMemberCount())
+                .createdAt(chatroom.getCreatedDate().toString())
+                .isJoined(isJoined)
+                .hasPassword(chatroom.getPassword() != null)
+                .hostProfile(buildProfileResponse(hostInfo))
+                .build();
+    }
+
+    private static ProfileResponse buildProfileResponse(ChatParticipant participantInfo) {
+        return ProfileResponse.builder()
+                .userId(participantInfo.getUser().getId())
+                .profileImage(participantInfo.getUser().getProfileImage())
+                .nickname(participantInfo.getUser().getNickname())
+                .isHost(participantInfo.getRole().equals(ChatroomRole.HOST))
+                .rankingType(participantInfo.getRankingStatus().toString())
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
@@ -18,7 +18,7 @@ public class ChatParticipantValidator {
     private final ChatParticipantRepository chatParticipantRepository;
 
     public void validateIsParticipate(User user, Chatroom chatroom) {
-        if (!chatParticipant(user, chatroom).getIsParticipate()) {
+        if (!chatParticipant(user, chatroom).getIsParticipated()) {
             throw new BadRequestException(ChatResponse.CHATROOM_NOT_PARTICIPATE);
         }
     }
@@ -49,7 +49,7 @@ public class ChatParticipantValidator {
     }
 
     private void validateIsParticipate(ChatParticipant chatParticipant) {
-        if (!chatParticipant.getIsParticipate()) {
+        if (!chatParticipant.getIsParticipated()) {
             throw new BadRequestException(ChatResponse.CHATROOM_NOT_PARTICIPATE);
         }
     }

--- a/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
@@ -25,12 +25,12 @@ public class ChatroomValidator {
             if (chatParticipant.get().getRole().equals(ChatroomRole.BANNED)) {
                 throw new ForbiddenException(ChatResponse.CHATROOM_ENTER_DENIED);
             }
-            if (chatParticipant.get().getIsParticipate()) {
+            if (chatParticipant.get().getIsParticipated()) {
                 throw new ConflictException(ChatResponse.CHATROOM_ENTER_DUPLICATED);
             }
         }
 
-        long currentMemberCount = chatParticipantRepository.countByChatroomAndIsParticipateTrue(chatroom);
+        long currentMemberCount = chatParticipantRepository.countByChatroomAndIsParticipatedTrue(chatroom);
         if (currentMemberCount == chatroom.getMaxMemberCount()) {
             throw new ForbiddenException(ChatResponse.CHATROOM_ENTER_DENIED);
         }
@@ -51,7 +51,7 @@ public class ChatroomValidator {
     }
 
     public void validateCanUpdateMaxMemberCount(Chatroom chatroom, Long maxMemberCount) {
-        Long currentMemberCount = chatParticipantRepository.countByChatroomAndIsParticipateTrue(chatroom);
+        Long currentMemberCount = chatParticipantRepository.countByChatroomAndIsParticipatedTrue(chatroom);
         if (currentMemberCount > maxMemberCount) {
             throw new BadRequestException(ChatResponse.CHATROOM_MAX_MEMBER_COUNT_EXCEED);
         }
@@ -60,7 +60,7 @@ public class ChatroomValidator {
     public void validateParticipate(User user, Chatroom chatroom) {
         Optional<ChatParticipant> chatParticipant = chatParticipantRepository.findByUserAndChatroom(user, chatroom);
 
-        if (chatParticipant.isEmpty() || !chatParticipant.get().getIsParticipate()) {
+        if (chatParticipant.isEmpty() || !chatParticipant.get().getIsParticipated()) {
             throw new BadRequestException(ChatResponse.CHATROOM_LEAVE_ALREADY);
         }
     }

--- a/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
@@ -37,7 +37,8 @@ public class ChatroomValidator {
     }
 
     public void validatePassword(Chatroom chatroom, String password) {
-        if (!password.equals(chatroom.getPassword())) {
+        String chatroomPassword = chatroom.getPassword();
+        if (chatroomPassword != null && !password.equals(chatroomPassword)) {
             throw new BadRequestException(ChatResponse.CHATROOM_PASSWORD_DO_NOT_MATCH);
         }
     }

--- a/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
@@ -6,6 +6,7 @@ import com.poortorich.chat.realtime.facade.ChatRealTimeFacade;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.request.enums.SortBy;
 import com.poortorich.chat.response.AllChatroomsResponse;
+import com.poortorich.chat.response.ChatroomCoverInfoResponse;
 import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.chat.response.ChatroomsResponse;
@@ -161,5 +162,21 @@ public class ChatControllerTest extends BaseSecurityTest {
                 .andExpect(jsonPath("$.message")
                         .value(ChatResponse.GET_SEARCH_CHATROOMS_SUCCESS.getMessage())
                 );
+    }
+
+    @Test
+    @WithMockUser(username = "test")
+    @DisplayName("채팅방 커버 정보 조회 성공")
+    void getChatroomCoverInfoSuccess() throws Exception {
+        Long chatroomId = 1L;
+
+        when(chatFacade.getChatroomCoverInfo(eq("test"), eq(chatroomId)))
+                .thenReturn(ChatroomCoverInfoResponse.builder().chatroomId(chatroomId).build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(ChatResponse.GET_CHATROOM_COVER_INFO_SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -1,9 +1,13 @@
 package com.poortorich.chat.facade;
 
+import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.request.enums.SortBy;
 import com.poortorich.chat.response.AllChatroomsResponse;
+import com.poortorich.chat.response.ChatroomCoverInfoResponse;
 import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.chat.response.ChatroomResponse;
@@ -25,6 +29,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,6 +76,7 @@ class ChatFacadeTest {
                 .maxMemberCount(maxMemberCount)
                 .isRankingEnabled(isRankingEnabled)
                 .password(chatroomPassword)
+                .createdDate(LocalDateTime.of(2025, 8, 3, 15, 24, 51))
                 .build();
     }
 
@@ -179,5 +185,43 @@ class ChatFacadeTest {
         assertThat(response.getChatrooms()).hasSize(2);
         assertThat(response.getChatrooms().get(0).getChatroomTitle()).isEqualTo(chatroom1.getTitle());
         assertThat(response.getChatrooms().get(1).getChatroomTitle()).isEqualTo(chatroom2.getTitle());
+    }
+
+
+    @Test
+    @DisplayName("채팅방 커버 정보 조회 성공")
+    void getChatroomCoverInfoSuccess() {
+        String username = "testUser";
+        User user = User.builder()
+                .id(1L)
+                .username(username)
+                .nickname(username)
+                .build();
+        ChatParticipant hostParticipant = ChatParticipant.builder()
+                .user(user)
+                .role(ChatroomRole.HOST)
+                .rankingStatus(RankingStatus.NONE)
+                .build();
+
+        when(userService.findUserByUsername(username)).thenReturn(user);
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(tagService.getTagNames(chatroom)).thenReturn(hashtags);
+        when(chatParticipantService.countByChatroom(chatroom)).thenReturn(3L);
+        when(chatParticipantService.isJoined(user, chatroom)).thenReturn(true);
+        when(chatParticipantService.getChatroomHost(chatroom)).thenReturn(hostParticipant);
+
+        ChatroomCoverInfoResponse response = chatFacade.getChatroomCoverInfo(username, chatroomId);
+
+        assertThat(response.getChatroomId()).isEqualTo(chatroomId);
+        assertThat(response.getChatroomTitle()).isEqualTo(chatroomTitle);
+        assertThat(response.getChatroomImage()).isEqualTo(imageUrl);
+        assertThat(response.getDescription()).isEqualTo(chatroom.getDescription());
+        assertThat(response.getHashtags()).isEqualTo(hashtags);
+        assertThat(response.getCurrentMemberCount()).isEqualTo(3L);
+        assertThat(response.getMaxMemberCount()).isEqualTo(maxMemberCount);
+        assertThat(response.getIsJoined()).isTrue();
+        assertThat(response.getHasPassword()).isTrue();
+        assertThat(response.getHostProfile().getUserId()).isEqualTo(user.getId());
+        assertThat(response.getHostProfile().getIsHost()).isTrue();
     }
 }

--- a/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
@@ -14,6 +14,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,5 +64,74 @@ class ChatParticipantServiceTest {
         Long result = chatParticipantService.countByChatroom(chatroom);
 
         assertThat(result).isEqualTo(currentMemberCount);
+    }
+
+    @Test
+    @DisplayName("유저가 채팅방에 참여중인 경우 true 반환")
+    void isJoinedIsParticipatedTrue() {
+        User user = User.builder().build();
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatParticipant participant = ChatParticipant.builder()
+                .user(user)
+                .chatroom(chatroom)
+                .isParticipated(true)
+                .build();
+
+        when(chatParticipantRepository.findByUserAndChatroom(user, chatroom)).thenReturn(Optional.of(participant));
+
+        Boolean result = chatParticipantService.isJoined(user, chatroom);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("유저가 채팅방에 참여한 이력은 있지만 현재 참여 중이지 않은 경우 false 반환")
+    void isJoinedIsNotParticipatedFalse() {
+        User user = User.builder().build();
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatParticipant participant = ChatParticipant.builder()
+                .user(user)
+                .chatroom(chatroom)
+                .isParticipated(false)
+                .build();
+
+        when(chatParticipantRepository.findByUserAndChatroom(user, chatroom)).thenReturn(Optional.of(participant));
+
+        Boolean result = chatParticipantService.isJoined(user, chatroom);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("유저가 채팅방에 참여한 이력이 없는 경우 false 반환")
+    void isJoinedNoParticipationHistoryFalse() {
+        User user = User.builder().build();
+        Chatroom chatroom = Chatroom.builder().build();
+
+        when(chatParticipantRepository.findByUserAndChatroom(user, chatroom)).thenReturn(Optional.empty());
+
+        Boolean result = chatParticipantService.isJoined(user, chatroom);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("채팅방 방장 조회 성공")
+    void getChatroomHostSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        User user = User.builder().build();
+        ChatParticipant hostParticipant = ChatParticipant.builder()
+                .user(user)
+                .chatroom(chatroom)
+                .role(ChatroomRole.HOST)
+                .build();
+
+        when(chatParticipantRepository.getChatroomHost(chatroom)).thenReturn(hostParticipant);
+
+        ChatParticipant result = chatParticipantService.getChatroomHost(chatroom);
+
+        assertThat(result).isEqualTo(hostParticipant);
+        assertThat(result.getRole()).isEqualTo(ChatroomRole.HOST);
+        assertThat(result.getChatroom()).isEqualTo(chatroom);
     }
 }

--- a/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
@@ -57,7 +57,7 @@ class ChatParticipantServiceTest {
         Chatroom chatroom = Chatroom.builder().build();
         Long currentMemberCount = 5L;
 
-        when(chatParticipantRepository.countByChatroomAndIsParticipateTrue(chatroom)).thenReturn(currentMemberCount);
+        when(chatParticipantRepository.countByChatroomAndIsParticipatedTrue(chatroom)).thenReturn(currentMemberCount);
 
         Long result = chatParticipantService.countByChatroom(chatroom);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#348
 
 ## 📝작업 내용
 
- 채팅방 커버 페이지 조회
  - 유저 정보와 채팅방 아이디로 채팅방 커버 정보 조회
  - 태그 정보 조회
  - 현재 인원 조회
  - 현재 채팅방에 참여중인지 조회
  - 채팅방 방장 정보 조회

### 데이터베이스 수정사항

- chatParticipant 테이블 `is_participate` 필드 이름 변경
  - 과거분사를 사용한 `is_participated`로 수정
  > 아래 명령어로 이전 필드 이름인 `is_participate` 필드 삭제
```sql
ALTER TABLE chat_participant DROP COLUMN is_participate;
```

- chatroom 테이블 `password` 필드 nullable 수정
  - nullable을 false에서 true로 변경
  > 아래 명령어로 `password` nullable 수정
```sql
ALTER TABLE chatroom MODIFY COLUMN password VARCHAR(255) NULL;
```
 
 ### 스크린샷

> 채팅방에 참여중인 경우
<img width="785" height="608" alt="스크린샷 2025-08-04 오후 9 09 22" src="https://github.com/user-attachments/assets/390dfb5b-a53a-49b7-aba4-fc1ed904e72b" />

> 채팅방에 참여중이지 않은 경우
<img width="971" height="602" alt="스크린샷 2025-08-04 오후 9 09 49" src="https://github.com/user-attachments/assets/d3ca645c-6154-4dfc-ab18-4d7cfa01ef23" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채팅방 커버 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 채팅방 커버 정보 및 호스트 프로필을 포함한 응답 구조가 도입되었습니다.

* **버그 수정**
  * 채팅 참여자 상태 필드명 및 관련 쿼리가 일관성 있게 수정되었습니다.
  * 채팅방 비밀번호가 필수 입력이 아니도록 변경되었습니다.

* **테스트**
  * 채팅방 커버 정보 조회 및 참여자 관련 신규 기능에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->