### PR TITLE
[#365] 랭킹 기능 활성화 메시지 생성 로직

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -45,7 +45,7 @@ public class ChatResponseMessage {
     public static final String GET_CHAT_MESSAGE_SUCCESS = "이전 채팅 조회가 완료됐습니다.";
 
     public static final String CHATROOM_ID_REQUIRED = "채팅방 아이디는 필수값입니다.";
-    public static final String MESSAGE_TPYE_REQUIRED = "메시지 타입은 필수값입니다.";
+    public static final String MESSAGE_TYPE_REQUIRED = "메시지 타입은 필수값입니다.";
 
     private ChatResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -14,6 +14,7 @@ import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomEnterResponse;
 import com.poortorich.chat.response.ChatroomLeaveAllResponse;
 import com.poortorich.chat.response.ChatroomLeaveResponse;
+import com.poortorich.chat.response.ChatroomUpdateResponse;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.response.BaseResponse;
 import com.poortorich.global.response.DataResponse;
@@ -55,6 +56,7 @@ public class ChatController {
     ) {
         ChatroomCreateResponse response = chatFacade.createChatroom(userDetails.getUsername(), request);
         realTimeFacade.createUserEnterSystemMessage(userDetails.getUsername(), response.getNewChatroomId());
+        realTimeFacade.createRankingStatusMessage(response.getNewChatroomId(), response.getSavedRankingStatus());
         return DataResponse.toResponseEntity(ChatResponse.CREATE_CHATROOM_SUCCESS, response);
     }
 
@@ -135,6 +137,19 @@ public class ChatController {
             @PathVariable("chatroomId") Long chatroomId,
             @Valid ChatroomUpdateRequest chatroomUpdateRequest
     ) {
+        ChatroomUpdateResponse response = chatFacade.updateChatroom(
+                userDetails.getUsername(),
+                chatroomId,
+                chatroomUpdateRequest);
+
+        BasePayload payload = realTimeFacade.createRankingStatusMessage(
+                chatroomId,
+                response.getIsChangedRankingStatus());
+
+        if (!Objects.isNull(payload)) {
+            messagingTemplate.convertAndSend(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId, payload);
+        }
+
         return DataResponse.toResponseEntity(
                 ChatResponse.CHATROOM_UPDATE_SUCCESS,
                 chatFacade.updateChatroom(userDetails.getUsername(), chatroomId, chatroomUpdateRequest));

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -56,7 +56,7 @@ public class ChatController {
     ) {
         ChatroomCreateResponse response = chatFacade.createChatroom(userDetails.getUsername(), request);
         realTimeFacade.createUserEnterSystemMessage(userDetails.getUsername(), response.getNewChatroomId());
-        realTimeFacade.createRankingStatusMessage(response.getNewChatroomId(), response.getSavedRankingStatus());
+        realTimeFacade.createRankingStatusMessage(response.getNewChatroomId(), request.getIsRankingEnabled());
         return DataResponse.toResponseEntity(ChatResponse.CREATE_CHATROOM_SUCCESS, response);
     }
 

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -150,9 +150,7 @@ public class ChatController {
             messagingTemplate.convertAndSend(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId, payload);
         }
 
-        return DataResponse.toResponseEntity(
-                ChatResponse.CHATROOM_UPDATE_SUCCESS,
-                chatFacade.updateChatroom(userDetails.getUsername(), chatroomId, chatroomUpdateRequest));
+        return DataResponse.toResponseEntity(ChatResponse.CHATROOM_UPDATE_SUCCESS, response);
     }
 
     @DeleteMapping("/{chatroomId}")

--- a/src/main/java/com/poortorich/chat/realtime/builder/RankingStatusChatMessageBuilder.java
+++ b/src/main/java/com/poortorich/chat/realtime/builder/RankingStatusChatMessageBuilder.java
@@ -1,4 +1,16 @@
 package com.poortorich.chat.realtime.builder;
 
+import com.poortorich.chat.entity.ChatMessage;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatMessageType;
+
 public class RankingStatusChatMessageBuilder {
+
+    public static ChatMessage buildRankingStatusMessage(Chatroom chatroom) {
+        return ChatMessage.builder()
+                .chatroom(chatroom)
+                .isRankingEnabled(chatroom.getIsRankingEnabled())
+                .type(ChatMessageType.RANKING_STATUS)
+                .build();
+    }
 }

--- a/src/main/java/com/poortorich/chat/realtime/builder/RankingStatusChatMessageBuilder.java
+++ b/src/main/java/com/poortorich/chat/realtime/builder/RankingStatusChatMessageBuilder.java
@@ -1,0 +1,4 @@
+package com.poortorich.chat.realtime.builder;
+
+public class RankingStatusChatMessageBuilder {
+}

--- a/src/main/java/com/poortorich/chat/realtime/collect/ChatPayloadCollector.java
+++ b/src/main/java/com/poortorich/chat/realtime/collect/ChatPayloadCollector.java
@@ -29,4 +29,9 @@ public class ChatPayloadCollector {
                 .chatParticipant(chatParticipant)
                 .build();
     }
+
+    public PayloadContext getPayloadContext(Long chatroomId) {
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+        return PayloadContext.builder().chatroom(chatroom).build();
+    }
 }

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -7,12 +7,14 @@ import com.poortorich.chat.realtime.collect.ChatPayloadCollector;
 import com.poortorich.chat.realtime.model.PayloadContext;
 import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
 import com.poortorich.chat.realtime.payload.response.BasePayload;
+import com.poortorich.chat.realtime.payload.response.RankingStatusMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserChatMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserEnterResponsePayload;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.service.UnreadChatMessageService;
+import com.poortorich.chat.util.detector.RankingStatusChangeDetector;
 import com.poortorich.chat.util.manager.ChatroomLeaveManager;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
@@ -32,6 +34,7 @@ public class ChatRealTimeFacade {
 
     private final ChatPayloadCollector payloadCollector;
     private final ChatroomLeaveManager chatroomLeaveManager;
+    private final RankingStatusChangeDetector rankingStatusChangeDetector;
 
     public BasePayload createUserEnterSystemMessage(String username, Long chatroomId) {
         User user = userService.findUserByUsername(username);
@@ -71,5 +74,14 @@ public class ChatRealTimeFacade {
                 .saveUserChatMessage(chatParticipant, chatMembers, chatMessagePayload);
 
         return chatMessage.mapToBasePayload();
+    }
+
+    public BasePayload createRankingStatusMessage(Long chatroomId, Boolean isChangedRankingStatus) {
+        if (isChangedRankingStatus) {
+            PayloadContext context = payloadCollector.getPayloadContext(chatroomId);
+            RankingStatusMessagePayload payload = chatMessageService.saveRankingStatusMessage(context);
+            return payload.mapToBasePayload();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/poortorich/chat/realtime/payload/request/ChatMessageRequestPayload.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/request/ChatMessageRequestPayload.java
@@ -13,7 +13,7 @@ public class ChatMessageRequestPayload {
     @NotNull(message = ChatResponseMessage.CHATROOM_ID_REQUIRED)
     private Long chatroomId;
 
-    @NotNull(message = ChatResponseMessage.MESSAGE_TPYE_REQUIRED)
+    @NotNull(message = ChatResponseMessage.MESSAGE_TYPE_REQUIRED)
     private MessageType messageType;
 
     private String content;

--- a/src/main/java/com/poortorich/chat/realtime/payload/response/RankingStatusMessagePayload.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/response/RankingStatusMessagePayload.java
@@ -8,11 +8,11 @@ import lombok.Data;
 
 @Data
 @Builder
-public class RankingStatusMessage implements ResponsePayload {
+public class RankingStatusMessagePayload implements ResponsePayload {
 
     private Long messageId;
     private Long chatroomId;
-    private Boolean isChatEnabled;
+    private Boolean isRankingEnabled;
     private LocalDateTime sendAt;
 
     @Override

--- a/src/main/java/com/poortorich/chat/realtime/payload/response/RankingStatusMessagePayload.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/response/RankingStatusMessagePayload.java
@@ -1,0 +1,25 @@
+package com.poortorich.chat.realtime.payload.response;
+
+import com.poortorich.chat.entity.enums.ChatMessageType;
+import com.poortorich.chat.realtime.payload.interfaces.ResponsePayload;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class RankingStatusMessage implements ResponsePayload {
+
+    private Long messageId;
+    private Long chatroomId;
+    private Boolean isChatEnabled;
+    private LocalDateTime sendAt;
+
+    @Override
+    public BasePayload mapToBasePayload() {
+        return BasePayload.builder()
+                .type(ChatMessageType.RANKING_STATUS)
+                .payload(this)
+                .build();
+    }
+}

--- a/src/main/java/com/poortorich/chat/response/ChatroomCreateResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomCreateResponse.java
@@ -1,6 +1,5 @@
 package com.poortorich.chat.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +12,4 @@ import lombok.NoArgsConstructor;
 public class ChatroomCreateResponse {
 
     private Long newChatroomId;
-
-    @JsonIgnore
-    private Boolean savedRankingStatus;
 }

--- a/src/main/java/com/poortorich/chat/response/ChatroomCreateResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomCreateResponse.java
@@ -1,5 +1,6 @@
 package com.poortorich.chat.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,4 +13,7 @@ import lombok.NoArgsConstructor;
 public class ChatroomCreateResponse {
 
     private Long newChatroomId;
+
+    @JsonIgnore
+    private Boolean savedRankingStatus;
 }

--- a/src/main/java/com/poortorich/chat/response/ChatroomUpdateResponse.java
+++ b/src/main/java/com/poortorich/chat/response/ChatroomUpdateResponse.java
@@ -1,5 +1,6 @@
 package com.poortorich.chat.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Data;
 
@@ -8,4 +9,7 @@ import lombok.Data;
 public class ChatroomUpdateResponse {
 
     private final Long chatroomId;
+
+    @JsonIgnore
+    private final Boolean isChangedRankingStatus;
 }

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -136,7 +136,7 @@ public class ChatMessageService {
         return RankingStatusMessagePayload.builder()
                 .messageId(savedRankingStatusChatMessage.getId())
                 .chatroomId(context.chatroom().getId())
-                .isChatEnabled(savedRankingStatusChatMessage.getIsRankingEnabled())
+                .isRankingEnabled(savedRankingStatusChatMessage.getIsRankingEnabled())
                 .sendAt(savedRankingStatusChatMessage.getSentAt())
                 .build();
     }

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -4,10 +4,13 @@ import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.model.ChatPaginationContext;
+import com.poortorich.chat.realtime.builder.RankingStatusChatMessageBuilder;
 import com.poortorich.chat.realtime.builder.SystemMessageBuilder;
 import com.poortorich.chat.realtime.builder.UserChatMessageBuilder;
+import com.poortorich.chat.realtime.model.PayloadContext;
 import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
 import com.poortorich.chat.realtime.payload.response.ChatroomClosedResponsePayload;
+import com.poortorich.chat.realtime.payload.response.RankingStatusMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserChatMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserEnterResponsePayload;
 import com.poortorich.chat.realtime.payload.response.UserLeaveResponsePayload;
@@ -122,5 +125,19 @@ public class ChatMessageService {
                 context.chatroom(),
                 context.cursor(),
                 context.pageRequest());
+    }
+
+    public RankingStatusMessagePayload saveRankingStatusMessage(PayloadContext context) {
+        ChatMessage rankingStatusChatMessage = RankingStatusChatMessageBuilder.buildRankingStatusMessage(
+                context.chatroom());
+
+        ChatMessage savedRankingStatusChatMessage = chatMessageRepository.save(rankingStatusChatMessage);
+
+        return RankingStatusMessagePayload.builder()
+                .messageId(savedRankingStatusChatMessage.getId())
+                .chatroomId(context.chatroom().getId())
+                .isChatEnabled(savedRankingStatusChatMessage.getIsRankingEnabled())
+                .sendAt(savedRankingStatusChatMessage.getSentAt())
+                .build();
     }
 }

--- a/src/main/java/com/poortorich/chat/util/detector/RankingStatusChangeDetector.java
+++ b/src/main/java/com/poortorich/chat/util/detector/RankingStatusChangeDetector.java
@@ -1,0 +1,12 @@
+package com.poortorich.chat.util.detector;
+
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RankingStatusChangeDetector {
+
+    public Boolean detectRankingChange(Boolean currentStatus, Boolean newStatus) {
+        return !Objects.equals(currentStatus, newStatus);
+    }
+}


### PR DESCRIPTION
## #️⃣365
 
 ## 📝작업 내용
 
채팅방에서 랭킹 기능을 활성화한 경우 안내메시지를 출력할 수 있도록 도와주는 랭킹 기능 활성화 메시지를 생성하는 로직을 구현

### 채팅방 생성
채팅방 생성 때 isRankingEnabled를 `true`로 설정한 경우 채팅 기능 활성화 메시지를 생성함

### 채팅방 편집으로 랭킹 기능 활성화를 수정한 경우
채팅 기능 활성화 메시지를 생성하고 payload를 브로드캐스트함

**전달 사항**
이전 채팅 조회에서 가장 마지막 채팅 내역이 누락됨 이 후 이슈를 파서 수정하겠음 
 
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채팅방 생성 및 수정 시 실시간 랭킹 상태 메시지 생성 및 전송 기능이 추가되었습니다.
  * 랭킹 상태 변경 여부를 감지하여, 변경 시에만 관련 알림 메시지가 실시간으로 전송됩니다.

* **버그 수정**
  * 메시지 타입 관련 영문 상수 및 검증 메시지의 오타가 수정되었습니다.

* **기타**
  * 랭킹 상태 변경 감지 및 메시지 생성을 위한 내부 로직이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->