### PR TITLE
[#361] 채팅방 내 사용자 역할 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -9,6 +9,7 @@ public class ChatResponseMessage {
     public static final String GET_HOSTED_CHATROOMS_SUCCESS = "나의 채팅방 목록 조회가 완료되었습니다.";
     public static final String GET_CHATROOM_DETAILS_SUCCESS = "채팅방 상세정보 조회를 완료했습니다.";
     public static final String GET_CHATROOM_COVER_INFO_SUCCESS = "채팅방 커버 정보 조회를 완료했습니다.";
+    public static final String GET_CHATROOM_ROLE_SUCCESS = "현재 채팅방의 유저 역할 조회를 완료했습니다.";
 
     public static final String GET_CHATROOM_LIKE_STATUS_SUCCESS = "채팅방 좋아요 상태 조회를 완료했습니다.";
 

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -109,6 +109,17 @@ public class ChatController {
         );
     }
 
+    @GetMapping("/{chatroomId}/role")
+    public ResponseEntity<BaseResponse> getChatroomRole(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId
+    ) {
+        return DataResponse.toResponseEntity(
+                ChatResponse.GET_CHATROOM_ROLE_SUCCESS,
+                chatFacade.getChatroomRole(userDetails.getUsername(), chatroomId)
+        );
+    }
+
     @PostMapping("/{chatroomId}/enter")
     public ResponseEntity<BaseResponse> enterChatroom(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -18,6 +18,7 @@ import com.poortorich.chat.response.ChatroomLeaveAllResponse;
 import com.poortorich.chat.response.ChatroomLeaveResponse;
 import com.poortorich.chat.response.ChatroomLikeStatusResponse;
 import com.poortorich.chat.response.ChatroomResponse;
+import com.poortorich.chat.response.ChatroomRoleResponse;
 import com.poortorich.chat.response.ChatroomUpdateResponse;
 import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.service.ChatMessageService;
@@ -141,6 +142,16 @@ public class ChatFacade {
         return ChatroomLikeStatusResponse.builder()
                 .isLiked(likeService.getLikeStatus(user, chatroom))
                 .likeCount(likeService.getLikeCount(chatroom))
+                .build();
+    }
+
+    public ChatroomRoleResponse getChatroomRole(String username, Long chatroomId) {
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+        ChatParticipant chatParticipant = chatParticipantService.findByUsernameAndChatroom(username, chatroom);
+
+        return ChatroomRoleResponse.builder()
+                .userId(chatParticipant.getUser().getId())
+                .chatroomRole(chatParticipant.getRole().toString())
                 .build();
     }
 

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -15,6 +15,17 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
     Optional<ChatParticipant> findByUserAndChatroom(User user, Chatroom chatroom);
 
+    @Query("""
+        SELECT cp
+          FROM ChatParticipant cp
+         WHERE cp.user.username = :username
+           AND cp.chatroom = :chatroom
+    """)
+    Optional<ChatParticipant> findByUsernameAndChatroom(
+            @Param("username") String username,
+            @Param("chatroom") Chatroom chatroom
+    );
+
     Long countByChatroomAndIsParticipatedTrue(Chatroom chatroom);
 
     @Query("""

--- a/src/main/java/com/poortorich/chat/response/ChatroomRoleResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomRoleResponse.java
@@ -1,0 +1,16 @@
+package com.poortorich.chat.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatroomRoleResponse {
+
+    private Long userId;
+    private String chatroomRole;
+}

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -16,6 +16,7 @@ public enum ChatResponse implements Response {
     GET_SEARCH_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_SEARCH_CHATROOMS_SUCCESS, null),
     GET_CHATROOM_DETAILS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_DETAILS_SUCCESS, null),
     GET_CHATROOM_COVER_INFO_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_COVER_INFO_SUCCESS, null),
+    GET_CHATROOM_ROLE_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_ROLE_SUCCESS, null),
 
     GET_CHATROOM_LIKE_STATUS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_LIKE_STATUS_SUCCESS, null),
 

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -33,6 +33,11 @@ public class ChatParticipantService {
         chatParticipantRepository.save(chatParticipant);
     }
 
+    public ChatParticipant findByUsernameAndChatroom(String username, Chatroom chatroom) {
+        return chatParticipantRepository.findByUsernameAndChatroom(username, chatroom)
+                .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND));
+    }
+
     public ChatParticipant findByUserAndChatroom(User user, Chatroom chatroom) {
         return chatParticipantRepository.findByUserAndChatroom(user, chatroom)
                 .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND));

--- a/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/poortorich/chat/controller/ChatControllerTest.java
@@ -11,6 +11,7 @@ import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomDetailsResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.chat.response.ChatroomLikeStatusResponse;
+import com.poortorich.chat.response.ChatroomRoleResponse;
 import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.config.BaseSecurityTest;
@@ -211,6 +212,23 @@ public class ChatControllerTest extends BaseSecurityTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
                         .value(ChatResponse.GET_CHATROOM_LIKE_STATUS_SUCCESS.getMessage())
+                );
+    }
+
+    @Test
+    @WithMockUser(username = "test")
+    @DisplayName("채팅방 내 사용자 역할 조회 성공")
+    void getChatroomRoleSuccess() throws Exception {
+        Long chatroomId = 1L;
+
+        when(chatFacade.getChatroomRole(eq("test"), eq(chatroomId)))
+                .thenReturn(ChatroomRoleResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/role")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(ChatResponse.GET_CHATROOM_ROLE_SUCCESS.getMessage())
                 );
     }
 }

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -12,6 +12,7 @@ import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomDetailsResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
 import com.poortorich.chat.response.ChatroomLikeStatusResponse;
+import com.poortorich.chat.response.ChatroomRoleResponse;
 import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
@@ -260,5 +261,29 @@ class ChatFacadeTest {
         assertThat(result).isNotNull();
         assertThat(result.getIsLiked()).isTrue();
         assertThat(result.getLikeCount()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("채팅방 내 사용자 역할 조회 성공")
+    void getChatroomRoleSuccess() {
+        String username = "testUser";
+        Long chatroomId = 1L;
+        User user = User.builder()
+                .id(1L)
+                .username(username)
+                .build();
+        ChatParticipant chatParticipant = ChatParticipant.builder()
+                .user(user)
+                .role(ChatroomRole.HOST)
+                .build();
+
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(chatParticipantService.findByUsernameAndChatroom(username, chatroom)).thenReturn(chatParticipant);
+
+        ChatroomRoleResponse result = chatFacade.getChatroomRole(username, chatroomId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getChatroomRole()).isEqualTo(ChatroomRole.HOST.toString());
+        assertThat(result.getUserId()).isEqualTo(user.getId());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#361
 
 ## 📝작업 내용
 
- 채팅방 내 사용자 역할 조회
  - 채팅방 아이디로 채팅방 조회
  - username과 채팅방으로 채팅방 참여자인지 조회
 
 ### 스크린샷

<img width="964" height="316" alt="스크린샷 2025-08-06 오후 2 45 36" src="https://github.com/user-attachments/assets/5edb3f3e-e99c-4758-9fbf-af0dfe067196" />

<img width="974" height="256" alt="스크린샷 2025-08-06 오후 2 45 59" src="https://github.com/user-attachments/assets/39ad6ee8-f44b-4f61-8b14-b70df93b7cea" />