### PR TITLE
[#362] 채팅방 편집 DTO 검증 로직 추가

### DIFF
--- a/src/main/java/com/poortorich/chat/request/ChatroomUpdateRequest.java
+++ b/src/main/java/com/poortorich/chat/request/ChatroomUpdateRequest.java
@@ -18,7 +18,7 @@ public class ChatroomUpdateRequest {
     private final MultipartFile chatroomImage;
 
     private final Boolean isDefaultImage;
-    
+
     @NotNull(message = ChatResponseMessage.CHATROOM_TITLE_REQUIRED)
     @Size(max = ChatValidationConstraints.CHATROOM_TITLE_MAX,
             message = ChatResponseMessage.CHATROOM_TITLE_TOO_BIG)
@@ -36,7 +36,10 @@ public class ChatroomUpdateRequest {
             message = ChatResponseMessage.CHATROOM_DESCRIPTION_TOO_BIG)
     private final String description;
 
+    @Size(max = ChatValidationConstraints.TAG_COUNT_MAX,
+            message = ChatResponseMessage.TAG_TOO_MANY)
     private final List<String> hashtags;
+
     private final Boolean isRankingEnabled;
     private final String chatroomPassword;
 }


### PR DESCRIPTION
## #️⃣362
 
 ## 📝작업 내용
 
채팅방 편집 DTO에 새로 추가된 해시태그 검증 로직을 추가했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 채팅방 해시태그 개수에 최대 제한이 적용되어, 너무 많은 해시태그 입력 시 안내 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->