### PR TITLE
[#427] 전체 공지 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
+++ b/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
@@ -2,6 +2,7 @@ package com.poortorich.chatnotice.constants;
 
 public class ChatNoticeResponseMessage {
 
+    public static final String GET_ALL_NOTICES_SUCCESS = "전체 공지 목록 조회를 완료했습니다.";
     public static final String GET_LATEST_NOTICE_SUCCESS = "최근 공지 조회를 완료했습니다.";
     public static final String GET_NOTICE_DETAILS_SUCCESS = "공지를 성공적으로 조회했습니다.";
     public static final String UPDATE_NOTICE_STATUS_SUCCESS = "공지 상태 변경이 완료되었습니다.";

--- a/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
+++ b/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
@@ -24,13 +24,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChatNoticeController {
 
+    private static final String DEFAULT_VALUE = "" + Long.MAX_VALUE;
+
     private final ChatFacade chatFacade;
     private final ChatNoticeFacade chatNoticeFacade;
 
     @GetMapping("/all")
     public ResponseEntity<BaseResponse> getAllNotices(
             @PathVariable Long chatroomId,
-            @RequestParam(defaultValue = "" + Long.MAX_VALUE) Long cursor
+            @RequestParam(defaultValue = DEFAULT_VALUE) Long cursor
     ) {
         return DataResponse.toResponseEntity(
                 ChatNoticeResponse.GET_ALL_NOTICES_SUCCESS,

--- a/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
+++ b/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,6 +26,17 @@ public class ChatNoticeController {
 
     private final ChatFacade chatFacade;
     private final ChatNoticeFacade chatNoticeFacade;
+
+    @GetMapping("/all")
+    public ResponseEntity<BaseResponse> getAllNotices(
+            @PathVariable Long chatroomId,
+            @RequestParam(defaultValue = "" + Long.MAX_VALUE) Long cursor
+    ) {
+        return DataResponse.toResponseEntity(
+                ChatNoticeResponse.GET_ALL_NOTICES_SUCCESS,
+                chatNoticeFacade.getAllNotices(chatroomId, cursor)
+        );
+    }
 
     @GetMapping
     public ResponseEntity<BaseResponse> getLatestNotice(

--- a/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
+++ b/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
@@ -36,19 +36,22 @@ public class ChatNoticeFacade {
         Pageable pageable = PageRequest.of(0, PAGEABLE_SIZE);
         Slice<ChatNotice> chatNotices = chatNoticeService.getAllNoticeByCursor(chatroom, cursor, pageable);
 
+        List<ChatNotice> contents = chatNotices.getContent();
+        Long lastId = contents.isEmpty() ? null : contents.getLast().getId();
+
         return ChatNoticeBuilder.buildAllNoticesResponse(
                 chatNotices.hasNext(),
-                getNextCursor(chatNotices.hasNext(), chatNotices.getContent().getLast().getId()),
-                chatNotices.getContent()
+                getNextCursor(chatNotices.hasNext(), lastId),
+                contents.isEmpty() ? null : contents
         );
     }
 
-    private Long getNextCursor(Boolean hasNext, Long lastContentId) {
-        if (hasNext == false) {
+    private Long getNextCursor(Boolean hasNext, Long lastId) {
+        if (!hasNext) {
             return null;
         }
 
-        return lastContentId - 1;
+        return lastId;
     }
 
     public LatestNoticeResponse getLatestNotice(String username, Long chatroomId) {

--- a/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
+++ b/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
@@ -5,12 +5,16 @@ import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chatnotice.entity.ChatNotice;
+import com.poortorich.chatnotice.response.AllNoticesResponse;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
 import com.poortorich.chatnotice.response.NoticeDetailsResponse;
 import com.poortorich.chatnotice.response.PreviewNoticesResponse;
 import com.poortorich.chatnotice.service.ChatNoticeService;
 import com.poortorich.chatnotice.util.ChatNoticeBuilder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,9 +24,32 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ChatNoticeFacade {
 
+    private static final int PAGEABLE_SIZE = 20;
+
     private final ChatroomService chatroomService;
     private final ChatParticipantService chatParticipantService;
     private final ChatNoticeService chatNoticeService;
+
+    public AllNoticesResponse getAllNotices(Long chatroomId, Long cursor) {
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+
+        Pageable pageable = PageRequest.of(0, PAGEABLE_SIZE);
+        Slice<ChatNotice> chatNotices = chatNoticeService.getAllNoticeByCursor(chatroom, cursor, pageable);
+
+        return ChatNoticeBuilder.buildAllNoticesResponse(
+                chatNotices.hasNext(),
+                getNextCursor(chatNotices.hasNext(), chatNotices.getContent().getLast().getId()),
+                chatNotices.getContent()
+        );
+    }
+
+    private Long getNextCursor(Boolean hasNext, Long lastContentId) {
+        if (hasNext == false) {
+            return null;
+        }
+
+        return lastContentId - 1;
+    }
 
     public LatestNoticeResponse getLatestNotice(String username, Long chatroomId) {
         Chatroom chatroom = chatroomService.findById(chatroomId);

--- a/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
+++ b/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface ChatNoticeRepository extends JpaRepository<ChatNotice, Long> {
 
-    Slice<ChatNotice> findByChatroomAndIdLessThanEqualOrderByIdDesc(Chatroom chatroom, Long cursor, Pageable pageable);
+    Slice<ChatNotice> findByChatroomAndIdLessThanOrderByIdDesc(Chatroom chatroom, Long cursor, Pageable pageable);
 
     Optional<ChatNotice> findTop1ByChatroomOrderByCreatedDateDesc(Chatroom chatroom);
 

--- a/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
+++ b/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
@@ -2,6 +2,8 @@ package com.poortorich.chatnotice.repository;
 
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chatnotice.entity.ChatNotice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +12,8 @@ import java.util.Optional;
 
 @Repository
 public interface ChatNoticeRepository extends JpaRepository<ChatNotice, Long> {
+
+    Slice<ChatNotice> findByChatroomAndIdLessThanEqualOrderByIdDesc(Chatroom chatroom, Long cursor, Pageable pageable);
 
     Optional<ChatNotice> findTop1ByChatroomOrderByCreatedDateDesc(Chatroom chatroom);
 

--- a/src/main/java/com/poortorich/chatnotice/response/AllNoticesResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/AllNoticesResponse.java
@@ -1,0 +1,19 @@
+package com.poortorich.chatnotice.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AllNoticesResponse {
+
+    private Boolean hasNext;
+    private Long nextCursor;
+    private List<NoticeResponse> notices;
+}

--- a/src/main/java/com/poortorich/chatnotice/response/NoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/NoticeResponse.java
@@ -1,0 +1,18 @@
+package com.poortorich.chatnotice.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeResponse {
+
+    private Long noticeId;
+    private String preview;
+    private String authorNickname;
+    private String createdAt;
+}

--- a/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ChatNoticeResponse implements Response {
 
+    GET_ALL_NOTICES_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.GET_ALL_NOTICES_SUCCESS, null),
     GET_LATEST_NOTICE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.GET_LATEST_NOTICE_SUCCESS, null),
     GET_NOTICE_DETAILS_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.GET_NOTICE_DETAILS_SUCCESS, null),
     UPDATE_NOTICE_STATUS_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.UPDATE_NOTICE_STATUS_SUCCESS, null),

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -9,6 +9,8 @@ import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -33,6 +35,10 @@ public class ChatNoticeService {
                 .build();
 
         return chatNoticeRepository.save(notice);
+    }
+
+    public Slice<ChatNotice> getAllNoticeByCursor(Chatroom chatroom, Long cursor, Pageable pageable) {
+        return chatNoticeRepository.findByChatroomAndIdLessThanEqualOrderByIdDesc(chatroom, cursor, pageable);
     }
 
     public ChatNotice getLatestNotice(Chatroom chatroom) {

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -38,7 +38,7 @@ public class ChatNoticeService {
     }
 
     public Slice<ChatNotice> getAllNoticeByCursor(Chatroom chatroom, Long cursor, Pageable pageable) {
-        return chatNoticeRepository.findByChatroomAndIdLessThanEqualOrderByIdDesc(chatroom, cursor, pageable);
+        return chatNoticeRepository.findByChatroomAndIdLessThanOrderByIdDesc(chatroom, cursor, pageable);
     }
 
     public ChatNotice getLatestNotice(Chatroom chatroom) {

--- a/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
+++ b/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
@@ -3,8 +3,10 @@ package com.poortorich.chatnotice.util;
 import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.util.ChatBuilder;
 import com.poortorich.chatnotice.entity.ChatNotice;
+import com.poortorich.chatnotice.response.AllNoticesResponse;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
 import com.poortorich.chatnotice.response.NoticeDetailsResponse;
+import com.poortorich.chatnotice.response.NoticeResponse;
 import com.poortorich.chatnotice.response.PreviewNoticeResponse;
 
 import java.util.List;
@@ -38,14 +40,6 @@ public class ChatNoticeBuilder {
                 .toList();
     }
 
-    private static String truncateContent(String content) {
-        if (content.length() > PREVIEW_MAX_LENGTH) {
-            return content.substring(0, PREVIEW_MAX_LENGTH);
-        }
-
-        return content;
-    }
-
     public static NoticeDetailsResponse buildNoticeDetailsResponse(ChatNotice notice) {
         return NoticeDetailsResponse.builder()
                 .noticeId(notice.getId())
@@ -53,5 +47,13 @@ public class ChatNoticeBuilder {
                 .createdAt(notice.getCreatedDate().toString())
                 .author(ChatBuilder.buildProfileResponse(notice.getAuthor()))
                 .build();
+    }
+
+    private static String truncateContent(String content) {
+        if (content.length() > PREVIEW_MAX_LENGTH) {
+            return content.substring(0, PREVIEW_MAX_LENGTH);
+        }
+
+        return content;
     }
 }

--- a/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
+++ b/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
@@ -16,6 +16,26 @@ public class ChatNoticeBuilder {
 
     private static final int PREVIEW_MAX_LENGTH = 30;
 
+    public static AllNoticesResponse buildAllNoticesResponse(Boolean hasNext, Long nextCursor, List<ChatNotice> chatNotices) {
+        return AllNoticesResponse.builder()
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .notices(buildNoticeResponses(chatNotices))
+                .build();
+    }
+
+    private static List<NoticeResponse> buildNoticeResponses(List<ChatNotice> chatNotices) {
+        return chatNotices.stream()
+                .filter(Objects::nonNull)
+                .map(notice -> NoticeResponse.builder()
+                        .noticeId(notice.getId())
+                        .preview(truncateContent(notice.getContent()))
+                        .authorNickname(notice.getAuthor().getUser().getNickname())
+                        .createdAt(notice.getCreatedDate().toString())
+                        .build())
+                .toList();
+    }
+
     public static LatestNoticeResponse buildLatestNoticeResponse(NoticeStatus status, ChatNotice notice) {
         if (notice == null) {
             return null;

--- a/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
+++ b/src/main/java/com/poortorich/chatnotice/util/ChatNoticeBuilder.java
@@ -16,11 +16,15 @@ public class ChatNoticeBuilder {
 
     private static final int PREVIEW_MAX_LENGTH = 30;
 
-    public static AllNoticesResponse buildAllNoticesResponse(Boolean hasNext, Long nextCursor, List<ChatNotice> chatNotices) {
+    public static AllNoticesResponse buildAllNoticesResponse(
+            Boolean hasNext,
+            Long nextCursor,
+            List<ChatNotice> chatNotices
+    ) {
         return AllNoticesResponse.builder()
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
-                .notices(buildNoticeResponses(chatNotices))
+                .notices(chatNotices == null ? List.of() : buildNoticeResponses(chatNotices))
                 .build();
     }
 

--- a/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
+++ b/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
@@ -5,6 +5,7 @@ import com.poortorich.chat.facade.ChatFacade;
 import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
 import com.poortorich.chatnotice.facade.ChatNoticeFacade;
 import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
+import com.poortorich.chatnotice.response.AllNoticesResponse;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
 import com.poortorich.chatnotice.response.NoticeDetailsResponse;
 import com.poortorich.chatnotice.response.PreviewNoticesResponse;
@@ -123,5 +124,21 @@ class ChatNoticeControllerTest extends BaseSecurityTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
                         .value(ChatNoticeResponse.GET_NOTICE_DETAILS_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @WithMockUser(username = username)
+    @DisplayName("전체 공지 목록 조회 성공")
+    void getAllNoticesSuccess() throws Exception {
+        Long chatroomId = 1L;
+
+        when(chatNoticeFacade.getAllNotices(chatroomId, Long.MAX_VALUE))
+                .thenReturn(AllNoticesResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/notices/all")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(ChatNoticeResponse.GET_ALL_NOTICES_SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
+++ b/src/test/java/com/poortorich/chatnotice/facade/ChatNoticeFacadeTest.java
@@ -236,7 +236,7 @@ class ChatNoticeFacadeTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getHasNext()).isTrue();
-        assertThat(result.getNextCursor()).isEqualTo(slice.getContent().getLast().getId() - 1);
+        assertThat(result.getNextCursor()).isEqualTo(slice.getContent().getLast().getId());
         assertThat(result.getNotices()).hasSize(2);
         assertThat(result.getNotices().get(0).getNoticeId()).isEqualTo(chatNotice.getId());
         assertThat(result.getNotices().get(0).getPreview()).isEqualTo(chatNotice.getContent());

--- a/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
+++ b/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
@@ -120,7 +120,7 @@ class ChatNoticeServiceTest {
 
         SliceImpl<ChatNotice> repoSlice = new SliceImpl<>(List.of(notice1, notice2), pageable, true);
 
-        when(chatNoticeRepository.findByChatroomAndIdLessThanEqualOrderByIdDesc(chatroom, Long.MAX_VALUE, pageable))
+        when(chatNoticeRepository.findByChatroomAndIdLessThanOrderByIdDesc(chatroom, Long.MAX_VALUE, pageable))
                 .thenReturn(repoSlice);
 
         Slice<ChatNotice> result = chatNoticeService.getAllNoticeByCursor(chatroom, Long.MAX_VALUE, pageable);
@@ -135,14 +135,14 @@ class ChatNoticeServiceTest {
     @DisplayName("전체 공지 목록 - cursor가 있는 경우 조회 성공")
     void getAllNoticeByCursorSuccess() {
         Chatroom chatroom = Chatroom.builder().build();
-        Long cursor = 5L;
+        Long cursor = 6L;
 
         ChatNotice notice1 = ChatNotice.builder().id(5L).chatroom(chatroom).build();
         ChatNotice notice2 = ChatNotice.builder().id(4L).chatroom(chatroom).build();
 
         SliceImpl<ChatNotice> repoSlice = new SliceImpl<>(List.of(notice1, notice2), pageable, true);
 
-        when(chatNoticeRepository.findByChatroomAndIdLessThanEqualOrderByIdDesc(chatroom, cursor, pageable))
+        when(chatNoticeRepository.findByChatroomAndIdLessThanOrderByIdDesc(chatroom, cursor, pageable))
                 .thenReturn(repoSlice);
 
         Slice<ChatNotice> result = chatNoticeService.getAllNoticeByCursor(chatroom, cursor, pageable);

--- a/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
+++ b/src/test/java/com/poortorich/chatnotice/service/ChatNoticeServiceTest.java
@@ -11,12 +11,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,6 +32,8 @@ class ChatNoticeServiceTest {
 
     @InjectMocks
     private ChatNoticeService chatNoticeService;
+
+    private final Pageable pageable = PageRequest.of(0, 20);
 
     @Test
     @DisplayName("최근 공지 조회 성공")
@@ -102,5 +109,47 @@ class ChatNoticeServiceTest {
         assertThatThrownBy(() -> chatNoticeService.findNotice(chatroom, noticeId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining(ChatNoticeResponse.NOTICE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("전체 공지 목록 - cursor가 기본 값인 경우 조회 성공")
+    void getAllNoticeByCursorDefaultValueSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatNotice notice1 = ChatNotice.builder().id(5L).chatroom(chatroom).build();
+        ChatNotice notice2 = ChatNotice.builder().id(4L).chatroom(chatroom).build();
+
+        SliceImpl<ChatNotice> repoSlice = new SliceImpl<>(List.of(notice1, notice2), pageable, true);
+
+        when(chatNoticeRepository.findByChatroomAndIdLessThanEqualOrderByIdDesc(chatroom, Long.MAX_VALUE, pageable))
+                .thenReturn(repoSlice);
+
+        Slice<ChatNotice> result = chatNoticeService.getAllNoticeByCursor(chatroom, Long.MAX_VALUE, pageable);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(5L);
+        assertThat(result.getContent().get(1).getId()).isEqualTo(4L);
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("전체 공지 목록 - cursor가 있는 경우 조회 성공")
+    void getAllNoticeByCursorSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        Long cursor = 5L;
+
+        ChatNotice notice1 = ChatNotice.builder().id(5L).chatroom(chatroom).build();
+        ChatNotice notice2 = ChatNotice.builder().id(4L).chatroom(chatroom).build();
+
+        SliceImpl<ChatNotice> repoSlice = new SliceImpl<>(List.of(notice1, notice2), pageable, true);
+
+        when(chatNoticeRepository.findByChatroomAndIdLessThanEqualOrderByIdDesc(chatroom, cursor, pageable))
+                .thenReturn(repoSlice);
+
+        Slice<ChatNotice> result = chatNoticeService.getAllNoticeByCursor(chatroom, cursor, pageable);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(5L);
+        assertThat(result.getContent().get(1).getId()).isEqualTo(4L);
+        assertThat(result.hasNext()).isTrue();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#427
 
 ## 📝작업 내용
 
- 전체 공지 목록 조회
  - cursor를 입력받아 해당 다음 위치부터 페이징
 
 ### 스크린샷

<img width="1041" height="593" alt="image" src="https://github.com/user-attachments/assets/6846fded-9bab-4afd-b72e-09e1c124c9ad" />

<img width="1042" height="605" alt="image" src="https://github.com/user-attachments/assets/68325704-92d1-471f-b4cc-585bdcc71e6f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 채팅방 전체 공지 조회용 신규 GET 엔드포인트 추가(커서 기반 페이지네이션 지원).
  - 응답에 hasNext, nextCursor 및 공지 목록(미리보기, 작성자 닉네임, 생성일) 포함.
  - 기본 커서값 제공으로 파라미터 없이도 첫 페이지 조회 가능.
  - 전체 조회 성공 메시지가 표준화되어 응답에 사용됨.

- 테스트
  - 전체 공지 조회와 커서 기반 페이지네이션 흐름에 대한 단위/컨트롤러 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->