### PR TITLE
[#423] 채팅방 공지 추가/수정/삭제 발행

### DIFF
--- a/src/main/java/com/poortorich/chat/realtime/controller/ChatRealtimeController.java
+++ b/src/main/java/com/poortorich/chat/realtime/controller/ChatRealtimeController.java
@@ -2,6 +2,7 @@ package com.poortorich.chat.realtime.controller;
 
 import com.poortorich.chat.realtime.facade.ChatRealTimeFacade;
 import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
+import com.poortorich.chat.realtime.payload.request.ChatNoticeRequestPayload;
 import com.poortorich.chat.realtime.payload.request.MarkMessagesAsReadRequestPayload;
 import com.poortorich.chat.realtime.payload.response.BasePayload;
 import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
@@ -45,6 +46,17 @@ public class ChatRealtimeController {
     ) {
         String username = sessionManager.getUsername(accessor);
         BasePayload responsePayload = chatRealTimeFacade.markMessagesAsRead(username, requestPayload);
+
+        messagingTemplate.convertAndSend(
+                SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + requestPayload.getChatroomId(),
+                responsePayload
+        );
+    }
+
+    @MessageMapping("/chat/notice")
+    public void handleChatNotice(StompHeaderAccessor accessor, @Payload @Valid ChatNoticeRequestPayload requestPayload) {
+        String username = sessionManager.getUsername(accessor);
+        BasePayload responsePayload = chatRealTimeFacade.handleChatNotice(username, requestPayload);
 
         messagingTemplate.convertAndSend(
                 SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + requestPayload.getChatroomId(),

--- a/src/main/java/com/poortorich/chat/realtime/controller/ChatRealtimeController.java
+++ b/src/main/java/com/poortorich/chat/realtime/controller/ChatRealtimeController.java
@@ -53,7 +53,7 @@ public class ChatRealtimeController {
         );
     }
 
-    @MessageMapping("/chat/notice")
+    @MessageMapping("/chat/notices")
     public void handleChatNotice(StompHeaderAccessor accessor, @Payload @Valid ChatNoticeRequestPayload requestPayload) {
         String username = sessionManager.getUsername(accessor);
         BasePayload responsePayload = chatRealTimeFacade.handleChatNotice(username, requestPayload);

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -127,11 +128,18 @@ public class ChatRealTimeFacade {
         participantValidator.validateIsHost(context.chatParticipant());
         ChatNotice chatNotice = chatNoticeService.handleChatNotice(context, requestPayload);
 
+        if (Objects.isNull(chatNotice)) {
+            return BasePayload.builder()
+                    .type(PayloadType.NOTICE)
+                    .payload(null)
+                    .build();
+        }
+
         List<ChatParticipant> chatParticipants = chatParticipantService.findAllByChatroom(context.chatroom());
         NoticeStatus noticeStatus = chatParticipantService.updateAllNoticeStatus(
                 chatParticipants,
                 requestPayload.getNoticeType());
-
+        
         return BasePayload.builder()
                 .type(PayloadType.NOTICE)
                 .payload(ChatNoticeBuilder.buildLatestNoticeResponse(noticeStatus, chatNotice))

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -3,23 +3,29 @@ package com.poortorich.chat.realtime.facade;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatMessageType;
+import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.model.MarkAllChatroomAsReadResult;
 import com.poortorich.chat.realtime.collect.ChatPayloadCollector;
 import com.poortorich.chat.realtime.model.PayloadContext;
 import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
+import com.poortorich.chat.realtime.payload.request.ChatNoticeRequestPayload;
 import com.poortorich.chat.realtime.payload.request.MarkMessagesAsReadRequestPayload;
 import com.poortorich.chat.realtime.payload.response.BasePayload;
 import com.poortorich.chat.realtime.payload.response.MessageReadPayload;
 import com.poortorich.chat.realtime.payload.response.RankingStatusMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserChatMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserEnterResponsePayload;
+import com.poortorich.chat.realtime.payload.response.enums.PayloadType;
 import com.poortorich.chat.response.MarkAllChatroomAsReadResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.service.UnreadChatMessageService;
-import com.poortorich.chat.util.detector.RankingStatusChangeDetector;
 import com.poortorich.chat.util.manager.ChatroomLeaveManager;
+import com.poortorich.chat.validator.ChatParticipantValidator;
+import com.poortorich.chatnotice.entity.ChatNotice;
+import com.poortorich.chatnotice.service.ChatNoticeService;
+import com.poortorich.chatnotice.util.ChatNoticeBuilder;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -37,10 +43,11 @@ public class ChatRealTimeFacade {
     private final ChatMessageService chatMessageService;
     private final ChatParticipantService chatParticipantService;
     private final UnreadChatMessageService unreadChatMessageService;
-
+    private final ChatNoticeService chatNoticeService;
     private final ChatPayloadCollector payloadCollector;
     private final ChatroomLeaveManager chatroomLeaveManager;
-    private final RankingStatusChangeDetector rankingStatusChangeDetector;
+
+    private final ChatParticipantValidator participantValidator;
 
     public BasePayload createUserEnterSystemMessage(String username, Long chatroomId) {
         User user = userService.findUserByUsername(username);
@@ -110,6 +117,24 @@ public class ChatRealTimeFacade {
         return MarkAllChatroomAsReadResult.builder()
                 .apiResponse(MarkAllChatroomAsReadResponse.builder().chatroomIds(chatroomIds).build())
                 .broadcastPayloads(broadcastPayloads)
+                .build();
+    }
+
+    @Transactional
+    public BasePayload handleChatNotice(String username, ChatNoticeRequestPayload requestPayload) {
+        PayloadContext context = payloadCollector.getPayloadContext(username, requestPayload.getChatroomId());
+
+        participantValidator.validateIsHost(context.chatParticipant());
+        ChatNotice chatNotice = chatNoticeService.handleChatNotice(context, requestPayload);
+
+        List<ChatParticipant> chatParticipants = chatParticipantService.findAllByChatroom(context.chatroom());
+        NoticeStatus noticeStatus = chatParticipantService.updateAllNoticeStatus(
+                chatParticipants,
+                requestPayload.getNoticeType());
+
+        return BasePayload.builder()
+                .type(PayloadType.NOTICE)
+                .payload(ChatNoticeBuilder.buildLatestNoticeResponse(noticeStatus, chatNotice))
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/chat/realtime/payload/request/ChatNoticeRequestPayload.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/request/ChatNoticeRequestPayload.java
@@ -1,0 +1,21 @@
+package com.poortorich.chat.realtime.payload.request;
+
+import com.poortorich.chat.constants.ChatResponseMessage;
+import com.poortorich.chat.realtime.payload.request.enums.NoticeType;
+import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatNoticeRequestPayload {
+
+    @NotNull(message = ChatResponseMessage.CHATROOM_ID_REQUIRED)
+    private final Long chatroomId;
+
+    private final String content;
+
+    @NotNull(message = ChatNoticeResponseMessage.NOTICE_TYPE_REQUIRED)
+    private final NoticeType noticeType;
+}

--- a/src/main/java/com/poortorich/chat/realtime/payload/request/enums/NoticeType.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/request/enums/NoticeType.java
@@ -1,0 +1,7 @@
+package com.poortorich.chat.realtime.payload.request.enums;
+
+public enum NoticeType {
+    CREATE,
+    UPDATE,
+    DELETE
+}

--- a/src/main/java/com/poortorich/chat/realtime/payload/response/enums/PayloadType.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/response/enums/PayloadType.java
@@ -3,5 +3,7 @@ package com.poortorich.chat.realtime.payload.response.enums;
 import com.poortorich.websocket.payload.interfaces.EventType;
 
 public enum PayloadType implements EventType {
+
+    NOTICE,
     USER_UPDATED
 }

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -4,6 +4,7 @@ import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chat.realtime.payload.request.enums.NoticeType;
 import com.poortorich.chat.repository.ChatParticipantRepository;
 import com.poortorich.chat.response.ChatParticipantProfile;
 import com.poortorich.chat.response.enums.ChatResponse;
@@ -134,5 +135,18 @@ public class ChatParticipantService {
         return chatParticipantRepository.findAllByChatroomAndIsParticipatedTrueAndUserNot(chatroom, user).stream()
                 .filter(chatParticipant -> !activeSubscribers.contains(chatParticipant.getUser().getUsername()))
                 .toList();
+    }
+
+    public NoticeStatus updateAllNoticeStatus(List<ChatParticipant> chatParticipants, NoticeType noticeType) {
+        NoticeStatus noticeStatus = findByNoticeType(noticeType);
+        chatParticipants.forEach(chatParticipant -> chatParticipant.updateNoticeStatus(noticeStatus));
+        return noticeStatus;
+    }
+
+    private NoticeStatus findByNoticeType(NoticeType noticeType) {
+        return switch (noticeType) {
+            case CREATE, UPDATE -> NoticeStatus.DEFAULT;
+            case DELETE -> NoticeStatus.PERMANENT_HIDDEN;
+        };
     }
 }

--- a/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
@@ -31,6 +31,12 @@ public class ChatParticipantValidator {
         }
     }
 
+    public void validateIsHost(ChatParticipant chatParticipant) {
+        if (!ChatroomRole.HOST.equals(chatParticipant.getRole())) {
+            throw new BadRequestException(ChatResponse.CHAT_PARTICIPANT_NOT_HOST);
+        }
+    }
+
     // TODO: 채팅방에서 역할이 멤버가 아니라면 예외를 발생
     public void validateIsMember(User user, Chatroom chatroom) {
     }

--- a/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
+++ b/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
@@ -10,6 +10,7 @@ public class ChatNoticeResponseMessage {
     public static final String NOTICE_STATUS_INVALID = "공지 상태가 적절하지 않습니다.";
 
     public static final String NOTICE_NOT_FOUND = "공지를 찾을 수 없습니다.";
+    public static final String NOTICE_TYPE_REQUIRED = "공지 처리 유형은 필수 값입니다.";
 
     private ChatNoticeResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
+++ b/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
@@ -11,6 +11,7 @@ public class ChatNoticeResponseMessage {
 
     public static final String NOTICE_NOT_FOUND = "공지를 찾을 수 없습니다.";
     public static final String NOTICE_TYPE_REQUIRED = "공지 처리 유형은 필수 값입니다.";
+    public static final String NOTICE_CONTENT_REQUIRED = "공지 내용이 없습니다.";
 
     private ChatNoticeResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chatnotice/entity/ChatNotice.java
+++ b/src/main/java/com/poortorich/chatnotice/entity/ChatNotice.java
@@ -54,4 +54,8 @@ public class ChatNotice {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatroom_id")
     private Chatroom chatroom;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
@@ -13,7 +13,8 @@ public enum ChatNoticeResponse implements Response {
     GET_PREVIEW_NOTICE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.GET_PREVIEW_NOTICE_SUCCESS, null),
 
     NOTICE_STATUS_INVALID(HttpStatus.BAD_REQUEST, ChatNoticeResponseMessage.NOTICE_STATUS_INVALID, "status"),
-    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, ChatNoticeResponseMessage.NOTICE_NOT_FOUND, null);
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, ChatNoticeResponseMessage.NOTICE_NOT_FOUND, null),
+    CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, ChatNoticeResponseMessage.NOTICE_CONTENT_REQUIRED, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -5,6 +5,8 @@ import com.poortorich.chat.realtime.model.PayloadContext;
 import com.poortorich.chat.realtime.payload.request.ChatNoticeRequestPayload;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.repository.ChatNoticeRepository;
+import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
+import com.poortorich.global.exceptions.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +21,10 @@ public class ChatNoticeService {
     private final ChatNoticeRepository chatNoticeRepository;
 
     public ChatNotice create(PayloadContext context, ChatNoticeRequestPayload requestPayload) {
+        if (Objects.isNull(requestPayload.getContent())) {
+            throw new BadRequestException(ChatNoticeResponse.CONTENT_REQUIRED);
+        }
+
         ChatNotice notice = ChatNotice.builder()
                 .content(requestPayload.getContent())
                 .author(context.user())

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -1,20 +1,32 @@
 package com.poortorich.chatnotice.service;
 
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.realtime.model.PayloadContext;
+import com.poortorich.chat.realtime.payload.request.ChatNoticeRequestPayload;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.repository.ChatNoticeRepository;
-import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
-import com.poortorich.global.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ChatNoticeService {
 
     private final ChatNoticeRepository chatNoticeRepository;
+
+    public ChatNotice create(PayloadContext context, ChatNoticeRequestPayload requestPayload) {
+        ChatNotice notice = ChatNotice.builder()
+                .content(requestPayload.getContent())
+                .author(context.user())
+                .chatroom(context.chatroom())
+                .build();
+
+        return chatNoticeRepository.save(notice);
+    }
 
     public ChatNotice getLatestNotice(Chatroom chatroom) {
         return chatNoticeRepository.findTop1ByChatroomOrderByCreatedDateDesc(chatroom)
@@ -23,5 +35,32 @@ public class ChatNoticeService {
 
     public List<ChatNotice> getPreviewNotices(Chatroom chatroom) {
         return chatNoticeRepository.findTop3ByChatroomOrderByCreatedDateDesc(chatroom);
+    }
+
+    public ChatNotice update(PayloadContext context, ChatNoticeRequestPayload requestPayload) {
+        ChatNotice chatNotice = chatNoticeRepository.findTop1ByChatroomOrderByCreatedDateDesc(context.chatroom())
+                .orElse(null);
+
+        if (Objects.isNull(chatNotice)) {
+            return chatNotice;
+        }
+
+        chatNotice.updateContent(requestPayload.getContent());
+
+        return chatNoticeRepository.save(chatNotice);
+    }
+
+    public ChatNotice handleChatNotice(PayloadContext context, ChatNoticeRequestPayload requestPayload) {
+        return switch (requestPayload.getNoticeType()) {
+            case CREATE -> create(context, requestPayload);
+            case UPDATE -> update(context, requestPayload);
+            case DELETE -> delete(context);
+        };
+    }
+
+    public ChatNotice delete(PayloadContext context) {
+        Optional<ChatNotice> chatNotice = chatNoticeRepository.findTop1ByChatroomOrderByCreatedDateDesc(context.chatroom());
+        chatNotice.ifPresent(chatNoticeRepository::delete);
+        return null;
     }
 }

--- a/src/main/java/com/poortorich/websocket/stomp/command/publish/endpoint/PublishEndpoint.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/publish/endpoint/PublishEndpoint.java
@@ -6,8 +6,10 @@ public class PublishEndpoint {
 
     public static final String CHAT_MESSAGE_PUBLISH_PREFIX = "/pub/chat/messages";
     public static final String CHAT_MESSAGE_READ_PUBLISH_PREFIX = "/pub/chat/read";
+    public static final String CHAT_NOTICE_PUBLISH_PREFIX = "/pub/chat/notices";
 
     public static final List<String> PUBLISH_PREFIXES = List.of(
             CHAT_MESSAGE_PUBLISH_PREFIX,
-            CHAT_MESSAGE_READ_PUBLISH_PREFIX);
+            CHAT_MESSAGE_READ_PUBLISH_PREFIX,
+            CHAT_NOTICE_PUBLISH_PREFIX);
 }


### PR DESCRIPTION
## #️⃣423
 
 ## 📝작업 내용
 - 채팅방 공지를 추가, 수정, 삭제를 발행하는 로직을 추가했습니다.
 - 공지 추가 및 수정 시
   - 모든 참여자의 공지 상태를 `DEFAULT`로 수정하고 공지 내용을 브로드캐스트합니다.
 - 공지 삭제
   - 모든 참여자의 공지 상태를 `PERMANENT_HIDDEN`으로 수정하고 공지 내용을 브로드캐스트합니다.(이때 null로 제공됨)
     -  공지 상태 변경 이유는 이전에 작성했던 공지가 REST API를 통해 조회되는 것을 방지하기 위함입니다.
     
 ### 스크린샷 (선택)
 
<img width="1022" height="60" alt="image" src="https://github.com/user-attachments/assets/0bffd224-121a-4133-a5a1-1481c5d8995e" />
<img width="1460" height="88" alt="image" src="https://github.com/user-attachments/assets/851c7cb6-7461-4e52-bd06-ff876832086b" />

<img width="1454" height="300" alt="image" src="https://github.com/user-attachments/assets/2812e7f9-1126-4bcc-af13-179f2fc8bc1d" />
<img width="1193" height="297" alt="image" src="https://github.com/user-attachments/assets/63121a1f-480e-4051-891c-be2193f5d00e" />

 ## 💬리뷰 요구사항(선택)
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채팅방 공지의 생성·수정·삭제 실시간 처리 추가.
  * 클라이언트에 NOTICE 이벤트로 공지 즉시 브로드캐스트하여 최신 공지 반영.
  * 클라이언트에서 공지 수신 및 처리 가능하도록 NOTICE 이벤트 타입 도입.
  * 공지 게시 권한(방장) 검증 및 필수 입력값(방ID, 처리유형) 유효성 강화.
  * 참여자들의 공지 표시 상태를 일괄 갱신해 UI 일관성 개선.
  * 새 발행 경로(/pub/chat/notices) 지원.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->