### PR TITLE
[#412] 이전 채팅 조회 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/realtime/event/user/UserProfileUpdatedEventListener.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/user/UserProfileUpdatedEventListener.java
@@ -5,16 +5,16 @@ import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.realtime.payload.response.UserUpdatedResponsePayload;
 import com.poortorich.chat.service.ChatParticipantService;
-import com.poortorich.s3.constants.S3Constants;
 import com.poortorich.user.entity.User;
 import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
-import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
@@ -32,16 +32,9 @@ public class UserProfileUpdatedEventListener {
             User user = participant.getUser();
             Chatroom chatroom = participant.getChatroom();
 
-            boolean isDefaultProfile = S3Constants.DEFAULT_PROFILES.contains(user.getProfileImage());
-            String profileImage = null;
-            if (!isDefaultProfile) {
-                profileImage = user.getProfileImage();
-            }
-
             var payload = UserUpdatedResponsePayload.builder()
                     .userId(participant.getUser().getId())
-                    .profileImage(profileImage)
-                    .isDefaultProfile(isDefaultProfile)
+                    .profileImage(user.getProfileImage())
                     .nickname(user.getNickname())
                     .isHost(Objects.equals(ChatroomRole.HOST, participant.getRole()))
                     .rankingType(participant.getRankingStatus())

--- a/src/main/java/com/poortorich/chat/realtime/payload/response/RankingStatusMessagePayload.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/response/RankingStatusMessagePayload.java
@@ -1,6 +1,7 @@
 package com.poortorich.chat.realtime.payload.response;
 
 import com.poortorich.chat.entity.enums.ChatMessageType;
+import com.poortorich.chat.entity.enums.MessageType;
 import com.poortorich.chat.model.ChatMessageResponse;
 import com.poortorich.chat.realtime.payload.interfaces.ResponsePayload;
 import lombok.Builder;
@@ -16,6 +17,7 @@ public class RankingStatusMessagePayload extends ChatMessageResponse implements 
     private Long chatroomId;
     private Boolean isRankingEnabled;
     private LocalDateTime sentAt;
+    private MessageType type;
 
     @Override
     public BasePayload mapToBasePayload() {

--- a/src/main/java/com/poortorich/chat/realtime/payload/response/UserUpdatedResponsePayload.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/response/UserUpdatedResponsePayload.java
@@ -12,7 +12,6 @@ public class UserUpdatedResponsePayload implements ResponsePayload {
 
     private final Long userId;
     private final String profileImage;
-    private final Boolean isDefaultProfile;
     private final String nickname;
     private final Boolean isHost;
     private final RankingStatus rankingType;

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatMessageMapper.java
@@ -34,6 +34,7 @@ public class ChatMessageMapper {
                 .messageId(chatMessage.getId())
                 .chatroomId(chatMessage.getChatroom().getId())
                 .isRankingEnabled(chatMessage.getIsRankingEnabled())
+                .type(chatMessage.getMessageType())
                 .sentAt(chatMessage.getSentAt())
                 .build();
     }


### PR DESCRIPTION
## #️⃣412
 
 ## 📝작업 내용
 
- 랭킹 상태 메시지에 type 필드를 추가
- 유저 프로필 변동에 따른 브로드캐스트 페이로드 필드 변경




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 랭킹 상태 메시지에 메시지 유형 필드가 추가되어 상태 구분과 표시가 더 명확해졌습니다.
* Refactor
  * 사용자 프로필 업데이트 알림에서 기본 프로필 여부 플래그가 제거되고, 프로필 이미지만 전송됩니다.
  * 관련 불필요한 분기가 정리되어 이벤트 전송이 단순화되었습니다.
  * 해당 플래그에 의존하던 클라이언트는 표시 로직을 업데이트해야 할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->