### PR TITLE
[#357] 채팅방 좋아요 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -10,6 +10,8 @@ public class ChatResponseMessage {
     public static final String GET_CHATROOM_DETAILS_SUCCESS = "채팅방 상세정보 조회를 완료했습니다.";
     public static final String GET_CHATROOM_COVER_INFO_SUCCESS = "채팅방 커버 정보 조회를 완료했습니다.";
 
+    public static final String GET_CHATROOM_LIKE_STATUS_SUCCESS = "채팅방 좋아요 상태 조회를 완료했습니다.";
+
     public static final String CHATROOM_TITLE_REQUIRED = "채팅방 이름은 필수값입니다.";
     public static final String CHATROOM_TITLE_TOO_BIG
             = "채팅방 이름은 " + ChatValidationConstraints.CHATROOM_TITLE_MAX + "자 이하여야 합니다.";

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -98,6 +98,17 @@ public class ChatController {
         );
     }
 
+    @GetMapping("/{chatroomId}/like")
+    public ResponseEntity<BaseResponse> getChatroomLike(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId
+    ) {
+        return DataResponse.toResponseEntity(
+                ChatResponse.GET_CHATROOM_LIKE_STATUS_SUCCESS,
+                chatFacade.getChatroomLike(userDetails.getUsername(), chatroomId)
+        );
+    }
+
     @PostMapping("/{chatroomId}/enter")
     public ResponseEntity<BaseResponse> enterChatroom(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -16,6 +16,7 @@ import com.poortorich.chat.response.ChatroomEnterResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.chat.response.ChatroomLeaveAllResponse;
 import com.poortorich.chat.response.ChatroomLeaveResponse;
+import com.poortorich.chat.response.ChatroomLikeStatusResponse;
 import com.poortorich.chat.response.ChatroomResponse;
 import com.poortorich.chat.response.ChatroomUpdateResponse;
 import com.poortorich.chat.response.ChatroomsResponse;
@@ -25,6 +26,7 @@ import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.util.ChatBuilder;
 import com.poortorich.chat.validator.ChatParticipantValidator;
 import com.poortorich.chat.validator.ChatroomValidator;
+import com.poortorich.like.service.LikeService;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
 import com.poortorich.user.entity.User;
@@ -44,6 +46,7 @@ public class ChatFacade {
     private final ChatMessageService chatMessageService;
     private final FileUploadService fileUploadService;
     private final TagService tagService;
+    private final LikeService likeService;
 
     private final ChatroomValidator chatroomValidator;
     private final ChatParticipantValidator chatParticipantValidator;
@@ -125,6 +128,20 @@ public class ChatFacade {
                 chatParticipantService.isJoined(user, chatroom),
                 chatParticipantService.getChatroomHost(chatroom)
         );
+    }
+
+    public ChatroomLikeStatusResponse getChatroomLike(String username, Long chatroomId) {
+        User user = userService.findUserByUsername(username);
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+
+        return buildChatroomLikeStatusResponse(user, chatroom);
+    }
+
+    private ChatroomLikeStatusResponse buildChatroomLikeStatusResponse(User user, Chatroom chatroom) {
+        return ChatroomLikeStatusResponse.builder()
+                .isLiked(likeService.getLikeStatus(user, chatroom))
+                .likeCount(likeService.getLikeCount(chatroom))
+                .build();
     }
 
     public ChatroomEnterResponse enterChatroom(

--- a/src/main/java/com/poortorich/chat/response/ChatroomLikeStatusResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomLikeStatusResponse.java
@@ -1,0 +1,16 @@
+package com.poortorich.chat.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatroomLikeStatusResponse {
+
+    private Boolean isLiked;
+    private Long likeCount;
+}

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -17,6 +17,8 @@ public enum ChatResponse implements Response {
     GET_CHATROOM_DETAILS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_DETAILS_SUCCESS, null),
     GET_CHATROOM_COVER_INFO_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_COVER_INFO_SUCCESS, null),
 
+    GET_CHATROOM_LIKE_STATUS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_LIKE_STATUS_SUCCESS, null),
+
     CHATROOM_ENTER_DENIED(HttpStatus.FORBIDDEN, ChatResponseMessage.CHATROOM_ENTER_DENIED, null),
     CHATROOM_PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_PASSWORD_DO_NOT_MATCH, null),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, ChatResponseMessage.CHATROOM_NOT_FOUND, "chatroomId"),

--- a/src/main/java/com/poortorich/like/repository/LikeRepository.java
+++ b/src/main/java/com/poortorich/like/repository/LikeRepository.java
@@ -1,0 +1,17 @@
+package com.poortorich.like.repository;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.like.entity.Like;
+import com.poortorich.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    Optional<Like> findByUserAndChatroom(User user, Chatroom chatroom);
+
+    Long countByChatroom(Chatroom chatroom);
+}

--- a/src/main/java/com/poortorich/like/service/LikeService.java
+++ b/src/main/java/com/poortorich/like/service/LikeService.java
@@ -1,0 +1,25 @@
+package com.poortorich.like.service;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.like.entity.Like;
+import com.poortorich.like.repository.LikeRepository;
+import com.poortorich.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    public Boolean getLikeStatus(User user, Chatroom chatroom) {
+        return likeRepository.findByUserAndChatroom(user, chatroom)
+                .map(Like::getLikeStatus)
+                .orElse(false);
+    }
+
+    public Long getLikeCount(Chatroom chatroom) {
+        return likeRepository.countByChatroom(chatroom);
+    }
+}

