### PR TITLE
[#397] 최근 공지 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
+++ b/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
@@ -4,6 +4,7 @@ public class ChatNoticeResponseMessage {
 
     public static final String GET_LATEST_NOTICE_SUCCESS = "최근 공지 조회를 완료했습니다.";
     public static final String UPDATE_NOTICE_STATUS_SUCCESS = "공지 상태 변경이 완료되었습니다.";
+    public static final String GET_PREVIEW_NOTICE_SUCCESS = "최신 공지 목록 조회를 완료했습니다.";
 
     public static final String NOTICE_STATUS_REQUIRED = "공지 상태는 필수값입니다.";
     public static final String NOTICE_STATUS_INVALID = "공지 상태가 적절하지 않습니다.";

--- a/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
+++ b/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
@@ -46,4 +46,12 @@ public class ChatNoticeController {
         chatFacade.updateNoticeStatus(userDetails.getUsername(), chatroomId, request);
         return BaseResponse.toResponseEntity(ChatNoticeResponse.UPDATE_NOTICE_STATUS_SUCCESS);
     }
+
+    @GetMapping("/preview")
+    public ResponseEntity<BaseResponse> getPreviewNotices(@PathVariable Long chatroomId) {
+        return DataResponse.toResponseEntity(
+                ChatNoticeResponse.GET_PREVIEW_NOTICE_SUCCESS,
+                chatNoticeFacade.getPreviewNotices(chatroomId)
+        );
+    }
 }

--- a/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
+++ b/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
@@ -2,20 +2,18 @@ package com.poortorich.chatnotice.facade;
 
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
-import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
 import com.poortorich.chatnotice.service.ChatNoticeService;
+import com.poortorich.chatnotice.util.ChatNoticeBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ChatNoticeFacade {
-
-    private static final int PREVIEW_MAX_LENGTH = 30;
 
     private final ChatroomService chatroomService;
     private final ChatParticipantService chatParticipantService;
@@ -26,24 +24,6 @@ public class ChatNoticeFacade {
         ChatParticipant chatParticipant = chatParticipantService.findByUsernameAndChatroom(username, chatroom);
         ChatNotice notice = chatNoticeService.getLatestNotice(chatroom);
 
-        return buildLatestNoticeResponse(chatParticipant.getNoticeStatus(), notice);
-    }
-
-    private LatestNoticeResponse buildLatestNoticeResponse(NoticeStatus status, ChatNotice notice) {
-        return LatestNoticeResponse.builder()
-                .status(status.toString())
-                .noticeId(notice.getId())
-                .preview(truncateContent(notice.getContent()))
-                .createdAt(notice.getCreatedDate().toString())
-                .authorNickname(notice.getAuthor().getNickname())
-                .build();
-    }
-
-    private String truncateContent(String content) {
-        if (content.length() > PREVIEW_MAX_LENGTH) {
-            return content.substring(0, PREVIEW_MAX_LENGTH);
-        }
-
-        return content;
+        return ChatNoticeBuilder.buildLatestNoticeResponse(chatParticipant.getNoticeStatus(), notice);
     }
 }

--- a/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
+++ b/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
@@ -6,10 +6,13 @@ import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
+import com.poortorich.chatnotice.response.PreviewNoticesResponse;
 import com.poortorich.chatnotice.service.ChatNoticeService;
 import com.poortorich.chatnotice.util.ChatNoticeBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,5 +28,14 @@ public class ChatNoticeFacade {
         ChatNotice notice = chatNoticeService.getLatestNotice(chatroom);
 
         return ChatNoticeBuilder.buildLatestNoticeResponse(chatParticipant.getNoticeStatus(), notice);
+    }
+
+    public PreviewNoticesResponse getPreviewNotices(Long chatroomId) {
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+        List<ChatNotice> previewNotice = chatNoticeService.getPreviewNotices(chatroom);
+
+        return PreviewNoticesResponse.builder()
+                .notices(ChatNoticeBuilder.buildPreviewNoticeResponse(previewNotice))
+                .build();
     }
 }

