### PR TITLE
[#437] 전체 참여 인원 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -10,6 +10,7 @@ public class ChatResponseMessage {
     public static final String GET_CHATROOM_DETAILS_SUCCESS = "채팅방 상세정보 조회를 완료했습니다.";
     public static final String GET_CHATROOM_COVER_INFO_SUCCESS = "채팅방 커버 정보 조회를 완료했습니다.";
     public static final String GET_CHATROOM_ROLE_SUCCESS = "현재 채팅방의 유저 역할 조회를 완료했습니다.";
+    public static final String GET_ALL_PARTICIPANTS_SUCCESS = "채팅방 참여자 목록 조회를 완료했습니다.";
 
     public static final String CHATROOM_TITLE_REQUIRED = "채팅방 이름은 필수값입니다.";
     public static final String CHATROOM_TITLE_TOO_BIG

--- a/src/main/java/com/poortorich/chat/controller/ChatParticipantController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatParticipantController.java
@@ -27,10 +27,13 @@ public class ChatParticipantController {
     }
 
     @GetMapping("/chatrooms/{chatroomId}/members/all")
-    public ResponseEntity<BaseResponse> getAllParticipants(@PathVariable Long chatroomId) {
+    public ResponseEntity<BaseResponse> getAllParticipants(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId
+    ) {
         return DataResponse.toResponseEntity(
                 ChatResponse.GET_ALL_PARTICIPANTS_SUCCESS,
-                chatFacade.getAllParticipants(chatroomId)
+                chatFacade.getAllParticipants(userDetails.getUsername(), chatroomId)
         );
     }
 }

--- a/src/main/java/com/poortorich/chat/controller/ChatParticipantController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatParticipantController.java
@@ -9,17 +9,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/users")
 @RequiredArgsConstructor
 public class ChatParticipantController {
 
     private final ChatFacade chatFacade;
 
-    @GetMapping("/hosted-chatrooms")
+    @GetMapping("/users/hosted-chatrooms")
     public ResponseEntity<BaseResponse> getHostedChatrooms(@AuthenticationPrincipal UserDetails userDetails) {
         return DataResponse.toResponseEntity(
                 ChatResponse.GET_HOSTED_CHATROOMS_SUCCESS,

--- a/src/main/java/com/poortorich/chat/controller/ChatParticipantController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatParticipantController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +23,14 @@ public class ChatParticipantController {
         return DataResponse.toResponseEntity(
                 ChatResponse.GET_HOSTED_CHATROOMS_SUCCESS,
                 chatFacade.getHostedChatrooms(userDetails.getUsername())
+        );
+    }
+
+    @GetMapping("/chatrooms/{chatroomId}/members/all")
+    public ResponseEntity<BaseResponse> getAllParticipants(@PathVariable Long chatroomId) {
+        return DataResponse.toResponseEntity(
+                ChatResponse.GET_ALL_PARTICIPANTS_SUCCESS,
+                chatFacade.getAllParticipants(chatroomId)
         );
     }
 }

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -275,8 +275,10 @@ public class ChatFacade {
                 .build();
     }
 
-    public AllParticipantsResponse getAllParticipants(Long chatroomId) {
+    public AllParticipantsResponse getAllParticipants(String username, Long chatroomId) {
+        User user = userService.findUserByUsername(username);
         Chatroom chatroom = chatroomService.findById(chatroomId);
+        chatParticipantValidator.validateIsParticipate(user, chatroom);
 
         return ChatBuilder.buildAllParticipantsResponse(chatParticipantService.getAllParticipants(chatroom));
     }

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -12,6 +12,7 @@ import com.poortorich.chat.request.ChatroomLeaveAllRequest;
 import com.poortorich.chat.request.ChatroomUpdateRequest;
 import com.poortorich.chat.request.enums.SortBy;
 import com.poortorich.chat.response.AllChatroomsResponse;
+import com.poortorich.chat.response.AllParticipantsResponse;
 import com.poortorich.chat.response.ChatMessagePageResponse;
 import com.poortorich.chat.response.ChatParticipantProfile;
 import com.poortorich.chat.response.ChatroomCoverInfoResponse;
@@ -272,5 +273,11 @@ public class ChatFacade {
                                 profile -> profile
                         )))
                 .build();
+    }
+
+    public AllParticipantsResponse getAllParticipants(Long chatroomId) {
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+
+        return ChatBuilder.buildAllParticipantsResponse(chatParticipantService.getAllParticipants(chatroom));
     }
 }

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -275,6 +275,7 @@ public class ChatFacade {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public AllParticipantsResponse getAllParticipants(String username, Long chatroomId) {
         User user = userService.findUserByUsername(username);
         Chatroom chatroom = chatroomService.findById(chatroomId);

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -73,4 +73,16 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             WHERE u.username = :username
             """)
     List<ChatParticipant> findAllByUsernameWithChatroomAndUser(@Param("username") String username);
+
+    @Query("""
+        SELECT cp
+        FROM ChatParticipant cp
+        JOIN FETCH cp.user u
+        WHERE cp.chatroom = :chatroom
+          AND cp.isParticipated = true
+        ORDER BY
+          CASE WHEN cp.role = com.poortorich.chat.entity.enums.ChatroomRole.HOST THEN 0 ELSE 1 END,
+          u.nickname ASC
+    """)
+    List<ChatParticipant> findAllOrderedParticipants(@Param("chatroom") Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chat/response/AllParticipantsResponse.java
+++ b/src/main/java/com/poortorich/chat/response/AllParticipantsResponse.java
@@ -1,0 +1,18 @@
+package com.poortorich.chat.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AllParticipantsResponse {
+
+    private Long memberCount;
+    private List<ProfileResponse> members;
+}

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -17,6 +17,7 @@ public enum ChatResponse implements Response {
     GET_CHATROOM_DETAILS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_DETAILS_SUCCESS, null),
     GET_CHATROOM_COVER_INFO_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_COVER_INFO_SUCCESS, null),
     GET_CHATROOM_ROLE_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHATROOM_ROLE_SUCCESS, null),
+    GET_ALL_PARTICIPANTS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_ALL_PARTICIPANTS_SUCCESS, null),
 
     CHATROOM_ENTER_DENIED(HttpStatus.FORBIDDEN, ChatResponseMessage.CHATROOM_ENTER_DENIED, null),
     CHATROOM_PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_PASSWORD_DO_NOT_MATCH, null),

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -149,4 +149,8 @@ public class ChatParticipantService {
             case DELETE -> NoticeStatus.PERMANENT_HIDDEN;
         };
     }
+
+    public List<ChatParticipant> getAllParticipants(Chatroom chatroom) {
+        return chatParticipantRepository.findAllOrderedParticipants(chatroom);
+    }
 }

--- a/src/main/java/com/poortorich/chat/util/ChatBuilder.java
+++ b/src/main/java/com/poortorich/chat/util/ChatBuilder.java
@@ -6,6 +6,7 @@ import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.chat.request.ChatroomCreateRequest;
+import com.poortorich.chat.response.AllParticipantsResponse;
 import com.poortorich.chat.response.ChatroomCoverInfoResponse;
 import com.poortorich.chat.response.ChatroomDetailsResponse;
 import com.poortorich.chat.response.ChatroomInfoResponse;
@@ -15,6 +16,7 @@ import com.poortorich.s3.constants.S3Constants;
 import com.poortorich.user.entity.User;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ChatBuilder {
 
@@ -107,6 +109,15 @@ public class ChatBuilder {
                 .isJoined(isJoined)
                 .hasPassword(chatroom.getPassword() != null)
                 .hostProfile(buildProfileResponse(hostInfo))
+                .build();
+    }
+
+    public static AllParticipantsResponse buildAllParticipantsResponse(List<ChatParticipant> participants) {
+        return AllParticipantsResponse.builder()
+                .memberCount((long) participants.size())
+                .members(participants.stream()
+                        .map(ChatBuilder::buildProfileResponse)
+                        .collect(Collectors.toList()))
                 .build();
     }
 

--- a/src/test/java/com/poortorich/chat/controller/ChatParticipantControllerTest.java
+++ b/src/test/java/com/poortorich/chat/controller/ChatParticipantControllerTest.java
@@ -1,6 +1,7 @@
 package com.poortorich.chat.controller;
 
 import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chat.response.AllParticipantsResponse;
 import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.config.BaseSecurityTest;
@@ -30,17 +31,33 @@ class ChatParticipantControllerTest extends BaseSecurityTest {
     @MockitoBean
     private ChatFacade chatFacade;
 
+    private final String username = "test";
+
     @Test
-    @WithMockUser(username = "test")
+    @WithMockUser(username = username)
     @DisplayName("내가 방장인 채팅방 조회 성공")
     void getHostedChatroomsSuccess() throws Exception {
         ChatroomsResponse response = ChatroomsResponse.builder().build();
-        when(chatFacade.getHostedChatrooms("test")).thenReturn(response);
+        when(chatFacade.getHostedChatrooms(username)).thenReturn(response);
 
         mockMvc.perform(get("/users/hosted-chatrooms")
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath(("$.message"))
                         .value(ChatResponse.GET_HOSTED_CHATROOMS_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @WithMockUser(username = username)
+    @DisplayName("전체 참여 인원 조회 성공")
+    void getAllParticipantsSuccess() throws Exception {
+        Long chatroomId = 1L;
+
+        when(chatFacade.getAllParticipants(chatroomId)).thenReturn(AllParticipantsResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/members/all")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(("$.message")).value(ChatResponse.GET_ALL_PARTICIPANTS_SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/poortorich/chat/controller/ChatParticipantControllerTest.java
+++ b/src/test/java/com/poortorich/chat/controller/ChatParticipantControllerTest.java
@@ -53,7 +53,7 @@ class ChatParticipantControllerTest extends BaseSecurityTest {
     void getAllParticipantsSuccess() throws Exception {
         Long chatroomId = 1L;
 
-        when(chatFacade.getAllParticipants(chatroomId)).thenReturn(AllParticipantsResponse.builder().build());
+        when(chatFacade.getAllParticipants(username, chatroomId)).thenReturn(AllParticipantsResponse.builder().build());
 
         mockMvc.perform(get("/chatrooms/" + chatroomId + "/members/all")
                         .with(csrf()))

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -305,7 +305,12 @@ class ChatFacadeTest {
     @DisplayName("전체 참여 인원 목록 조회 성공")
     void getAllParticipantsSuccess() {
         String username = "host";
-        User hostUser = User.builder().id(1L).profileImage("profileImage.com").nickname(username).build();
+        User hostUser = User.builder()
+                .id(1L)
+                .profileImage("profileImage.com")
+                .username(username)
+                .nickname(username)
+                .build();
         ChatParticipant host = ChatParticipant.builder()
                 .user(hostUser)
                 .chatroom(chatroom)
@@ -320,6 +325,7 @@ class ChatFacadeTest {
                 .rankingStatus(RankingStatus.NONE)
                 .build();
 
+        when(userService.findUserByUsername(username)).thenReturn(hostUser);
         when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
         when(chatParticipantService.getAllParticipants(chatroom)).thenReturn(List.of(host, member1));
 

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -17,6 +17,7 @@ import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.chat.validator.ChatParticipantValidator;
 import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
@@ -63,6 +64,8 @@ class ChatFacadeTest {
     private TagService tagService;
     @Mock
     private ChatMessageService chatMessageService;
+    @Mock
+    private ChatParticipantValidator chatParticipantValidator;
     @InjectMocks
     private ChatFacade chatFacade;
     private Chatroom chatroom;
@@ -301,7 +304,8 @@ class ChatFacadeTest {
     @Test
     @DisplayName("전체 참여 인원 목록 조회 성공")
     void getAllParticipantsSuccess() {
-        User hostUser = User.builder().id(1L).profileImage("profileImage.com").nickname("host").build();
+        String username = "host";
+        User hostUser = User.builder().id(1L).profileImage("profileImage.com").nickname(username).build();
         ChatParticipant host = ChatParticipant.builder()
                 .user(hostUser)
                 .chatroom(chatroom)
@@ -319,7 +323,7 @@ class ChatFacadeTest {
         when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
         when(chatParticipantService.getAllParticipants(chatroom)).thenReturn(List.of(host, member1));
 
-        AllParticipantsResponse response = chatFacade.getAllParticipants(chatroomId);
+        AllParticipantsResponse response = chatFacade.getAllParticipants(username, chatroomId);
 
         assertThat(response).isNotNull();
         assertThat(response.getMemberCount()).isEqualTo(2);

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -7,6 +7,7 @@ import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.request.enums.SortBy;
 import com.poortorich.chat.response.AllChatroomsResponse;
+import com.poortorich.chat.response.AllParticipantsResponse;
 import com.poortorich.chat.response.ChatroomCoverInfoResponse;
 import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomDetailsResponse;
@@ -295,5 +296,38 @@ class ChatFacadeTest {
         chatFacade.updateNoticeStatus(username, chatroomId, request);
 
         verify(chatParticipantService).updateNoticeStatus(username, chatroom, request);
+    }
+
+    @Test
+    @DisplayName("전체 참여 인원 목록 조회 성공")
+    void getAllParticipantsSuccess() {
+        User hostUser = User.builder().id(1L).profileImage("profileImage.com").nickname("host").build();
+        ChatParticipant host = ChatParticipant.builder()
+                .user(hostUser)
+                .chatroom(chatroom)
+                .role(ChatroomRole.HOST)
+                .rankingStatus(RankingStatus.NONE)
+                .build();
+        User memberUser = User.builder().id(2L).profileImage("profileImage.com").nickname("member1").build();
+        ChatParticipant member1 = ChatParticipant.builder()
+                .user(memberUser)
+                .chatroom(chatroom)
+                .role(ChatroomRole.MEMBER)
+                .rankingStatus(RankingStatus.NONE)
+                .build();
+
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(chatParticipantService.getAllParticipants(chatroom)).thenReturn(List.of(host, member1));
+
+        AllParticipantsResponse response = chatFacade.getAllParticipants(chatroomId);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getMemberCount()).isEqualTo(2);
+        assertThat(response.getMembers().get(0).getUserId()).isEqualTo(hostUser.getId());
+        assertThat(response.getMembers().get(0).getNickname()).isEqualTo(hostUser.getNickname());
+        assertThat(response.getMembers().get(0).getIsHost()).isTrue();
+        assertThat(response.getMembers().get(1).getUserId()).isEqualTo(memberUser.getId());
+        assertThat(response.getMembers().get(1).getNickname()).isEqualTo(memberUser.getNickname());
+        assertThat(response.getMembers().get(1).getIsHost()).isFalse();
     }
 }

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -326,7 +326,7 @@ class ChatFacadeTest {
         AllParticipantsResponse response = chatFacade.getAllParticipants(username, chatroomId);
 
         assertThat(response).isNotNull();
-        assertThat(response.getMemberCount()).isEqualTo(2);
+        assertThat(response.getMemberCount()).isEqualTo(2L);
         assertThat(response.getMembers().get(0).getUserId()).isEqualTo(hostUser.getId());
         assertThat(response.getMembers().get(0).getNickname()).isEqualTo(hostUser.getNickname());
         assertThat(response.getMembers().get(0).getIsHost()).isTrue();

--- a/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
@@ -4,6 +4,7 @@ import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.chat.repository.ChatParticipantRepository;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
@@ -20,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -280,5 +282,24 @@ class ChatParticipantServiceTest {
         assertThatThrownBy(() -> chatParticipantService.findByUserIdAndChatroom(userId, chatroom))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("전체 참여 인원 목록 조회 성공")
+    void getAllParticipantsSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        ChatParticipant host = ChatParticipant.builder().build();
+        ChatParticipant member1 = ChatParticipant.builder().build();
+        ChatParticipant member2 = ChatParticipant.builder().build();
+
+        when(chatParticipantRepository.findAllOrderedParticipants(chatroom))
+                .thenReturn(List.of(host, member1, member2));
+
+        List<ChatParticipant> result = chatParticipantService.getAllParticipants(chatroom);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0)).isEqualTo(host);
+        assertThat(result.get(1)).isEqualTo(member1);
+        assertThat(result.get(2)).isEqualTo(member2);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#437 
 
## 📝작업 내용
 
- 전체 참여 인원 목록 조회
  - 방장 먼저, 그 후 사전순으로 인원 정렬
 
### 스크린샷

<img width="1042" height="612" alt="image" src="https://github.com/user-attachments/assets/527093e4-8b75-4185-b0f2-1c1876ee20bc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 채팅방 전체 참여자 조회 API 추가: GET /chatrooms/{chatroomId}/members/all
  - 응답에 총원(memberCount)과 참여자 프로필 목록 포함
  - 정렬: 방장 우선, 이후 닉네임 오름차순
  - 성공 메시지 추가로 사용자 피드백 개선
- **변경**
  - hosted-chatrooms 엔드포인트 매핑이 경로 수준으로 조정되어 노출 경로 갱신
- **테스트**
  - 컨트롤러·파사드·서비스 레이어에 신규 API 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->