### PR TITLE
[#442] 최신 랭킹 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/ranking/constants/RankingResponseMessage.java
+++ b/src/main/java/com/poortorich/ranking/constants/RankingResponseMessage.java
@@ -6,6 +6,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RankingResponseMessage {
 
-    public static final String GET_LATEST_RANKING_SUCCESS = "최신 랭킹 조회에 완료했습니다.";
+    public static final String GET_LATEST_RANKING_SUCCESS = "최신 랭킹 조회를 완료했습니다.";
     public static final String GET_LATEST_RANKING_NOT_FOUND = "랭킹이 집계되지 않았습니다.";
 }

--- a/src/main/java/com/poortorich/ranking/constants/RankingResponseMessage.java
+++ b/src/main/java/com/poortorich/ranking/constants/RankingResponseMessage.java
@@ -1,0 +1,11 @@
+package com.poortorich.ranking.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankingResponseMessage {
+
+    public static final String GET_LATEST_RANKING_SUCCESS = "최신 랭킹 조회에 완료했습니다.";
+    public static final String GET_LATEST_RANKING_NOT_FOUND = "랭킹이 집계되지 않았습니다.";
+}

--- a/src/main/java/com/poortorich/ranking/controller/RankingController.java
+++ b/src/main/java/com/poortorich/ranking/controller/RankingController.java
@@ -1,6 +1,7 @@
 package com.poortorich.ranking.controller;
 
 import com.poortorich.global.response.BaseResponse;
+import com.poortorich.global.response.DataResponse;
 import com.poortorich.ranking.facade.RankingFacade;
 import com.poortorich.ranking.response.enums.RankingResponse;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,6 @@ public class RankingController {
         RankingResponse code = result.found()
                 ? RankingResponse.GET_LATEST_RANKING_SUCCESS
                 : RankingResponse.GET_LATEST_RANKING_NOT_FOUND;
-        return com.poortorich.global.response.DataResponse.toResponseEntity(code, result.response());
+        return DataResponse.toResponseEntity(code, result.response());
     }
 }

--- a/src/main/java/com/poortorich/ranking/controller/RankingController.java
+++ b/src/main/java/com/poortorich/ranking/controller/RankingController.java
@@ -1,0 +1,33 @@
+package com.poortorich.ranking.controller;
+
+import com.poortorich.global.response.BaseResponse;
+import com.poortorich.ranking.facade.RankingFacade;
+import com.poortorich.ranking.response.enums.RankingResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/chatrooms/{chatroomId}/rankings")
+@RequiredArgsConstructor
+public class RankingController {
+
+    private final RankingFacade rankingFacade;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse> getLatestRanking(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId
+    ) {
+        var result = rankingFacade.getLatestRanking(userDetails.getUsername(), chatroomId);
+        RankingResponse code = result.found()
+                ? RankingResponse.GET_LATEST_RANKING_SUCCESS
+                : RankingResponse.GET_LATEST_RANKING_NOT_FOUND;
+        return com.poortorich.global.response.DataResponse.toResponseEntity(code, result.response());
+    }
+}

