### PR TITLE
[#395] 최근 공지 조회 API 수정

### DIFF
--- a/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
+++ b/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
@@ -30,6 +30,10 @@ public class ChatNoticeFacade {
     }
 
     private LatestNoticeResponse buildLatestNoticeResponse(NoticeStatus status, ChatNotice notice) {
+        if (notice == null) {
+            return null;
+        }
+
         return LatestNoticeResponse.builder()
                 .status(status.toString())
                 .noticeId(notice.getId())

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -16,6 +16,6 @@ public class ChatNoticeService {
 
     public ChatNotice getLatestNotice(Chatroom chatroom) {
         return chatNoticeRepository.findTop1ByChatroomOrderByCreatedDateDesc(chatroom)
-                .orElseThrow(() -> new NotFoundException(ChatNoticeResponse.NOTICE_NOT_FOUND));
+                .orElse(null);
     }
 }

--- a/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
+++ b/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
@@ -111,4 +111,16 @@ class ChatNoticeFacadeTest {
         assertThat(result.getAuthorNickname()).isEqualTo(user.getNickname());
         assertThat(result.getCreatedAt()).isEqualTo(chatNotice.getCreatedDate().toString());
     }
+
+    @Test
+    @DisplayName("최근 공지가 null인 경우 null response 반환")
+    void getLatestNoticeNull() {
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(chatParticipantService.findByUsernameAndChatroom(username, chatroom)).thenReturn(chatParticipant);
+        when(chatNoticeService.getLatestNotice(chatroom)).thenReturn(null);
+
+        LatestNoticeResponse result = chatNoticeFacade.getLatestNotice(username, chatroomId);
+
+        assertThat(result).isNull();
+    }
 }

--- a/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
+++ b/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
@@ -42,14 +42,14 @@ class ChatNoticeServiceTest {
     }
 
     @Test
-    @DisplayName("공지가 없는 경우 예외 발생")
-    void getLatestNoticeNotFound() {
+    @DisplayName("공지가 없는 경우 null 반환")
+    void getLatestNoticeNotFoundNull() {
         Chatroom chatroom = Chatroom.builder().build();
 
         when(chatNoticeRepository.findTop1ByChatroomOrderByCreatedDateDesc(chatroom)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> chatNoticeService.getLatestNotice(chatroom))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining(ChatNoticeResponse.NOTICE_NOT_FOUND.getMessage());
+        ChatNotice latestNotice = chatNoticeService.getLatestNotice(chatroom);
+
+        assertThat(latestNotice).isNull();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#395
 
 ## 📝작업 내용
 
- 프론트엔드의 요청에 따라 최근 공지 조회시 값이 없는 경우 예외 처리를 삭제하고 null을 반환하도록 수정
  - 최근 공지가 null인 경우 `data` 필드 X
 
 ### 스크린샷

<img width="970" height="254" alt="image" src="https://github.com/user-attachments/assets/e7f749df-7f84-4c3e-8a7a-581af8391725" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 최신 공지가 없는 채팅방에서 오류가 발생하던 문제를 개선했습니다. 최신 공지가 없을 경우 예외 대신 빈 결과를 반환하여 NPE 및 예외로 인한 화면 중단을 방지합니다.
- 테스트
  - 최신 공지 부재 시 동작을 검증하는 테스트를 추가/수정하여 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->