### PR TITLE
[#428] 실시간 읽음 처리 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/websocket/stomp/command/subscribe/handler/StompSubscribeHandler.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/subscribe/handler/StompSubscribeHandler.java
@@ -47,6 +47,6 @@ public class StompSubscribeHandler {
         chatroomValidator.validateSubscribe(user, chatroom);
         log.info("[SUBSCRIBE]: 유저 `{}`가 채팅방[{}] 구독 완료", username, chatroom.getId());
 
-        subscribeService.subscribe(chatroomId, username);
+        subscribeService.subscribe(chatroomId, username, accessor.getSessionId(), accessor.getSubscriptionId());
     }
 }

--- a/src/main/java/com/poortorich/websocket/stomp/command/unsubscribe/handler/StompUnsubscribeHandler.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/unsubscribe/handler/StompUnsubscribeHandler.java
@@ -1,6 +1,5 @@
 package com.poortorich.websocket.stomp.command.unsubscribe.handler;
 
-import com.poortorich.websocket.stomp.command.subscribe.util.SubscribeEndpointExtractor;
 import com.poortorich.websocket.stomp.command.subscribe.validator.SubscribeValidator;
 import com.poortorich.websocket.stomp.service.SubscribeService;
 import com.poortorich.websocket.stomp.util.StompSessionManager;
@@ -15,15 +14,13 @@ import org.springframework.stereotype.Component;
 public class StompUnsubscribeHandler {
 
     private final SubscribeValidator subscribeValidator;
-    private final SubscribeEndpointExtractor endpointExtractor;
     private final StompSessionManager sessionManager;
     private final SubscribeService subscribeService;
 
     public void handle(StompHeaderAccessor accessor) {
         subscribeValidator.validateEndPoint(accessor);
-        Long chatroomId = endpointExtractor.getChatroomId(accessor.getDestination());
         String username = sessionManager.getUsername(accessor);
 
-        subscribeService.unsubscribe(chatroomId, username);
+        subscribeService.unsubscribe(username, accessor.getSessionId(), accessor.getSubscriptionId());
     }
 }


### PR DESCRIPTION
## #️⃣428
 
 ## 📝작업 내용
 - 실시간 읽음 처리 로직 수정
 - UNSUBSCRIBE시 Destination 없이 subscription-id로만 구독 해제를 진행함
 - 따라서 subscription-id로 채팅방 아이디를 조회하도록 수정
 