--- a/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
+++ b/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
@@ -24,8 +24,12 @@ import java.time.temporal.TemporalAdjusters;
 public class RankingFacade {
 
     public record LatestRankingResult(boolean found, LatestRankingResponse response) {
-        public static LatestRankingResult create(boolean found, LatestRankingResponse response) {
-            return new LatestRankingResult(found, response);
+        public static LatestRankingResult found(LatestRankingResponse response) {
+            return new LatestRankingResult(true, response);
+        }
+
+        public static LatestRankingResult notFound(LatestRankingResponse response) {
+            return new LatestRankingResult(false, response);
         }
     }
 
@@ -58,7 +62,7 @@ public class RankingFacade {
     ) {
         if (latestRanking == null) {
             LatestRankingResponse response = RankingBuilder.buildNotFoundLatestRankingResponse(lastMonday);
-            return LatestRankingResult.create(false, response);
+            return LatestRankingResult.notFound(response);
         }
 
         ChatParticipant saver = chatParticipantService.findByUserIdAndChatroom(
@@ -71,6 +75,6 @@ public class RankingFacade {
         );
 
         LatestRankingResponse response = RankingBuilder.buildLatestRankingResponse(latestRanking, saver, flexer);
-        return LatestRankingResult.create(true, response);
+        return LatestRankingResult.found(response);
     }
 }

--- a/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 @Repository
 public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
-    Optional<Ranking> findByChatroomAndCreatedDateBetween(
+    Optional<Ranking> findFirstByChatroomAndCreatedDateBetweenOrderByCreatedDateDesc(
             Chatroom chatroom,
             LocalDateTime startDate,
             LocalDateTime endDate

--- a/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
@@ -1,9 +1,19 @@
 package com.poortorich.ranking.repository;
 
+import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.ranking.entity.Ranking;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 @Repository
 public interface RankingRepository extends JpaRepository<Ranking, Long> {
+
+    Optional<Ranking> findByChatroomAndCreatedDateBetween(
+            Chatroom chatroom,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
 }

--- a/src/main/java/com/poortorich/ranking/response/LatestRankingResponse.java
+++ b/src/main/java/com/poortorich/ranking/response/LatestRankingResponse.java
@@ -1,0 +1,19 @@
+package com.poortorich.ranking.response;
+
+import com.poortorich.chat.response.ProfileResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LatestRankingResponse {
+
+    private String rankedAt;
+    private Long rankingId;
+    private ProfileResponse saver;
+    private ProfileResponse flexer;
+}

--- a/src/main/java/com/poortorich/ranking/response/enums/RankingResponse.java
+++ b/src/main/java/com/poortorich/ranking/response/enums/RankingResponse.java
@@ -1,0 +1,34 @@
+package com.poortorich.ranking.response.enums;
+
+import com.poortorich.global.response.Response;
+import com.poortorich.ranking.constants.RankingResponseMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RankingResponse implements Response {
+
+    GET_LATEST_RANKING_SUCCESS(HttpStatus.OK, RankingResponseMessage.GET_LATEST_RANKING_SUCCESS, null),
+    GET_LATEST_RANKING_NOT_FOUND(HttpStatus.OK, RankingResponseMessage.GET_LATEST_RANKING_NOT_FOUND, null);
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String field;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
+}

--- a/src/main/java/com/poortorich/ranking/service/RankingService.java
+++ b/src/main/java/com/poortorich/ranking/service/RankingService.java
@@ -6,9 +6,7 @@ import com.poortorich.ranking.repository.RankingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.DayOfWeek;
 import java.time.LocalDateTime;
-import java.time.temporal.TemporalAdjusters;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +15,7 @@ public class RankingService {
     private final RankingRepository rankingRepository;
 
     public Ranking findLatestRanking(Chatroom chatroom, LocalDateTime start, LocalDateTime end) {
-        return rankingRepository.findByChatroomAndCreatedDateBetween(chatroom, start, end)
+        return rankingRepository.findFirstByChatroomAndCreatedDateBetweenOrderByCreatedDateDesc(chatroom, start, end)
                 .orElse(null);
     }
 }

--- a/src/main/java/com/poortorich/ranking/service/RankingService.java
+++ b/src/main/java/com/poortorich/ranking/service/RankingService.java
@@ -1,0 +1,23 @@
+package com.poortorich.ranking.service;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.ranking.entity.Ranking;
+import com.poortorich.ranking.repository.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final RankingRepository rankingRepository;
+
+    public Ranking findLatestRanking(Chatroom chatroom, LocalDateTime start, LocalDateTime end) {
+        return rankingRepository.findByChatroomAndCreatedDateBetween(chatroom, start, end)
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/poortorich/ranking/util/RankingBuilder.java
+++ b/src/main/java/com/poortorich/ranking/util/RankingBuilder.java
@@ -1,0 +1,36 @@
+package com.poortorich.ranking.util;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.util.ChatBuilder;
+import com.poortorich.ranking.entity.Ranking;
+import com.poortorich.ranking.response.LatestRankingResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankingBuilder {
+
+    public static LatestRankingResponse buildNotFoundLatestRankingResponse(LocalDateTime rankedAt) {
+        return LatestRankingResponse.builder()
+                .rankedAt(rankedAt.toString())
+                .rankingId(null)
+                .saver(null)
+                .flexer(null)
+                .build();
+    }
+
+    public static LatestRankingResponse buildLatestRankingResponse(
+            Ranking latestRanking,
+            ChatParticipant saver,
+            ChatParticipant flexer
+    ) {
+        return LatestRankingResponse.builder()
+                .rankedAt(latestRanking.getCreatedDate().toString())
+                .rankingId(latestRanking.getId())
+                .saver(ChatBuilder.buildProfileResponse(saver))
+                .flexer(ChatBuilder.buildProfileResponse(flexer))
+                .build();
+    }
+}

--- a/src/test/java/com/poortorich/ranking/controller/RankingControllerTest.java
+++ b/src/test/java/com/poortorich/ranking/controller/RankingControllerTest.java
@@ -1,0 +1,68 @@
+package com.poortorich.ranking.controller;
+
+import com.poortorich.global.config.BaseSecurityTest;
+import com.poortorich.ranking.facade.RankingFacade;
+import com.poortorich.ranking.response.LatestRankingResponse;
+import com.poortorich.ranking.response.enums.RankingResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RankingController.class)
+@ExtendWith(MockitoExtension.class)
+class RankingControllerTest extends BaseSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RankingFacade rankingFacade;
+
+    private final String username = "test";
+
+    @Test
+    @WithMockUser(username = username)
+    @DisplayName("최신 랭킹 조회 성공")
+    void getLatestRankingSuccess() throws Exception {
+        Long chatroomId = 1L;
+
+        when(rankingFacade.getLatestRanking(username, chatroomId)).thenReturn(
+                RankingFacade.LatestRankingResult.create(true, LatestRankingResponse.builder().build())
+        );
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/rankings")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(RankingResponse.GET_LATEST_RANKING_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @WithMockUser(username = username)
+    @DisplayName("최신 랭킹이 없는 경우 null 조회 성공")
+    void getLatestRankingNull() throws Exception {
+        Long chatroomId = 1L;
+
+        when(rankingFacade.getLatestRanking(username, chatroomId)).thenReturn(
+                RankingFacade.LatestRankingResult.create(false, LatestRankingResponse.builder().build())
+        );
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/rankings")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(RankingResponse.GET_LATEST_RANKING_NOT_FOUND.getMessage()));
+    }
+}

--- a/src/test/java/com/poortorich/ranking/controller/RankingControllerTest.java
+++ b/src/test/java/com/poortorich/ranking/controller/RankingControllerTest.java
@@ -39,7 +39,7 @@ class RankingControllerTest extends BaseSecurityTest {
         Long chatroomId = 1L;
 
         when(rankingFacade.getLatestRanking(username, chatroomId)).thenReturn(
-                RankingFacade.LatestRankingResult.create(true, LatestRankingResponse.builder().build())
+                RankingFacade.LatestRankingResult.found(LatestRankingResponse.builder().build())
         );
 
         mockMvc.perform(get("/chatrooms/" + chatroomId + "/rankings")
@@ -56,7 +56,7 @@ class RankingControllerTest extends BaseSecurityTest {
         Long chatroomId = 1L;
 
         when(rankingFacade.getLatestRanking(username, chatroomId)).thenReturn(
-                RankingFacade.LatestRankingResult.create(false, LatestRankingResponse.builder().build())
+                RankingFacade.LatestRankingResult.notFound(LatestRankingResponse.builder().build())
         );
 
         mockMvc.perform(get("/chatrooms/" + chatroomId + "/rankings")

--- a/src/test/java/com/poortorich/ranking/facade/RankingFacadeTest.java
+++ b/src/test/java/com/poortorich/ranking/facade/RankingFacadeTest.java
@@ -1,0 +1,137 @@
+package com.poortorich.ranking.facade;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.entity.enums.RankingStatus;
+import com.poortorich.chat.service.ChatParticipantService;
+import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.chat.validator.ChatParticipantValidator;
+import com.poortorich.global.response.BaseResponse;
+import com.poortorich.global.response.DataResponse;
+import com.poortorich.ranking.entity.Ranking;
+import com.poortorich.ranking.response.enums.RankingResponse;
+import com.poortorich.ranking.service.RankingService;
+import com.poortorich.user.entity.User;
+import com.poortorich.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RankingFacadeTest {
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private ChatroomService chatroomService;
+    @Mock
+    private ChatParticipantService chatParticipantService;
+    @Mock
+    private ChatParticipantValidator chatParticipantValidator;
+    @Mock
+    private RankingService rankingService;
+
+    @InjectMocks
+    private RankingFacade rankingFacade;
+
+    private final LocalDateTime now = LocalDateTime.now();
+    private final LocalDateTime lastMonday = now
+            .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            .toLocalDate()
+            .atStartOfDay();
+
+    @Test
+    @DisplayName("최신 랭킹 조회 성공")
+    void getLatestRankingSuccess() {
+        String username = "test";
+        Long chatroomId = 1L;
+        Long saverId = 1L;
+        Long flexerId = 2L;
+        User user = User.builder().username(username).build();
+        Chatroom chatroom = Chatroom.builder().id(chatroomId).build();
+        Ranking ranking = Ranking.builder()
+                .id(1L)
+                .chatroom(chatroom)
+                .saverFirst(saverId)
+                .flexerFirst(flexerId)
+                .createdDate(LocalDateTime.of(2025, 8, 18, 0, 0, 0))
+                .build();
+        User saverUser = User.builder()
+                .id(saverId)
+                .profileImage("")
+                .nickname("saver")
+                .build();
+        ChatParticipant saver = ChatParticipant.builder()
+                .id(saverId)
+                .user(saverUser)
+                .role(ChatroomRole.MEMBER)
+                .rankingStatus(RankingStatus.SAVER)
+                .build();
+        User flexerUser = User.builder()
+                .id(flexerId)
+                .profileImage("")
+                .nickname("flexer")
+                .build();
+        ChatParticipant flexer = ChatParticipant.builder()
+                .id(flexerId)
+                .user(flexerUser)
+                .role(ChatroomRole.MEMBER)
+                .rankingStatus(RankingStatus.FLEXER)
+                .build();
+
+        when(userService.findUserByUsername(username)).thenReturn(user);
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(rankingService.findLatestRanking(eq(chatroom), eq(lastMonday), any(LocalDateTime.class)))
+                .thenReturn(ranking);
+        when(chatParticipantService.findByUserIdAndChatroom(saverId, chatroom)).thenReturn(saver);
+        when(chatParticipantService.findByUserIdAndChatroom(flexerId, chatroom)).thenReturn(flexer);
+
+        var result = rankingFacade.getLatestRanking(username, chatroomId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.found()).isTrue();
+        assertThat(result.response().getRankingId()).isEqualTo(ranking.getId());
+        assertThat(result.response().getRankedAt()).isEqualTo(ranking.getCreatedDate().toString());
+        assertThat(result.response().getSaver().getUserId()).isEqualTo(saverId);
+        assertThat(result.response().getFlexer().getUserId()).isEqualTo(flexerId);
+    }
+
+    @Test
+    @DisplayName("최신 공지가 없는 경우 null 반환")
+    void getLatestRankingNull() {
+        String username = "test";
+        Long chatroomId = 1L;
+        User user = User.builder().username(username).build();
+        Chatroom chatroom = Chatroom.builder().id(chatroomId).build();
+
+        when(userService.findUserByUsername(username)).thenReturn(user);
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(rankingService.findLatestRanking(eq(chatroom), eq(lastMonday), any(LocalDateTime.class)))
+                .thenReturn(null);
+
+        var result = rankingFacade.getLatestRanking(username, chatroomId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.found()).isFalse();
+        assertThat(result.response().getRankedAt()).isEqualTo(lastMonday.toString());
+        assertThat(result.response().getRankingId()).isNull();
+        assertThat(result.response().getSaver()).isNull();
+        assertThat(result.response().getFlexer()).isNull();
+    }
+}

--- a/src/test/java/com/poortorich/ranking/facade/RankingFacadeTest.java
+++ b/src/test/java/com/poortorich/ranking/facade/RankingFacadeTest.java
@@ -113,7 +113,7 @@ class RankingFacadeTest {
     }
 
     @Test
-    @DisplayName("최신 공지가 없는 경우 null 반환")
+    @DisplayName("최신 랭킹이 없는 경우 null 반환")
     void getLatestRankingNull() {
         String username = "test";
         Long chatroomId = 1L;

--- a/src/test/java/com/poortorich/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/poortorich/ranking/service/RankingServiceTest.java
@@ -1,0 +1,63 @@
+package com.poortorich.ranking.service;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.ranking.entity.Ranking;
+import com.poortorich.ranking.repository.RankingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RankingServiceTest {
+
+    @Mock
+    private RankingRepository rankingRepository;
+
+    @InjectMocks
+    private RankingService rankingService;
+
+    private final LocalDateTime now = LocalDateTime.now();
+    private final LocalDateTime lastMonday = now
+            .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            .toLocalDate()
+            .atStartOfDay();
+
+    @Test
+    @DisplayName("최신 랭킹 조회 성공")
+    void findLatestRankingSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        Ranking ranking = Ranking.builder().chatroom(chatroom).build();
+
+        when(rankingRepository.findByChatroomAndCreatedDateBetween(chatroom, lastMonday, now))
+                .thenReturn(Optional.of(ranking));
+
+        Ranking result = rankingService.findLatestRanking(chatroom, lastMonday, now);
+
+        assertThat(result).isEqualTo(ranking);
+        assertThat(result.getChatroom()).isEqualTo(chatroom);
+    }
+
+    @Test
+    @DisplayName("최신 랭킹이 없는 경우 null 반환")
+    void findLatestRankingNull() {
+        Chatroom chatroom = Chatroom.builder().build();
+
+        when(rankingRepository.findByChatroomAndCreatedDateBetween(chatroom, lastMonday, now))
+                .thenReturn(Optional.empty());
+
+        Ranking result = rankingService.findLatestRanking(chatroom, lastMonday, now);
+
+        assertThat(result).isNull();
+    }
+}

--- a/src/test/java/com/poortorich/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/poortorich/ranking/service/RankingServiceTest.java
@@ -39,7 +39,7 @@ class RankingServiceTest {
         Chatroom chatroom = Chatroom.builder().build();
         Ranking ranking = Ranking.builder().chatroom(chatroom).build();
 
-        when(rankingRepository.findByChatroomAndCreatedDateBetween(chatroom, lastMonday, now))
+        when(rankingRepository.findFirstByChatroomAndCreatedDateBetweenOrderByCreatedDateDesc(chatroom, lastMonday, now))
                 .thenReturn(Optional.of(ranking));
 
         Ranking result = rankingService.findLatestRanking(chatroom, lastMonday, now);
@@ -53,7 +53,7 @@ class RankingServiceTest {
     void findLatestRankingNull() {
         Chatroom chatroom = Chatroom.builder().build();
 
-        when(rankingRepository.findByChatroomAndCreatedDateBetween(chatroom, lastMonday, now))
+        when(rankingRepository.findFirstByChatroomAndCreatedDateBetweenOrderByCreatedDateDesc(chatroom, lastMonday, now))
                 .thenReturn(Optional.empty());
 
         Ranking result = rankingService.findLatestRanking(chatroom, lastMonday, now);


### PR DESCRIPTION
## #️⃣연관된 이슈

#442
 
## 📝작업 내용
 
- 최신 랭킹 조회
  - 채팅방의 최신 랭킹을 조회
  - 최신 랭킹이 없는 경우 - `랭킹이 집계되지 않았습니다` 메시지와 함께 필수 필드 null 반환
 
### 스크린샷

<img width="1041" height="569" alt="image" src="https://github.com/user-attachments/assets/56027fea-40b1-4321-96f1-a56358ea593a" />

<img width="1040" height="356" alt="image" src="https://github.com/user-attachments/assets/5f318993-f057-41b3-9501-5bb6e8f32862" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 최신 랭킹 조회 API 추가: GET /chatrooms/{chatroomId}/rankings (인증 필요)
  - 응답: 랭킹 존재 시 200 OK와 랭킹 정보(rankedAt, rankingId, saver, flexer) 반환
  - 랭킹 미존재 시 200 OK와 안내 메시지 및 기준 일자(rankedAt) 제공
  - 안내 메시지(한국어) 추가: "최신 랭킹 조회를 완료했습니다.", "랭킹이 집계되지 않았습니다."

- **Tests**
  - 컨트롤러·서비스·페이스드 단위 테스트 추가로 성공/미존재 시나리오 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->