--- a/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
+++ b/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
@@ -5,10 +5,13 @@ import com.poortorich.chatnotice.entity.ChatNotice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ChatNoticeRepository extends JpaRepository<ChatNotice, Long> {
 
     Optional<ChatNotice> findTop1ByChatroomOrderByCreatedDateDesc(Chatroom chatroom);
+
+    List<ChatNotice> findTop3ByChatroomOrderByCreatedDateDesc(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chatnotice/response/PreviewNoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/PreviewNoticeResponse.java
@@ -1,0 +1,16 @@
+package com.poortorich.chatnotice.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreviewNoticeResponse {
+
+    private Long noticeId;
+    private String preview;
+}

--- a/src/main/java/com/poortorich/chatnotice/response/PreviewNoticesResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/PreviewNoticesResponse.java
@@ -1,0 +1,17 @@
+package com.poortorich.chatnotice.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreviewNoticesResponse {
+
+    private List<PreviewNoticeResponse> notices;
+}

--- a/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
@@ -10,6 +10,7 @@ public enum ChatNoticeResponse implements Response {
 
     GET_LATEST_NOTICE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.GET_LATEST_NOTICE_SUCCESS, null),
     UPDATE_NOTICE_STATUS_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.UPDATE_NOTICE_STATUS_SUCCESS, null),
+    GET_PREVIEW_NOTICE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.GET_PREVIEW_NOTICE_SUCCESS, null),
 
     NOTICE_STATUS_INVALID(HttpStatus.BAD_REQUEST, ChatNoticeResponseMessage.NOTICE_STATUS_INVALID, "status"),
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, ChatNoticeResponseMessage.NOTICE_NOT_FOUND, null);

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -8,6 +8,8 @@ import com.poortorich.global.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ChatNoticeService {
@@ -17,5 +19,9 @@ public class ChatNoticeService {
     public ChatNotice getLatestNotice(Chatroom chatroom) {
         return chatNoticeRepository.findTop1ByChatroomOrderByCreatedDateDesc(chatroom)
                 .orElseThrow(() -> new NotFoundException(ChatNoticeResponse.NOTICE_NOT_FOUND));
+    }
+
+    public List<ChatNotice> getPreviewNotices(Chatroom chatroom) {
+        return chatNoticeRepository.findTop3ByChatroomOrderByCreatedDateDesc(chatroom);
     }
 }

--- a/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
+++ b/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
@@ -3,6 +3,10 @@ package com.poortorich.chatnotice.util;
 import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
+import com.poortorich.chatnotice.response.PreviewNoticeResponse;
+
+import java.util.List;
+import java.util.Objects;
 
 public class ChatNoticeBuilder {
 
@@ -16,6 +20,16 @@ public class ChatNoticeBuilder {
                 .createdAt(notice.getCreatedDate().toString())
                 .authorNickname(notice.getAuthor().getNickname())
                 .build();
+    }
+
+    public static List<PreviewNoticeResponse> buildPreviewNoticeResponse(List<ChatNotice> previewNotice) {
+        return previewNotice.stream()
+                .filter(Objects::nonNull)
+                .map(notice -> PreviewNoticeResponse.builder()
+                        .noticeId(notice.getId())
+                        .preview(truncateContent(notice.getContent()))
+                        .build())
+                .toList();
     }
 
     private static String truncateContent(String content) {

--- a/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
+++ b/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
@@ -1,0 +1,28 @@
+package com.poortorich.chatnotice.util;
+
+import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chatnotice.entity.ChatNotice;
+import com.poortorich.chatnotice.response.LatestNoticeResponse;
+
+public class ChatNoticeBuilder {
+
+    private static final int PREVIEW_MAX_LENGTH = 30;
+
+    public static LatestNoticeResponse buildLatestNoticeResponse(NoticeStatus status, ChatNotice notice) {
+        return LatestNoticeResponse.builder()
+                .status(status.toString())
+                .noticeId(notice.getId())
+                .preview(truncateContent(notice.getContent()))
+                .createdAt(notice.getCreatedDate().toString())
+                .authorNickname(notice.getAuthor().getNickname())
+                .build();
+    }
+
+    private static String truncateContent(String content) {
+        if (content.length() > PREVIEW_MAX_LENGTH) {
+            return content.substring(0, PREVIEW_MAX_LENGTH);
+        }
+
+        return content;
+    }
+}

--- a/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
+++ b/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
@@ -1,16 +1,14 @@
 package com.poortorich.chatnotice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.poortorich.chat.facade.ChatFacade;
 import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
 import com.poortorich.chatnotice.facade.ChatNoticeFacade;
 import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
+import com.poortorich.chatnotice.response.PreviewNoticesResponse;
 import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
 import com.poortorich.global.config.BaseSecurityTest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,26 +33,20 @@ class ChatNoticeControllerTest extends BaseSecurityTest {
 
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private ChatFacade chatFacade;
     @MockitoBean
     private ChatNoticeFacade chatNoticeFacade;
 
-    private ObjectMapper objectMapper;
-
-    @BeforeEach
-    void setUp() {
-        objectMapper = new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    }
+    private final String username = "test";
 
     @Test
-    @WithMockUser(username = "test")
+    @WithMockUser(username = username)
     @DisplayName("최신 공지 조회 성공")
     void getLatestNoticeSuccess() throws Exception {
-        String username = "test";
         Long chatroomId = 1L;
 
         when(chatNoticeFacade.getLatestNotice(username, chatroomId)).thenReturn(LatestNoticeResponse.builder().build());
@@ -68,7 +60,7 @@ class ChatNoticeControllerTest extends BaseSecurityTest {
     }
 
     @Test
-    @WithMockUser(username = "test")
+    @WithMockUser(username = username)
     @DisplayName("공지 상태 변경 성공")
     void updateNoticeStatusSuccess() throws Exception {
         long chatroomId = 1L;
@@ -85,7 +77,7 @@ class ChatNoticeControllerTest extends BaseSecurityTest {
     }
 
     @Test
-    @WithMockUser(username = "test")
+    @WithMockUser(username = username)
     @DisplayName("공지 상태 변경 입력값이 없는 경우 예외 발생")
     void updateNoticeStatusRequestNull() throws Exception {
         long chatroomId = 1L;
@@ -99,5 +91,20 @@ class ChatNoticeControllerTest extends BaseSecurityTest {
                 .andExpect(jsonPath("$.message")
                         .value(ChatNoticeResponseMessage.NOTICE_STATUS_REQUIRED)
                 );
+    }
+
+    @Test
+    @WithMockUser(username = username)
+    @DisplayName("최근 공지 목록 조회 성공")
+    void getPreviewNoticesSuccess() throws Exception {
+        Long chatroomId = 1L;
+
+        when(chatNoticeFacade.getPreviewNotices(chatroomId)).thenReturn(PreviewNoticesResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/notices/preview")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(ChatNoticeResponse.GET_PREVIEW_NOTICE_SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
+++ b/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
@@ -7,6 +7,7 @@ import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
+import com.poortorich.chatnotice.response.PreviewNoticesResponse;
 import com.poortorich.chatnotice.service.ChatNoticeService;
 import com.poortorich.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -110,5 +112,54 @@ class ChatNoticeFacadeTest {
         assertThat(result.getPreview()).hasSize(30);
         assertThat(result.getAuthorNickname()).isEqualTo(user.getNickname());
         assertThat(result.getCreatedAt()).isEqualTo(chatNotice.getCreatedDate().toString());
+    }
+
+    @Test
+    @DisplayName("최근 공지 목록 조회 성공")
+    void getPreviewNoticesSuccess() {
+        ChatNotice chatNotice2 = ChatNotice.builder()
+                .id(1L)
+                .chatroom(chatroom)
+                .author(user)
+                .content("공지 내용")
+                .createdDate(LocalDateTime.of(2025, 8, 8, 0, 0))
+                .build();
+
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(chatNoticeService.getPreviewNotices(chatroom)).thenReturn(List.of(chatNotice, chatNotice2));
+
+        PreviewNoticesResponse result = chatNoticeFacade.getPreviewNotices(chatroomId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getNotices()).hasSize(2);
+        assertThat(result.getNotices().get(0).getNoticeId()).isEqualTo(chatNotice.getId());
+        assertThat(result.getNotices().get(0).getPreview()).isEqualTo(chatNotice.getContent());
+        assertThat(result.getNotices().get(1).getNoticeId()).isEqualTo(chatNotice2.getId());
+        assertThat(result.getNotices().get(1).getPreview()).isEqualTo(chatNotice2.getContent());
+    }
+
+    @Test
+    @DisplayName("최근 공지 중 공지 내용이 30자 초과인 경우 30자만 표출")
+    void getPreviewNoticesPreviewTest() {
+        String preview = "코딩하다가 정신 차려보니 새벽 3시가 되었다. 피곤하지";
+        ChatNotice chatNotice2 = ChatNotice.builder()
+                .id(1L)
+                .chatroom(chatroom)
+                .author(user)
+                .content("코딩하다가 정신 차려보니 새벽 3시가 되었다. 피곤하지만 너무 재밌어서 멈출수가 없다.")
+                .createdDate(LocalDateTime.of(2025, 8, 8, 0, 0))
+                .build();
+
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(chatNoticeService.getPreviewNotices(chatroom)).thenReturn(List.of(chatNotice, chatNotice2));
+
+        PreviewNoticesResponse result = chatNoticeFacade.getPreviewNotices(chatroomId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getNotices()).hasSize(2);
+        assertThat(result.getNotices().get(0).getNoticeId()).isEqualTo(chatNotice.getId());
+        assertThat(result.getNotices().get(0).getPreview()).isEqualTo(chatNotice.getContent());
+        assertThat(result.getNotices().get(1).getNoticeId()).isEqualTo(chatNotice2.getId());
+        assertThat(result.getNotices().get(1).getPreview()).isEqualTo(preview);
     }
 }

--- a/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
+++ b/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,5 +52,24 @@ class ChatNoticeServiceTest {
         assertThatThrownBy(() -> chatNoticeService.getLatestNotice(chatroom))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining(ChatNoticeResponse.NOTICE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("최근 공지 목록 조회 성공")
+    void getPreviewNoticesSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatNotice chatNotice1 = ChatNotice.builder().chatroom(chatroom).build();
+        ChatNotice chatNotice2 = ChatNotice.builder().chatroom(chatroom).build();
+        ChatNotice chatNotice3 = ChatNotice.builder().chatroom(chatroom).build();
+
+        when(chatNoticeRepository.findTop3ByChatroomOrderByCreatedDateDesc(chatroom))
+                .thenReturn(List.of(chatNotice1, chatNotice2, chatNotice3));
+
+        List<ChatNotice> previewNotice = chatNoticeService.getPreviewNotices(chatroom);
+
+        assertThat(previewNotice).hasSize(3);
+        assertThat(previewNotice.get(0)).isEqualTo(chatNotice1);
+        assertThat(previewNotice.get(1)).isEqualTo(chatNotice2);
+        assertThat(previewNotice.get(2)).isEqualTo(chatNotice3);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#397
 
 ## 📝작업 내용
 
- 최근 공지 목록 조회
  - 채팅방 아이디로 채팅방 조회
  - 채팅방의 최근 공지 3개를 조회 후 전달
 
 ### 스크린샷

<img width="964" height="534" alt="image" src="https://github.com/user-attachments/assets/545cf0e5-d840-4add-8dd2-5383ff290bfa" />

> 최근 공지가 없는 경우 빈 데이터 전달
<img width="967" height="297" alt="image" src="https://github.com/user-attachments/assets/17354039-4c8c-4fe4-ad20-90b8fa7ad15e" />
