### PR TITLE
[#384] 채팅방 모두 읽음 처리

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -47,6 +47,7 @@ public class ChatResponseMessage {
 
     public static final String CHATROOM_ID_REQUIRED = "채팅방 아이디는 필수값입니다.";
     public static final String MESSAGE_TYPE_REQUIRED = "메시지 타입은 필수값입니다.";
+    public static final String MARK_ALL_CHATROOM_AS_READ_SUCCESS = "참여중인 채팅방의 메세지를 모두 읽었습니다.";
 
     private ChatResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -2,8 +2,10 @@ package com.poortorich.chat.controller;
 
 import com.poortorich.chat.constants.ChatResponseMessage;
 import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chat.model.MarkAllChatroomAsReadResult;
 import com.poortorich.chat.realtime.facade.ChatRealTimeFacade;
 import com.poortorich.chat.realtime.payload.response.BasePayload;
+import com.poortorich.chat.realtime.payload.response.MessageReadPayload;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.request.ChatroomEnterRequest;
 import com.poortorich.chat.request.ChatroomLeaveAllRequest;
@@ -31,6 +33,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -207,5 +210,20 @@ public class ChatController {
                 pageSize);
 
         return DataResponse.toResponseEntity(ChatResponse.GET_CHAT_MESSAGE_SUCCESS, response);
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<BaseResponse> markAllChatroomAsRead(@AuthenticationPrincipal UserDetails userDetails) {
+        MarkAllChatroomAsReadResult result = realTimeFacade.markAllChatroomAsRead(userDetails.getUsername());
+
+        result.getBroadcastPayloads().stream()
+                .forEach(basePayload -> {
+                    MessageReadPayload payload = (MessageReadPayload) basePayload.getPayload();
+                    messagingTemplate.convertAndSend(
+                            SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + payload.getChatroomId(),
+                            basePayload);
+                });
+
+        return DataResponse.toResponseEntity(ChatResponse.MARK_ALL_CHATROOM_AS_READ_SUCCESS, result.getApiResponse());
     }
 }

--- a/src/main/java/com/poortorich/chat/model/MarkAllChatroomAsReadResult.java
+++ b/src/main/java/com/poortorich/chat/model/MarkAllChatroomAsReadResult.java
@@ -1,0 +1,15 @@
+package com.poortorich.chat.model;
+
+import com.poortorich.chat.realtime.payload.response.BasePayload;
+import com.poortorich.chat.response.MarkAllChatroomAsReadResponse;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MarkAllChatroomAsReadResult {
+
+    private final MarkAllChatroomAsReadResponse apiResponse;
+    private final List<BasePayload> broadcastPayloads;
+}

--- a/src/main/java/com/poortorich/chat/realtime/collect/ChatPayloadCollector.java
+++ b/src/main/java/com/poortorich/chat/realtime/collect/ChatPayloadCollector.java
@@ -7,6 +7,7 @@ import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -33,5 +34,19 @@ public class ChatPayloadCollector {
     public PayloadContext getPayloadContext(Long chatroomId) {
         Chatroom chatroom = chatroomService.findById(chatroomId);
         return PayloadContext.builder().chatroom(chatroom).build();
+    }
+
+    public List<PayloadContext> getAllPayloadContext(String username) {
+        User user = userService.findUserByUsername(username);
+
+        List<ChatParticipant> participants = chatParticipantService.findAllByUser(user);
+
+        return participants.stream()
+                .map(participant -> PayloadContext.builder()
+                        .user(user)
+                        .chatroom(participant.getChatroom())
+                        .chatParticipant(participant)
+                        .build())
+                .toList();
     }
 }

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -3,6 +3,7 @@ package com.poortorich.chat.realtime.facade;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatMessageType;
+import com.poortorich.chat.model.MarkAllChatroomAsReadResult;
 import com.poortorich.chat.realtime.collect.ChatPayloadCollector;
 import com.poortorich.chat.realtime.model.PayloadContext;
 import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
@@ -12,6 +13,7 @@ import com.poortorich.chat.realtime.payload.response.MessageReadPayload;
 import com.poortorich.chat.realtime.payload.response.RankingStatusMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserChatMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserEnterResponsePayload;
+import com.poortorich.chat.response.MarkAllChatroomAsReadResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
@@ -95,5 +97,21 @@ public class ChatRealTimeFacade {
         MessageReadPayload payload = unreadChatMessageService.markMessageAsRead(context.chatParticipant());
 
         return payload.mapToBasePayload();
+    }
+
+    public MarkAllChatroomAsReadResult markAllChatroomAsRead(String username) {
+        List<PayloadContext> contexts = payloadCollector.getAllPayloadContext(username);
+
+        List<Long> chatroomIds = contexts.stream().map(PayloadContext::chatroom).map(Chatroom::getId).toList();
+        
+        List<BasePayload> broadcastPayloads = contexts.stream()
+                .map(context -> unreadChatMessageService.markMessageAsRead(context.chatParticipant())
+                        .mapToBasePayload())
+                .toList();
+
+        return MarkAllChatroomAsReadResult.builder()
+                .apiResponse(MarkAllChatroomAsReadResponse.builder().chatroomIds(chatroomIds).build())
+                .broadcastPayloads(broadcastPayloads)
+                .build();
     }
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -16,11 +16,11 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     Optional<ChatParticipant> findByUserAndChatroom(User user, Chatroom chatroom);
 
     @Query("""
-        SELECT cp
-          FROM ChatParticipant cp
-         WHERE cp.user.username = :username
-           AND cp.chatroom = :chatroom
-    """)
+                SELECT cp
+                  FROM ChatParticipant cp
+                 WHERE cp.user.username = :username
+                   AND cp.chatroom = :chatroom
+            """)
     Optional<ChatParticipant> findByUsernameAndChatroom(
             @Param("username") String username,
             @Param("chatroom") Chatroom chatroom
@@ -43,4 +43,6 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     List<ChatParticipant> findAllByChatroom(Chatroom chatroom);
 
     List<ChatParticipant> findAllByChatroomAndIsParticipatedTrueAndUserNot(Chatroom chatroom, User excludedUser);
+
+    List<ChatParticipant> findAllByUserAndIsParticipatedTrue(User user);
 }

--- a/src/main/java/com/poortorich/chat/response/MarkAllChatroomAsReadResponse.java
+++ b/src/main/java/com/poortorich/chat/response/MarkAllChatroomAsReadResponse.java
@@ -1,0 +1,12 @@
+package com.poortorich.chat.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MarkAllChatroomAsReadResponse {
+
+    private List<Long> chatroomIds;
+}

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -38,7 +38,8 @@ public enum ChatResponse implements Response {
     CHATROOM_LEAVE_ALREADY(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_LEAVE_ALREADY, null),
     CHATROOM_LEAVE_SUCCESS(HttpStatus.OK, ChatResponseMessage.CHATROOM_LEAVE_SUCCESS, null),
     CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, ChatResponseMessage.CHAT_MESSAGE_NOT_FOUND, null),
-    GET_CHAT_MESSAGE_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHAT_MESSAGE_SUCCESS, null);
+    GET_CHAT_MESSAGE_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHAT_MESSAGE_SUCCESS, null),
+    MARK_ALL_CHATROOM_AS_READ_SUCCESS(HttpStatus.OK, ChatResponseMessage.MARK_ALL_CHATROOM_AS_READ_SUCCESS, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -109,4 +109,8 @@ public class ChatParticipantService {
     public List<ChatParticipant> findAllByChatroomExcludingUser(Chatroom chatroom, User excludedUser) {
         return chatParticipantRepository.findAllByChatroomAndIsParticipatedTrueAndUserNot(chatroom, excludedUser);
     }
+
+    public List<ChatParticipant> findAllByUser(User user) {
+        return chatParticipantRepository.findAllByUserAndIsParticipatedTrue(user);
+    }
 }


### PR DESCRIPTION
## #️⃣384
 ## 📝작업 내용
- 참석중인 모든 채팅방에 읽음 처리를 하는 로직을 추가
 
 ### 스크린샷 (선택)
 
<img width="1407" height="266" alt="잘 발행됨" src="https://github.com/user-attachments/assets/3acf980c-bbc2-49cc-96b4-666109ffcdd4" />

<img width="616" height="407" alt="RestAPI 응답" src="https://github.com/user-attachments/assets/a357339e-a4e3-490b-a5f4-9d88f80469e3" />