--- a/src/main/java/com/poortorich/tag/service/TagService.java
+++ b/src/main/java/com/poortorich/tag/service/TagService.java
@@ -1,11 +1,8 @@
 package com.poortorich.tag.service;
 
 import com.poortorich.chat.entity.Chatroom;
-import com.poortorich.global.exceptions.BadRequestException;
-import com.poortorich.tag.constants.TagValidationConstraints;
 import com.poortorich.tag.entity.Tag;
 import com.poortorich.tag.repository.TagRepository;
-import com.poortorich.tag.response.enums.TagResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
@@ -10,6 +10,7 @@ import com.poortorich.chat.response.ChatroomCoverInfoResponse;
 import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomDetailsResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
+import com.poortorich.chat.response.ChatroomLikeStatusResponse;
 import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.config.BaseSecurityTest;
@@ -193,6 +194,23 @@ public class ChatControllerTest extends BaseSecurityTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
                         .value(ChatResponse.GET_CHATROOM_COVER_INFO_SUCCESS.getMessage())
+                );
+    }
+
+    @Test
+    @WithMockUser(username = "test")
+    @DisplayName("채팅방 좋아요 상태 조회 성공")
+    void getChatroomLikeSuccess() throws Exception {
+        Long chatroomId = 1L;
+
+        when(chatFacade.getChatroomLike(eq("test"), eq(chatroomId)))
+                .thenReturn(ChatroomLikeStatusResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/like")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(ChatResponse.GET_CHATROOM_LIKE_STATUS_SUCCESS.getMessage())
                 );
     }
 }

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -11,10 +11,12 @@ import com.poortorich.chat.response.ChatroomCoverInfoResponse;
 import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomDetailsResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
+import com.poortorich.chat.response.ChatroomLikeStatusResponse;
 import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.like.service.LikeService;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
 import com.poortorich.user.entity.User;
@@ -52,6 +54,8 @@ class ChatFacadeTest {
     private TagService tagService;
     @Mock
     private ChatMessageService chatMessageService;
+    @Mock
+    private LikeService likeService;
 
     @InjectMocks
     private ChatFacade chatFacade;
@@ -238,5 +242,23 @@ class ChatFacadeTest {
         assertThat(response.getHasPassword()).isTrue();
         assertThat(response.getHostProfile().getUserId()).isEqualTo(user.getId());
         assertThat(response.getHostProfile().getIsHost()).isTrue();
+    }
+
+    @Test
+    @DisplayName("채팅방 좋아요 상태 조회 성공")
+    void getChatroomLikeSuccess() {
+        String username = "testUser";
+        User user = User.builder().username(username).build();
+
+        when(userService.findUserByUsername(username)).thenReturn(user);
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(likeService.getLikeStatus(user, chatroom)).thenReturn(true);
+        when(likeService.getLikeCount(chatroom)).thenReturn(3L);
+
+        ChatroomLikeStatusResponse result = chatFacade.getChatroomLike(username, chatroomId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getIsLiked()).isTrue();
+        assertThat(result.getLikeCount()).isEqualTo(3L);
     }
 }

--- a/src/test/java/com/poortorich/like/service/LikeServiceTest.java
+++ b/src/test/java/com/poortorich/like/service/LikeServiceTest.java
@@ -1,0 +1,71 @@
+package com.poortorich.like.service;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.like.entity.Like;
+import com.poortorich.like.repository.LikeRepository;
+import com.poortorich.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @Test
+    @DisplayName("좋아요 상태 조회 성공 - 좋아요 이력이 존재하는 경우")
+    void getLikeStatusSuccess() {
+        User user = User.builder().build();
+        Chatroom chatroom = Chatroom.builder().build();
+        Like like = Like.builder()
+                .user(user)
+                .chatroom(chatroom)
+                .likeStatus(true)
+                .build();
+
+        when(likeRepository.findByUserAndChatroom(user, chatroom)).thenReturn(Optional.of(like));
+
+        Boolean result = likeService.getLikeStatus(user, chatroom);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("좋아요 상태 조회 성공 - 좋아요 이력이 존재하지 않는 경우")
+    void getLikeStatusNoHistorySuccess() {
+        User user = User.builder().build();
+        Chatroom chatroom = Chatroom.builder().build();
+
+        when(likeRepository.findByUserAndChatroom(user, chatroom)).thenReturn(Optional.empty());
+
+        Boolean result = likeService.getLikeStatus(user, chatroom);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("좋아요 개수 조회 성공")
+    void getLikeCountSuccess() {
+        Long likeCount = 10L;
+        Chatroom chatroom = Chatroom.builder().build();
+
+        when(likeRepository.countByChatroom(chatroom)).thenReturn(likeCount);
+
+        Long result = likeService.getLikeCount(chatroom);
+
+        assertThat(result).isEqualTo(likeCount);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#357 
 
 ## 📝작업 내용
 
- 채팅방 좋아요 조회
  - 유저 정보와 채팅방 정보를 이용
  - 유저의 현재 채팅방 좋아요 상태 조회
  - 현재 채팅방의 총 좋아요 개수 조회
 
 ### 스크린샷

<img width="966" height="308" alt="image" src="https://github.com/user-attachments/assets/abf5b640-82b8-4118-ac7f-f0af4d2a3f3f" />
