### PR TITLE
[#391] 채팅방 추가 API 태그 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -73,7 +73,9 @@ public class ChatFacade {
 
         Chatroom chatroom = chatroomService.createChatroom(imageUrl, request);
         chatParticipantService.createChatroomHost(user, chatroom);
-        tagService.createTag(request.getHashtags(), chatroom);
+        if (request.getHashtags() != null) {
+            tagService.createTag(request.getHashtags(), chatroom);
+        }
 
         return ChatroomCreateResponse.builder().newChatroomId(chatroom.getId()).build();
     }

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -102,6 +102,26 @@ class ChatFacadeTest {
     }
 
     @Test
+    @DisplayName("해시태그가 없는 채팅방 추가 성공")
+    void createChatroomTagNullSuccess() {
+        String username = "test";
+        ChatroomCreateRequest request = new ChatroomCreateRequest(
+                image, chatroomTitle, maxMemberCount, null, null, isRankingEnabled, chatroomPassword
+        );
+        User user = User.builder().username(username).build();
+
+        when(userService.findUserByUsername(username)).thenReturn(user);
+        when(fileUploadService.uploadImage(image)).thenReturn(imageUrl);
+        when(chatroomService.createChatroom(imageUrl, request)).thenReturn(chatroom);
+
+        ChatroomCreateResponse response = chatFacade.createChatroom(username, request);
+
+        verify(chatParticipantService).createChatroomHost(user, chatroom);
+
+        assertThat(response.getNewChatroomId()).isEqualTo(chatroom.getId());
+    }
+
+    @Test
     @DisplayName("채팅방 정보 조회 성공")
     void getChatroomSuccess() {
         when(chatroomService.findById(chatroomId)).thenReturn(chatroom);


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#391
 
 ## 📝작업 내용
 
- 태그가 null인 경우 403 예외 처리를 삭제하고 태그가 null이 아닌 경우만 태그를 추가하도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 해당 항목 없음
- 버그 수정
  - 해시태그 없이도 채팅방을 오류 없이 생성할 수 있으며, 불필요한 태그 생성 시도가 제거되어 예외 발생 가능성이 낮아졌습니다. 전반적인 안정성과 예측 가능성이 개선되었습니다.
- 테스트
  - 해시태그가 없는 채팅방 생성 시나리오를 검증하는 단위 테스트를 추가하여 동작을 보장하고 회귀를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->