### PR TITLE
[#420] 공지 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/util/ChatBuilder.java
+++ b/src/main/java/com/poortorich/chat/util/ChatBuilder.java
@@ -110,7 +110,7 @@ public class ChatBuilder {
                 .build();
     }
 
-    private static ProfileResponse buildProfileResponse(ChatParticipant participantInfo) {
+    public static ProfileResponse buildProfileResponse(ChatParticipant participantInfo) {
         return ProfileResponse.builder()
                 .userId(participantInfo.getUser().getId())
                 .profileImage(participantInfo.getUser().getProfileImage())

--- a/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
+++ b/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
@@ -3,6 +3,7 @@ package com.poortorich.chatnotice.constants;
 public class ChatNoticeResponseMessage {
 
     public static final String GET_LATEST_NOTICE_SUCCESS = "최근 공지 조회를 완료했습니다.";
+    public static final String GET_NOTICE_DETAILS_SUCCESS = "공지를 성공적으로 조회했습니다.";
     public static final String UPDATE_NOTICE_STATUS_SUCCESS = "공지 상태 변경이 완료되었습니다.";
     public static final String GET_PREVIEW_NOTICE_SUCCESS = "최신 공지 목록 조회를 완료했습니다.";
 

--- a/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
+++ b/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
@@ -37,6 +37,14 @@ public class ChatNoticeController {
         );
     }
 
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<BaseResponse> getNoticeDetails(@PathVariable Long chatroomId, @PathVariable Long noticeId) {
+        return DataResponse.toResponseEntity(
+                ChatNoticeResponse.GET_NOTICE_DETAILS_SUCCESS,
+                chatNoticeFacade.getNoticeDetails(chatroomId, noticeId)
+        );
+    }
+
     @PatchMapping
     public ResponseEntity<BaseResponse> updateNoticeStatus(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/poortorich/chatnotice/entity/ChatNotice.java
+++ b/src/main/java/com/poortorich/chatnotice/entity/ChatNotice.java
@@ -52,6 +52,6 @@ public class ChatNotice {
     private ChatParticipant author;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chatroom_id")
+    @JoinColumn(name = "chatroom_id", nullable = false)
     private Chatroom chatroom;
 }

--- a/src/main/java/com/poortorich/chatnotice/entity/ChatNotice.java
+++ b/src/main/java/com/poortorich/chatnotice/entity/ChatNotice.java
@@ -1,7 +1,7 @@
 package com.poortorich.chatnotice.entity;
 
+import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
-import com.poortorich.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -49,7 +49,7 @@ public class ChatNotice {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id", nullable = false)
-    private User author;
+    private ChatParticipant author;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatroom_id")

--- a/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
+++ b/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
@@ -6,6 +6,7 @@ import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
+import com.poortorich.chatnotice.response.NoticeDetailsResponse;
 import com.poortorich.chatnotice.response.PreviewNoticesResponse;
 import com.poortorich.chatnotice.service.ChatNoticeService;
 import com.poortorich.chatnotice.util.ChatNoticeBuilder;
@@ -28,6 +29,13 @@ public class ChatNoticeFacade {
         ChatNotice notice = chatNoticeService.getLatestNotice(chatroom);
 
         return ChatNoticeBuilder.buildLatestNoticeResponse(chatParticipant.getNoticeStatus(), notice);
+    }
+
+    public NoticeDetailsResponse getNoticeDetails(Long chatroomId, Long noticeId) {
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+        ChatNotice notice = chatNoticeService.findNotice(chatroom, noticeId);
+
+        return ChatNoticeBuilder.buildNoticeDetailsResponse(notice);
     }
 
     public PreviewNoticesResponse getPreviewNotices(Long chatroomId) {

--- a/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
+++ b/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
@@ -12,6 +12,7 @@ import com.poortorich.chatnotice.service.ChatNoticeService;
 import com.poortorich.chatnotice.util.ChatNoticeBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -31,6 +32,7 @@ public class ChatNoticeFacade {
         return ChatNoticeBuilder.buildLatestNoticeResponse(chatParticipant.getNoticeStatus(), notice);
     }
 
+    @Transactional(readOnly = true)
     public NoticeDetailsResponse getNoticeDetails(Long chatroomId, Long noticeId) {
         Chatroom chatroom = chatroomService.findById(chatroomId);
         ChatNotice notice = chatNoticeService.findNotice(chatroom, noticeId);

--- a/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
+++ b/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
@@ -14,4 +14,6 @@ public interface ChatNoticeRepository extends JpaRepository<ChatNotice, Long> {
     Optional<ChatNotice> findTop1ByChatroomOrderByCreatedDateDesc(Chatroom chatroom);
 
     List<ChatNotice> findTop3ByChatroomOrderByCreatedDateDesc(Chatroom chatroom);
+
+    Optional<ChatNotice> findByChatroomAndId(Chatroom chatroom, Long noticeId);
 }

--- a/src/main/java/com/poortorich/chatnotice/response/NoticeDetailsResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/NoticeDetailsResponse.java
@@ -1,0 +1,19 @@
+package com.poortorich.chatnotice.response;
+
+import com.poortorich.chat.response.ProfileResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeDetailsResponse {
+
+    private Long noticeId;
+    private String content;
+    private String createdAt;
+    private ProfileResponse author;
+}

--- a/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ChatNoticeResponse implements Response {
 
     GET_LATEST_NOTICE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.GET_LATEST_NOTICE_SUCCESS, null),
+    GET_NOTICE_DETAILS_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.GET_NOTICE_DETAILS_SUCCESS, null),
     UPDATE_NOTICE_STATUS_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.UPDATE_NOTICE_STATUS_SUCCESS, null),
     GET_PREVIEW_NOTICE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.GET_PREVIEW_NOTICE_SUCCESS, null),
 

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -24,4 +24,9 @@ public class ChatNoticeService {
     public List<ChatNotice> getPreviewNotices(Chatroom chatroom) {
         return chatNoticeRepository.findTop3ByChatroomOrderByCreatedDateDesc(chatroom);
     }
+
+    public ChatNotice findNotice(Chatroom chatroom, Long noticeId) {
+        return chatNoticeRepository.findByChatroomAndId(chatroom, noticeId)
+                .orElseThrow(() -> new NotFoundException(ChatNoticeResponse.NOTICE_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
+++ b/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
@@ -1,8 +1,10 @@
 package com.poortorich.chatnotice.util;
 
 import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chat.util.ChatBuilder;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
+import com.poortorich.chatnotice.response.NoticeDetailsResponse;
 import com.poortorich.chatnotice.response.PreviewNoticeResponse;
 
 import java.util.List;
@@ -18,7 +20,7 @@ public class ChatNoticeBuilder {
                 .noticeId(notice.getId())
                 .preview(truncateContent(notice.getContent()))
                 .createdAt(notice.getCreatedDate().toString())
-                .authorNickname(notice.getAuthor().getNickname())
+                .authorNickname(notice.getAuthor().getUser().getNickname())
                 .build();
     }
 
@@ -38,5 +40,14 @@ public class ChatNoticeBuilder {
         }
 
         return content;
+    }
+
+    public static NoticeDetailsResponse buildNoticeDetailsResponse(ChatNotice notice) {
+        return NoticeDetailsResponse.builder()
+                .noticeId(notice.getId())
+                .content(notice.getContent())
+                .createdAt(notice.getCreatedDate().toString())
+                .author(ChatBuilder.buildProfileResponse(notice.getAuthor()))
+                .build();
     }
 }

--- a/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
+++ b/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
@@ -6,6 +6,7 @@ import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
 import com.poortorich.chatnotice.facade.ChatNoticeFacade;
 import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
+import com.poortorich.chatnotice.response.NoticeDetailsResponse;
 import com.poortorich.chatnotice.response.PreviewNoticesResponse;
 import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
 import com.poortorich.global.config.BaseSecurityTest;
@@ -106,5 +107,21 @@ class ChatNoticeControllerTest extends BaseSecurityTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
                         .value(ChatNoticeResponse.GET_PREVIEW_NOTICE_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @WithMockUser(username = username)
+    @DisplayName("공지 상세 조회 성공")
+    void getNoticeDetailsSuccess() throws Exception {
+        Long chatroomId = 1L;
+        Long noticeId = 1L;
+        when(chatNoticeFacade.getNoticeDetails(chatroomId, noticeId))
+                .thenReturn(NoticeDetailsResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/notices/" + noticeId)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(ChatNoticeResponse.GET_NOTICE_DETAILS_SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
+++ b/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
@@ -64,7 +64,7 @@ class ChatNoticeFacadeTest {
         chatNotice = ChatNotice.builder()
                 .id(1L)
                 .chatroom(chatroom)
-                .author(user)
+                .author(chatParticipant)
                 .content("공지 내용")
                 .createdDate(LocalDateTime.of(2025, 8, 8, 0, 0))
                 .build();
@@ -94,7 +94,7 @@ class ChatNoticeFacadeTest {
         chatNotice = ChatNotice.builder()
                 .id(1L)
                 .chatroom(chatroom)
-                .author(user)
+                .author(chatParticipant)
                 .content("코딩하다가 정신 차려보니 새벽 3시가 되었다. 피곤하지만 너무 재밌어서 멈출수가 없다.")
                 .createdDate(LocalDateTime.of(2025, 8, 8, 0, 0))
                 .build();
@@ -120,7 +120,7 @@ class ChatNoticeFacadeTest {
         ChatNotice chatNotice2 = ChatNotice.builder()
                 .id(2L)
                 .chatroom(chatroom)
-                .author(user)
+                .author(chatParticipant)
                 .content("공지 내용")
                 .createdDate(LocalDateTime.of(2025, 8, 8, 0, 0))
                 .build();
@@ -145,7 +145,7 @@ class ChatNoticeFacadeTest {
         ChatNotice chatNotice2 = ChatNotice.builder()
                 .id(2L)
                 .chatroom(chatroom)
-                .author(user)
+                .author(chatParticipant)
                 .content("코딩하다가 정신 차려보니 새벽 3시가 되었다. 피곤하지만 너무 재밌어서 멈출수가 없다.")
                 .createdDate(LocalDateTime.of(2025, 8, 8, 0, 0))
                 .build();

--- a/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
+++ b/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
@@ -2,11 +2,14 @@ package com.poortorich.chatnotice.facade;
 
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
+import com.poortorich.chatnotice.response.NoticeDetailsResponse;
 import com.poortorich.chatnotice.response.PreviewNoticesResponse;
 import com.poortorich.chatnotice.service.ChatNoticeService;
 import com.poortorich.user.entity.User;
@@ -59,6 +62,8 @@ class ChatNoticeFacadeTest {
                 .user(user)
                 .chatroom(chatroom)
                 .noticeStatus(NoticeStatus.DEFAULT)
+                .role(ChatroomRole.HOST)
+                .rankingStatus(RankingStatus.NONE)
                 .build();
 
         chatNotice = ChatNotice.builder()
@@ -185,5 +190,23 @@ class ChatNoticeFacadeTest {
         LatestNoticeResponse result = chatNoticeFacade.getLatestNotice(username, chatroomId);
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("공지 상세 조회 성공")
+    void getNoticeDetailsSuccess() {
+        Long noticeId = 1L;
+
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(chatNoticeService.findNotice(chatroom, noticeId)).thenReturn(chatNotice);
+
+        NoticeDetailsResponse result = chatNoticeFacade.getNoticeDetails(chatroomId, noticeId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getNoticeId()).isEqualTo(noticeId);
+        assertThat(result.getContent()).isEqualTo(chatNotice.getContent());
+        assertThat(result.getCreatedAt()).isEqualTo(chatNotice.getCreatedDate().toString());
+        assertThat(result.getAuthor().getUserId()).isEqualTo(user.getId());
+        assertThat(result.getAuthor().getNickname()).isEqualTo(user.getNickname());
     }
 }

--- a/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
+++ b/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
@@ -72,4 +72,35 @@ class ChatNoticeServiceTest {
         assertThat(previewNotice.get(1)).isEqualTo(chatNotice2);
         assertThat(previewNotice.get(2)).isEqualTo(chatNotice3);
     }
+
+    @Test
+    @DisplayName("채팅방과 아이디로 공지 조회 성공")
+    void findNoticeSuccess() {
+        Long noticeId = 1L;
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatNotice chatNotice = ChatNotice.builder()
+                .id(noticeId)
+                .chatroom(chatroom)
+                .build();
+
+        when(chatNoticeRepository.findByChatroomAndId(chatroom, noticeId)).thenReturn(Optional.of(chatNotice));
+
+        ChatNotice result = chatNoticeService.findNotice(chatroom, noticeId);
+
+        assertThat(result.getId()).isEqualTo(noticeId);
+        assertThat(result.getChatroom()).isEqualTo(chatroom);
+    }
+
+    @Test
+    @DisplayName("공지가 없는 경우 예외 발생")
+    void findNoticeNotFound() {
+        Long noticeId = 1L;
+        Chatroom chatroom = Chatroom.builder().build();
+
+        when(chatNoticeRepository.findByChatroomAndId(chatroom, noticeId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chatNoticeService.findNotice(chatroom, noticeId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining(ChatNoticeResponse.NOTICE_NOT_FOUND.getMessage());
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#420
 
 ## 📝작업 내용

- 공지 상세조회
  - 채팅방과 공지 아이디로 공지를 조회한 후 공지와 작성자를 응답으로 반환
 
 ### 스크린샷

<img width="1043" height="256" alt="image" src="https://github.com/user-attachments/assets/7252f0a6-7401-4981-93ff-632830914817" />
<img width="1042" height="457" alt="image" src="https://github.com/user-attachments/assets/1b4ed2d1-806b-40c3-88ab-6b76c433e3c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 공지 상세 조회 엔드포인트 추가(/chatrooms/{chatroomId}/notices/{noticeId}): 공지 본문, 생성일시, 작성자 프로필을 확인할 수 있습니다.
  - 공지 상세 응답용 DTO 및 성공 메시지 추가로 응답이 명확해졌습니다.

- **Bug Fixes / 개선**
  - 존재하지 않는 공지 요청에 대해 적절한 404형 오류 응답을 반환하도록 처리 강화했습니다.

- **기타**
  - 공지 작성자 정보가 채팅 참가자 단위로 정리되어 작성자 프로필 표시가 일관성 있게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->