### PR TITLE
[#416] 채팅방 입장 api 직렬화 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/request/ChatroomEnterRequest.java
+++ b/src/main/java/com/poortorich/chat/request/ChatroomEnterRequest.java
@@ -1,11 +1,15 @@
 package com.poortorich.chat.request;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChatroomEnterRequest {
 
-    private final String chatroomPassword;
+    private String chatroomPassword;
 }

--- a/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatroomValidator.java
@@ -9,9 +9,11 @@ import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.ConflictException;
 import com.poortorich.global.exceptions.ForbiddenException;
 import com.poortorich.user.entity.User;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -38,7 +40,7 @@ public class ChatroomValidator {
 
     public void validatePassword(Chatroom chatroom, String password) {
         String chatroomPassword = chatroom.getPassword();
-        if (chatroomPassword != null && !password.equals(chatroomPassword)) {
+        if (!Objects.equals(chatroomPassword, password)) {
             throw new BadRequestException(ChatResponse.CHATROOM_PASSWORD_DO_NOT_MATCH);
         }
     }


### PR DESCRIPTION
## #️⃣416
 
 ## 📝작업 내용
 
채팅 직렬화 오류를 수정하였음, 필드를 명시적으로 추가하지 않아도 api가 작동하도록 함
 
 ### 스크린샷 (선택)
 
<img width="602" height="787" alt="image" src="https://github.com/user-attachments/assets/884b1a8d-b251-4c4f-aa16-6db5ba96d4b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 비밀번호가 없는 채팅방 입장 검증을 수정했습니다. 이제 비밀번호가 없는 방에는 비밀번호 입력란을 비워야만 입장할 수 있으며, 임의의 비밀번호 입력은 거부됩니다.
- Refactor
  - 채팅방 입장 요청의 JSON에서 비어 있는 값(null)이 제외되어, 불필요한 데이터 전송을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->