### PR TITLE
[#369] 공지 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -30,6 +30,8 @@ public class ChatResponseMessage {
 
     public static final String TAG_TOO_MANY = "태그는 " + ChatValidationConstraints.TAG_COUNT_MAX + "개 이하여야 합니다.";
 
+    public static final String CHAT_NOTICE_STATUS_IMMUTABLE = "이 공지사항은 더 이상 상태를 변경할 수 없습니다.";
+
     public static final String IS_LIKED_REQUIRED = "좋아요 상태는 필수값입니다.";
 
     public static final String CHATROOM_ENTER_DENIED = "이 채팅방에 입장할 수 없습니다.";

--- a/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
@@ -83,4 +83,8 @@ public class ChatParticipant {
         this.isParticipated = Boolean.FALSE;
         this.leaveTime = LocalDateTime.now();
     }
+
+    public void updateNoticeStatus(NoticeStatus status) {
+        this.noticeStatus = status;
+    }
 }

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -35,6 +35,7 @@ import com.poortorich.chat.util.mapper.ChatMessageMapper;
 import com.poortorich.chat.util.provider.ChatPaginationProvider;
 import com.poortorich.chat.validator.ChatParticipantValidator;
 import com.poortorich.chat.validator.ChatroomValidator;
+import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
 import com.poortorich.like.service.LikeService;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
