### PR TITLE
[#377] 사용자 신고하기 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -3,6 +3,7 @@ package com.poortorich.chat.repository;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.user.entity.User;
+
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,6 +24,17 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     """)
     Optional<ChatParticipant> findByUsernameAndChatroom(
             @Param("username") String username,
+            @Param("chatroom") Chatroom chatroom
+    );
+
+    @Query("""
+        SELECT cp
+          FROM ChatParticipant cp
+         WHERE cp.user.id = :userId
+           AND cp.chatroom = :chatroom
+    """)
+    Optional<ChatParticipant> findByUserIdAndChatroom(
+            @Param("userId") Long userId,
             @Param("chatroom") Chatroom chatroom
     );
 

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -60,6 +60,11 @@ public class ChatParticipantService {
                 .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND));
     }
 
+    public ChatParticipant findByUserIdAndChatroom(Long userId, Chatroom chatroom) {
+        return chatParticipantRepository.findByUserIdAndChatroom(userId, chatroom)
+                .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND));
+    }
+
     public Long countByChatroom(Chatroom chatroom) {
         return chatParticipantRepository.countByChatroomAndIsParticipatedTrue(chatroom);
     }

--- a/src/main/java/com/poortorich/report/constants/ReportResponseMessage.java
+++ b/src/main/java/com/poortorich/report/constants/ReportResponseMessage.java
@@ -1,0 +1,12 @@
+package com.poortorich.report.constants;
+
+public class ReportResponseMessage {
+
+    public static final String MEMBER_REPORT_SUCCESS = "신고가 정상적으로 접수되었습니다.";
+
+    public static final String REPORT_REASON_REQUIRED = "신고 사유는 필수입니다.";
+    public static final String REPORT_DUPLICATE = "현재 채팅방에서 이미 이 참여자를 신고했습니다.";
+
+    private ReportResponseMessage() {
+    }
+}

--- a/src/main/java/com/poortorich/report/controller/ReportController.java
+++ b/src/main/java/com/poortorich/report/controller/ReportController.java
@@ -1,0 +1,38 @@
+package com.poortorich.report.controller;
+
+import com.poortorich.global.response.BaseResponse;
+import com.poortorich.global.response.DataResponse;
+import com.poortorich.report.facade.ReportFacade;
+import com.poortorich.report.request.ReceiptReportRequest;
+import com.poortorich.report.response.enums.ReportResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportFacade reportFacade;
+
+    @PostMapping("/chatrooms/{chatroomId}/members/{userId}/reports")
+    public ResponseEntity<BaseResponse> reportMember(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("chatroomId") Long chatroomId,
+            @PathVariable("userId") Long userId,
+            @RequestBody @Valid ReceiptReportRequest request
+    ) {
+        return DataResponse.toResponseEntity(
+                ReportResponse.MEMBER_REPORT_SUCCESS,
+                reportFacade.reportMember(userDetails.getUsername(), chatroomId, userId, request)
+        );
+    }
+}

--- a/src/main/java/com/poortorich/report/entity/Report.java
+++ b/src/main/java/com/poortorich/report/entity/Report.java
@@ -1,0 +1,82 @@
+package com.poortorich.report.entity;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.report.entity.enums.ReportReason;
+import com.poortorich.report.entity.enums.ReportStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "report",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_reporter_reported_chatroom",
+                        columnNames = { "reporter_id", "reported_id", "chatroom_id" }
+                )
+        }
+)
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Builder.Default
+    private ReportStatus status = ReportStatus.PENDING;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason", nullable = false)
+    private ReportReason reason;
+
+    @Column(name = "custom_reason")
+    private String customReason;
+
+    @CreationTimestamp
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @UpdateTimestamp
+    @Column(name = "updated_date")
+    private LocalDateTime updatedDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id")
+    private ChatParticipant reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_id")
+    private ChatParticipant reported;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private Chatroom chatroom;
+}

--- a/src/main/java/com/poortorich/report/entity/enums/ReportReason.java
+++ b/src/main/java/com/poortorich/report/entity/enums/ReportReason.java
@@ -1,0 +1,11 @@
+package com.poortorich.report.entity.enums;
+
+public enum ReportReason {
+
+    INSULT,     // 욕설 / 비하
+    SEXUAL,     // 성희롱 / 불쾌한 표현
+    SPAM,       // 광고 / 스팸
+    FLOOD,      // 도배 / 무의미한 글 반복
+    POLITICAL,  // 정치 / 종교적 발언
+    CUSTOM      // 기타 (직접 입력)
+}

--- a/src/main/java/com/poortorich/report/entity/enums/ReportStatus.java
+++ b/src/main/java/com/poortorich/report/entity/enums/ReportStatus.java
@@ -1,0 +1,7 @@
+package com.poortorich.report.entity.enums;
+
+public enum ReportStatus {
+
+    PENDING,
+    RESOLVED
+}

--- a/src/main/java/com/poortorich/report/facade/ReportFacade.java
+++ b/src/main/java/com/poortorich/report/facade/ReportFacade.java
@@ -1,0 +1,36 @@
+package com.poortorich.report.facade;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.service.ChatParticipantService;
+import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.report.request.ReceiptReportRequest;
+import com.poortorich.report.service.ReportService;
+import com.poortorich.report.util.ReportBuilder;
+import com.poortorich.report.response.ReceiptReportResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportFacade {
+
+    private final ChatParticipantService chatParticipantService;
+    private final ChatroomService chatroomService;
+    private final ReportService reportService;
+
+    public ReceiptReportResponse reportMember(
+            String username,
+            Long chatroomId,
+            Long reportedId,
+            ReceiptReportRequest request
+    ) {
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+        ChatParticipant reporterMember = chatParticipantService.findByUsernameAndChatroom(username, chatroom);
+        ChatParticipant reportedMember = chatParticipantService.findByUserIdAndChatroom(reportedId, chatroom);
+
+        reportService.reportMember(reporterMember, reportedMember, chatroom, request);
+
+        return ReportBuilder.buildReceiptReportResponse(reportedId, chatroomId, request.getReportType());
+    }
+}

--- a/src/main/java/com/poortorich/report/repository/ReportRepository.java
+++ b/src/main/java/com/poortorich/report/repository/ReportRepository.java
@@ -1,0 +1,17 @@
+package com.poortorich.report.repository;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    boolean existsByReporterAndReportedAndChatroom(
+            ChatParticipant reporterMember,
+            ChatParticipant reportedMember,
+            Chatroom chatroom
+    );
+}

--- a/src/main/java/com/poortorich/report/request/ReceiptReportRequest.java
+++ b/src/main/java/com/poortorich/report/request/ReceiptReportRequest.java
@@ -1,0 +1,15 @@
+package com.poortorich.report.request;
+
+import com.poortorich.report.constants.ReportResponseMessage;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReceiptReportRequest {
+
+    @NotNull(message = ReportResponseMessage.REPORT_REASON_REQUIRED)
+    private String reportType;
+    private String customReason;
+}

--- a/src/main/java/com/poortorich/report/response/ReceiptReportResponse.java
+++ b/src/main/java/com/poortorich/report/response/ReceiptReportResponse.java
@@ -1,0 +1,17 @@
+package com.poortorich.report.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReceiptReportResponse {
+
+    private Long reportedUserId;
+    private Long chatroomId;
+    private String reportType;
+}

--- a/src/main/java/com/poortorich/report/response/enums/ReportResponse.java
+++ b/src/main/java/com/poortorich/report/response/enums/ReportResponse.java
@@ -1,0 +1,35 @@
+package com.poortorich.report.response.enums;
+
+import com.poortorich.global.response.Response;
+import com.poortorich.report.constants.ReportResponseMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportResponse implements Response {
+
+    MEMBER_REPORT_SUCCESS(HttpStatus.OK, ReportResponseMessage.MEMBER_REPORT_SUCCESS, null),
+
+    REPORT_DUPLICATE(HttpStatus.CONFLICT, ReportResponseMessage.REPORT_DUPLICATE, "userId, chatroomId");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String field;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
+}

--- a/src/main/java/com/poortorich/report/service/ReportService.java
+++ b/src/main/java/com/poortorich/report/service/ReportService.java
@@ -1,0 +1,40 @@
+package com.poortorich.report.service;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.global.exceptions.ConflictException;
+import com.poortorich.report.entity.enums.ReportReason;
+import com.poortorich.report.repository.ReportRepository;
+import com.poortorich.report.request.ReceiptReportRequest;
+import com.poortorich.report.response.enums.ReportResponse;
+import com.poortorich.report.util.ReportBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+
+    public void reportMember(
+            ChatParticipant reporterMember,
+            ChatParticipant reportedMember,
+            Chatroom chatroom,
+            ReceiptReportRequest request
+    ) {
+        // TODO : 같은 조합으로도 신고가 가능하게 할 지, 아니면 신고에 개수 제한을 둘 지
+        if (reportRepository.existsByReporterAndReportedAndChatroom(reporterMember, reportedMember, chatroom)) {
+            throw new ConflictException(ReportResponse.REPORT_DUPLICATE);
+        }
+
+        reportRepository.save(
+                ReportBuilder.buildReport(
+                        reporterMember,
+                        reportedMember,
+                        chatroom,
+                        ReportReason.valueOf(request.getReportType()),
+                        request.getCustomReason())
+        );
+    }
+}

--- a/src/main/java/com/poortorich/report/util/ReportBuilder.java
+++ b/src/main/java/com/poortorich/report/util/ReportBuilder.java
@@ -1,0 +1,38 @@
+package com.poortorich.report.util;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.report.entity.Report;
+import com.poortorich.report.entity.enums.ReportReason;
+import com.poortorich.report.response.ReceiptReportResponse;
+
+public class ReportBuilder {
+
+    public static Report buildReport(
+            ChatParticipant reporterUser,
+            ChatParticipant reportedUser,
+            Chatroom chatroom,
+            ReportReason reason,
+            String customReason
+    ) {
+        return Report.builder()
+                .reporter(reporterUser)
+                .reported(reportedUser)
+                .chatroom(chatroom)
+                .reason(reason)
+                .customReason(customReason)
+                .build();
+    }
+
+    public static ReceiptReportResponse buildReceiptReportResponse(
+            Long reportedUserId,
+            Long chatroomId,
+            String reportType
+    ) {
+        return ReceiptReportResponse.builder()
+                .reportedUserId(reportedUserId)
+                .chatroomId(chatroomId)
+                .reportType(reportType)
+                .build();
+    }
+}

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -16,6 +16,7 @@ import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
 import com.poortorich.user.entity.User;

--- a/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
@@ -247,4 +247,38 @@ class ChatParticipantServiceTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining(ChatNoticeResponse.NOTICE_STATUS_INVALID.getMessage());
     }
+
+    @Test
+    @DisplayName("회원 아이디와 채팅방으로 채팅방 참여자 조회 성공")
+    void findByUserIdAndChatroomSuccess() {
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatParticipant chatParticipant = ChatParticipant.builder()
+                .user(user)
+                .chatroom(chatroom)
+                .build();
+
+        when(chatParticipantRepository.findByUserIdAndChatroom(userId, chatroom))
+                .thenReturn(Optional.of(chatParticipant));
+
+        ChatParticipant result = chatParticipantService.findByUserIdAndChatroom(userId, chatroom);
+
+        assertThat(result).isEqualTo(chatParticipant);
+        assertThat(result.getUser().getId()).isEqualTo(user.getId());
+        assertThat(result.getChatroom()).isEqualTo(chatroom);
+    }
+
+    @Test
+    @DisplayName("회원 아이디와 채팅방으로 채팅방 참여자 조회 실패")
+    void findByUserIdAndChatroomNotFound() {
+        Long userId = 1L;
+        Chatroom chatroom = Chatroom.builder().build();
+
+        when(chatParticipantRepository.findByUserIdAndChatroom(userId, chatroom)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chatParticipantService.findByUserIdAndChatroom(userId, chatroom))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND.getMessage());
+    }
 }

--- a/src/test/java/com/poortorich/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/poortorich/report/controller/ReportControllerTest.java
@@ -1,0 +1,63 @@
+package com.poortorich.report.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.poortorich.global.config.BaseSecurityTest;
+import com.poortorich.report.facade.ReportFacade;
+import com.poortorich.report.request.ReceiptReportRequest;
+import com.poortorich.report.response.ReceiptReportResponse;
+import com.poortorich.report.response.enums.ReportResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportController.class)
+@ExtendWith(MockitoExtension.class)
+class ReportControllerTest extends BaseSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ReportFacade reportFacade;
+
+    private final String username = "test";
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @WithMockUser(username = username)
+    @DisplayName("채팅방 참여자 신고 성공")
+    void reportMemberSuccess() throws Exception {
+        Long chatroomId = 1L;
+        Long userId = 1L;
+        ReceiptReportRequest request = new ReceiptReportRequest("INSULT", null);
+
+        when(reportFacade.reportMember(username, chatroomId, userId, request))
+                .thenReturn(ReceiptReportResponse.builder().build());
+
+        mockMvc.perform(post("/chatrooms/" + chatroomId + "/members/" + userId + "/reports")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(("$.message")).value(ReportResponse.MEMBER_REPORT_SUCCESS.getMessage()));
+    }
+}

--- a/src/test/java/com/poortorich/report/facade/ReportFacadeTest.java
+++ b/src/test/java/com/poortorich/report/facade/ReportFacadeTest.java
@@ -1,0 +1,66 @@
+package com.poortorich.report.facade;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.service.ChatParticipantService;
+import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.report.request.ReceiptReportRequest;
+import com.poortorich.report.response.ReceiptReportResponse;
+import com.poortorich.report.service.ReportService;
+import com.poortorich.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReportFacadeTest {
+
+    @Mock
+    private ChatParticipantService chatParticipantService;
+    @Mock
+    private ChatroomService chatroomService;
+    @Mock
+    private ReportService reportService;
+
+    @InjectMocks
+    private ReportFacade reportFacade;
+
+    @Test
+    @DisplayName("채팅방 참여자 신고 성공")
+    void reportMemberSuccess() {
+        String username = "test";
+        Long chatroomId = 1L;
+        Long reportedId = 2L;
+        ReceiptReportRequest request = new ReceiptReportRequest("INSULT", null);
+
+        User reporter = User.builder().username(username).build();
+        User reported = User.builder().id(reportedId).build();
+        Chatroom chatroom = Chatroom.builder().id(chatroomId).build();
+        ChatParticipant reporterMember = ChatParticipant.builder()
+                .user(reporter)
+                .chatroom(chatroom)
+                .build();
+        ChatParticipant reportedMember = ChatParticipant.builder()
+                .user(reported)
+                .chatroom(chatroom)
+                .build();
+
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(chatParticipantService.findByUsernameAndChatroom(username, chatroom)).thenReturn(reporterMember);
+        when(chatParticipantService.findByUserIdAndChatroom(reportedId, chatroom)).thenReturn(reportedMember);
+
+        ReceiptReportResponse result = reportFacade.reportMember(username, chatroomId, reportedId, request);
+
+        verify(reportService).reportMember(reporterMember, reportedMember, chatroom, request);
+
+        assertThat(result.getReportType()).isEqualTo(request.getReportType());
+        assertThat(result.getReportedUserId()).isEqualTo(reportedId);
+    }
+}

--- a/src/test/java/com/poortorich/report/service/ReportServiceTest.java
+++ b/src/test/java/com/poortorich/report/service/ReportServiceTest.java
@@ -1,0 +1,76 @@
+package com.poortorich.report.service;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.global.exceptions.ConflictException;
+import com.poortorich.report.entity.Report;
+import com.poortorich.report.entity.enums.ReportReason;
+import com.poortorich.report.repository.ReportRepository;
+import com.poortorich.report.request.ReceiptReportRequest;
+import com.poortorich.report.response.enums.ReportResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @InjectMocks
+    private ReportService reportService;
+
+    @Captor
+    private ArgumentCaptor<Report> reportCaptor;
+
+    @Test
+    @DisplayName("채팅방 참여자 신고 성공")
+    void reportMemberSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatParticipant reporterMember = ChatParticipant.builder().chatroom(chatroom).build();
+        ChatParticipant reportedMember = ChatParticipant.builder().chatroom(chatroom).build();
+
+        ReceiptReportRequest request = new ReceiptReportRequest("INSULT", null);
+
+        when(reportRepository.existsByReporterAndReportedAndChatroom(reporterMember, reportedMember, chatroom))
+                .thenReturn(false);
+
+        reportService.reportMember(reporterMember, reportedMember, chatroom, request);
+
+        verify(reportRepository).save(reportCaptor.capture());
+        Report report = reportCaptor.getValue();
+
+        assertThat(report.getReporter()).isEqualTo(reporterMember);
+        assertThat(report.getReported()).isEqualTo(reportedMember);
+        assertThat(report.getChatroom()).isEqualTo(chatroom);
+        assertThat(report.getReason()).isEqualTo(ReportReason.valueOf(request.getReportType()));
+    }
+
+    @Test
+    @DisplayName("이미 같은 조합으로 신고를 진행한 경우 예외 발생")
+    void reportMemberConflict() {
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatParticipant reporterMember = ChatParticipant.builder().chatroom(chatroom).build();
+        ChatParticipant reportedMember = ChatParticipant.builder().chatroom(chatroom).build();
+
+        ReceiptReportRequest request = new ReceiptReportRequest("INSULT", null);
+
+        when(reportRepository.existsByReporterAndReportedAndChatroom(reporterMember, reportedMember, chatroom))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> reportService.reportMember(reporterMember, reportedMember, chatroom, request))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining(ReportResponse.REPORT_DUPLICATE.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#377
 
 ## 📝작업 내용
 
### Entity

<img width="1285" height="310" alt="image" src="https://github.com/user-attachments/assets/dc2bd54a-ee0a-42e0-9668-d046474c1796" />

- 신고 테이블 추가
  - 신고한/신고당한 유저 -> `ChatParticipant` 테이블과 매핑
  - `@UniqueConstraint`: reported_id, reporter_id, chatroom_id 를 묶어서 중복되지 않도록 설정
    > 같은 채팅방에서 같은 유저를 신고하는 경우에 한 번만 신고가 가능하도록 하는 방식입니다. 
    > 현재 이 방식이 맞는지 고민이 있어 `ReportService`에 TODO 주석을 달아두었습니다! 리뷰 요구사항에도 작성하였으니 리뷰에 참고해주시면 감사하겠습니다 🙇🏻‍♀️

### API

- 사용자 신고하기 
  - 채팅방 아이디로 채팅방 찾기
  - 신고를 진행하는 회원(이하 reporter)은 username으로 채팅방 참여자 찾기
  - 신고를 당하는 회원(이하 reported)은 회원 아이디로 채팅방 참여자 찾기
  - 이미 존재하는 조합인지 검증 (reporter, reported, chatroom의 unique 제약)
  - 신고 접수 (저장)
 
 ### 스크린샷

<img width="967" height="346" alt="image" src="https://github.com/user-attachments/assets/4745e54c-411e-417d-8281-8355ab4aa087" />

<img width="969" height="411" alt="image" src="https://github.com/user-attachments/assets/b524fc68-c28e-4388-ab16-88e8e3032d6e" />

 
 ## 💬리뷰 요구사항

- 신고 도배를 방지하기 위해 신고 제약사항을 두고 싶은데, 같은 조합으로도 신고가 가능하게 할 지 신고에 개수 제한을 둘 지 고민입니다