@@ -177,6 +178,11 @@ public class ChatFacade {
                 .userId(chatParticipant.getUser().getId())
                 .chatroomRole(chatParticipant.getRole().toString())
                 .build();
+    }
+
+    public void updateNoticeStatus(String username, Long chatroomId, ChatNoticeUpdateRequest request) {
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+        chatParticipantService.updateNoticeStatus(username, chatroom, request);
     }
 
     public ChatroomEnterResponse enterChatroom(

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -30,6 +30,7 @@ public enum ChatResponse implements Response {
     CHAT_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, ChatResponseMessage.CHAT_PARTICIPANT_NOT_FOUND, null),
     CHATROOM_NOT_PARTICIPATE(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_NOT_PARTICIPATE, null),
     CHAT_PARTICIPANT_NOT_HOST(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHAT_PARTICIPANT_NOT_HOST, null),
+    CHAT_NOTICE_STATUS_IMMUTABLE(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHAT_NOTICE_STATUS_IMMUTABLE, null),
 
     CHATROOM_MAX_MEMBER_COUNT_EXCEED(
             HttpStatus.BAD_REQUEST,

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -3,10 +3,13 @@ package com.poortorich.chat.service;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.repository.ChatParticipantRepository;
 import com.poortorich.chat.response.ChatParticipantProfile;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.chat.util.ChatBuilder;
+import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
+import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.user.entity.User;
 import java.util.List;
@@ -23,6 +26,19 @@ public class ChatParticipantService {
     public void createChatroomHost(User user, Chatroom chatroom) {
         ChatParticipant chatParticipant = ChatBuilder.buildChatParticipant(user, ChatroomRole.HOST, chatroom);
         chatParticipantRepository.save(chatParticipant);
+    }
+
+    public void updateNoticeStatus(String username, Chatroom chatroom, ChatNoticeUpdateRequest request) {
+        ChatParticipant chatParticipant = findByUsernameAndChatroom(username, chatroom);
+        validateNoticeStatus(chatParticipant.getNoticeStatus());
+        chatParticipant.updateNoticeStatus(request.parseStatus());
+        chatParticipantRepository.save(chatParticipant);
+    }
+
+    private void validateNoticeStatus(NoticeStatus noticeStatus) {
+        if (noticeStatus.equals(NoticeStatus.PERMANENT_HIDDEN)) {
+            throw new BadRequestException(ChatResponse.CHAT_NOTICE_STATUS_IMMUTABLE);
+        }
     }
 
     public void enterUser(User user, Chatroom chatroom) {

--- a/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
+++ b/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
@@ -1,0 +1,12 @@
+package com.poortorich.chatnotice.constants;
+
+public class ChatNoticeResponseMessage {
+
+    public static final String UPDATE_CHAT_NOTICE_STATUS_SUCCESS = "공지 상태 변경이 완료되었습니다.";
+
+    public static final String NOTICE_STATUS_REQUIRED = "공지 상태는 필수값입니다.";
+    public static final String NOTICE_STATUS_INVALID = "공지 상태가 적절하지 않습니다.";
+
+    private ChatNoticeResponseMessage() {
+    }
+}

--- a/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
+++ b/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
@@ -1,0 +1,33 @@
+package com.poortorich.chatnotice.controller;
+
+import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
+import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
+import com.poortorich.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/chatrooms/{chatroomId}/notices")
+@RequiredArgsConstructor
+public class ChatNoticeController {
+
+    private final ChatFacade chatFacade;
+
+    @PatchMapping
+    public ResponseEntity<BaseResponse> updateNoticeStatus(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId,
+            @RequestBody ChatNoticeUpdateRequest request
+    ) {
+        chatFacade.updateNoticeStatus(userDetails.getUsername(), chatroomId, request);
+        return BaseResponse.toResponseEntity(ChatNoticeResponse.UPDATE_CHAT_NOTICE_STATUS_SUCCESS);
+    }
+}

--- a/src/main/java/com/poortorich/chatnotice/request/ChatNoticeUpdateRequest.java
+++ b/src/main/java/com/poortorich/chatnotice/request/ChatNoticeUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.poortorich.chatnotice.request;
+
+import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
+import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatNoticeUpdateRequest {
+
+    @NotNull(message = ChatNoticeResponseMessage.NOTICE_STATUS_REQUIRED)
+    private String status;
+
+    public NoticeStatus parseStatus() {
+        try {
+            return NoticeStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(ChatNoticeResponse.NOTICE_STATUS_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
@@ -1,0 +1,33 @@
+package com.poortorich.chatnotice.response.enums;
+
+import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
+import com.poortorich.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ChatNoticeResponse implements Response {
+
+    UPDATE_CHAT_NOTICE_STATUS_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.UPDATE_CHAT_NOTICE_STATUS_SUCCESS, null),
+
+    NOTICE_STATUS_INVALID(HttpStatus.BAD_REQUEST, ChatNoticeResponseMessage.NOTICE_STATUS_INVALID, "status");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String field;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
+}

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -18,6 +18,7 @@ import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
 import com.poortorich.like.service.LikeService;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
@@ -308,5 +309,19 @@ class ChatFacadeTest {
         assertThat(result).isNotNull();
         assertThat(result.getChatroomRole()).isEqualTo(ChatroomRole.HOST.toString());
         assertThat(result.getUserId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    @DisplayName("공지 상태 변경 성공")
+    void updateNoticeStatusSuccess() {
+        String username = "testUser";
+        Long chatroomId = 1L;
+        ChatNoticeUpdateRequest request = new ChatNoticeUpdateRequest("DEFAULT");
+
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+
+        chatFacade.updateNoticeStatus(username, chatroomId, request);
+
+        verify(chatParticipantService).updateNoticeStatus(username, chatroom, request);
     }
 }

--- a/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
+++ b/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
@@ -1,0 +1,64 @@
+package com.poortorich.chatnotice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
+import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
+import com.poortorich.global.config.BaseSecurityTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatNoticeController.class)
+@ExtendWith(MockitoExtension.class)
+class ChatNoticeControllerTest extends BaseSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ChatFacade chatFacade;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    }
+
+    @Test
+    @WithMockUser(username = "test")
+    @DisplayName("공지 상태 변경 성공")
+    void updateNoticeStatus() throws Exception {
+        long chatroomId = 1L;
+        ChatNoticeUpdateRequest request = new ChatNoticeUpdateRequest("TEMP_HIDDEN");
+
+        mockMvc.perform(patch("/chatrooms/" + chatroomId + "/notices")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(ChatNoticeResponse.UPDATE_CHAT_NOTICE_STATUS_SUCCESS.getMessage())
+                );
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#369 
 
 ## 📝작업 내용

- 공지 상태 변경
  - 입력으로 들어온 공지 상태로 변경
  - 공지 상태가 현재 `PERMANENT_HIDDEN`(다신 열지 않음)인 경우 예외 발생
  - 공지 상태 입력이 유효하지 않은 경우 예외 발생
  - 공지 상태 입력값이 없는 경우 예외 발생
 
 ### 스크린샷

<img width="972" height="358" alt="스크린샷 2025-08-07 오후 7 05 06" src="https://github.com/user-attachments/assets/efb790d9-0b45-4fc8-b0ea-20d991b90311" />

<img width="974" height="365" alt="스크린샷 2025-08-07 오후 7 05 17" src="https://github.com/user-attachments/assets/2effd9f0-b03c-4cca-8731-12ab3b4af5a6" />