### PR TITLE
[#440] 공지 추가/수정/삭제 API

### DIFF
--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -34,7 +34,7 @@ import com.poortorich.chat.util.mapper.ChatMessageMapper;
 import com.poortorich.chat.util.provider.ChatPaginationProvider;
 import com.poortorich.chat.validator.ChatParticipantValidator;
 import com.poortorich.chat.validator.ChatroomValidator;
-import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
+import com.poortorich.chatnotice.request.ChatNoticeStatusUpdateRequest;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
 import com.poortorich.user.entity.User;
@@ -155,7 +155,7 @@ public class ChatFacade {
                 .build();
     }
 
-    public void updateNoticeStatus(String username, Long chatroomId, ChatNoticeUpdateRequest request) {
+    public void updateNoticeStatus(String username, Long chatroomId, ChatNoticeStatusUpdateRequest request) {
         Chatroom chatroom = chatroomService.findById(chatroomId);
         chatParticipantService.updateNoticeStatus(username, chatroom, request);
     }

--- a/src/main/java/com/poortorich/chat/realtime/controller/ChatRealtimeController.java
+++ b/src/main/java/com/poortorich/chat/realtime/controller/ChatRealtimeController.java
@@ -2,7 +2,6 @@ package com.poortorich.chat.realtime.controller;
 
 import com.poortorich.chat.realtime.facade.ChatRealTimeFacade;
 import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
-import com.poortorich.chat.realtime.payload.request.ChatNoticeRequestPayload;
 import com.poortorich.chat.realtime.payload.request.MarkMessagesAsReadRequestPayload;
 import com.poortorich.chat.realtime.payload.response.BasePayload;
 import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
@@ -46,17 +45,6 @@ public class ChatRealtimeController {
     ) {
         String username = sessionManager.getUsername(accessor);
         BasePayload responsePayload = chatRealTimeFacade.markMessagesAsRead(username, requestPayload);
-
-        messagingTemplate.convertAndSend(
-                SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + requestPayload.getChatroomId(),
-                responsePayload
-        );
-    }
-
-    @MessageMapping("/chat/notices")
-    public void handleChatNotice(StompHeaderAccessor accessor, @Payload @Valid ChatNoticeRequestPayload requestPayload) {
-        String username = sessionManager.getUsername(accessor);
-        BasePayload responsePayload = chatRealTimeFacade.handleChatNotice(username, requestPayload);
 
         messagingTemplate.convertAndSend(
                 SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + requestPayload.getChatroomId(),

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -3,12 +3,10 @@ package com.poortorich.chat.realtime.facade;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatMessageType;
-import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.model.MarkAllChatroomAsReadResult;
 import com.poortorich.chat.realtime.collect.ChatPayloadCollector;
 import com.poortorich.chat.realtime.model.PayloadContext;
 import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
-import com.poortorich.chat.realtime.payload.request.ChatNoticeRequestPayload;
 import com.poortorich.chat.realtime.payload.request.MarkMessagesAsReadRequestPayload;
 import com.poortorich.chat.realtime.payload.response.BasePayload;
 import com.poortorich.chat.realtime.payload.response.DateChangeMessagePayload;
@@ -16,7 +14,6 @@ import com.poortorich.chat.realtime.payload.response.MessageReadPayload;
 import com.poortorich.chat.realtime.payload.response.RankingStatusMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserChatMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserEnterResponsePayload;
-import com.poortorich.chat.realtime.payload.response.enums.PayloadType;
 import com.poortorich.chat.response.MarkAllChatroomAsReadResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
@@ -24,9 +21,7 @@ import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.service.UnreadChatMessageService;
 import com.poortorich.chat.util.manager.ChatroomLeaveManager;
 import com.poortorich.chat.validator.ChatParticipantValidator;
-import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.service.ChatNoticeService;
-import com.poortorich.chatnotice.util.ChatNoticeBuilder;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +29,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -129,30 +123,5 @@ public class ChatRealTimeFacade {
                 .broadcastPayloads(broadcastPayloads)
                 .build();
 
-    }
-
-    @Transactional
-    public BasePayload handleChatNotice(String username, ChatNoticeRequestPayload requestPayload) {
-        PayloadContext context = payloadCollector.getPayloadContext(username, requestPayload.getChatroomId());
-
-        participantValidator.validateIsHost(context.chatParticipant());
-        ChatNotice chatNotice = chatNoticeService.handleChatNotice(context, requestPayload);
-
-        if (Objects.isNull(chatNotice)) {
-            return BasePayload.builder()
-                    .type(PayloadType.NOTICE)
-                    .payload(null)
-                    .build();
-        }
-
-        List<ChatParticipant> chatParticipants = chatParticipantService.findAllByChatroom(context.chatroom());
-        NoticeStatus noticeStatus = chatParticipantService.updateAllNoticeStatus(
-                chatParticipants,
-                requestPayload.getNoticeType());
-        
-        return BasePayload.builder()
-                .type(PayloadType.NOTICE)
-                .payload(ChatNoticeBuilder.buildLatestNoticeResponse(noticeStatus, chatNotice))
-                .build();
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -8,7 +8,7 @@ import com.poortorich.chat.repository.ChatParticipantRepository;
 import com.poortorich.chat.response.ChatParticipantProfile;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.chat.util.ChatBuilder;
-import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
+import com.poortorich.chatnotice.request.ChatNoticeStatusUpdateRequest;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.user.entity.User;
@@ -32,7 +32,7 @@ public class ChatParticipantService {
         chatParticipantRepository.save(chatParticipant);
     }
 
-    public void updateNoticeStatus(String username, Chatroom chatroom, ChatNoticeUpdateRequest request) {
+    public void updateNoticeStatus(String username, Chatroom chatroom, ChatNoticeStatusUpdateRequest request) {
         ChatParticipant chatParticipant = findByUsernameAndChatroom(username, chatroom);
         validateNoticeStatus(chatParticipant.getNoticeStatus());
         chatParticipant.updateNoticeStatus(request.parseStatus());

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -4,7 +4,6 @@ import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.entity.enums.NoticeStatus;
-import com.poortorich.chat.realtime.payload.request.enums.NoticeType;
 import com.poortorich.chat.repository.ChatParticipantRepository;
 import com.poortorich.chat.response.ChatParticipantProfile;
 import com.poortorich.chat.response.enums.ChatResponse;
@@ -137,16 +136,7 @@ public class ChatParticipantService {
                 .toList();
     }
 
-    public NoticeStatus updateAllNoticeStatus(List<ChatParticipant> chatParticipants, NoticeType noticeType) {
-        NoticeStatus noticeStatus = findByNoticeType(noticeType);
+    public void updateAllNoticeStatus(List<ChatParticipant> chatParticipants, NoticeStatus noticeStatus) {
         chatParticipants.forEach(chatParticipant -> chatParticipant.updateNoticeStatus(noticeStatus));
-        return noticeStatus;
-    }
-
-    private NoticeStatus findByNoticeType(NoticeType noticeType) {
-        return switch (noticeType) {
-            case CREATE, UPDATE -> NoticeStatus.DEFAULT;
-            case DELETE -> NoticeStatus.PERMANENT_HIDDEN;
-        };
     }
 }

--- a/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
+++ b/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
@@ -18,6 +18,7 @@ public class ChatNoticeResponseMessage {
     public static final String CHAT_NOTICE_UPDATE_SUCCESS = "공지를 성공적으로 편집했습니다.";
     public static final String CHAT_NOTICE_UPDATE_FAILURE = "공지 편집을 실패했습니다.";
     public static final String CHAT_NOTICE_DELETE_SUCCESS = "공지를 성공적으로 삭제했습니다.";
+    public static final String CHATROOM_NOTICE_MISMATCH = "해당 공지는 채팅방에 속하지 않습니다.";
 
     private ChatNoticeResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
+++ b/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
@@ -13,6 +13,8 @@ public class ChatNoticeResponseMessage {
     public static final String NOTICE_NOT_FOUND = "공지를 찾을 수 없습니다.";
     public static final String NOTICE_TYPE_REQUIRED = "공지 처리 유형은 필수 값입니다.";
     public static final String NOTICE_CONTENT_REQUIRED = "공지 내용이 없습니다.";
+    public static final String CHAT_NOTICE_CREATE_SUCCESS = "공지를 성공적으로 추가했습니다.";
+    public static final String CHAT_NOTICE_CREATE_FAILURE = "공지 추가를 실패했습니다.";
 
     private ChatNoticeResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
+++ b/src/main/java/com/poortorich/chatnotice/constants/ChatNoticeResponseMessage.java
@@ -15,6 +15,9 @@ public class ChatNoticeResponseMessage {
     public static final String NOTICE_CONTENT_REQUIRED = "공지 내용이 없습니다.";
     public static final String CHAT_NOTICE_CREATE_SUCCESS = "공지를 성공적으로 추가했습니다.";
     public static final String CHAT_NOTICE_CREATE_FAILURE = "공지 추가를 실패했습니다.";
+    public static final String CHAT_NOTICE_UPDATE_SUCCESS = "공지를 성공적으로 편집했습니다.";
+    public static final String CHAT_NOTICE_UPDATE_FAILURE = "공지 편집을 실패했습니다.";
+    public static final String CHAT_NOTICE_DELETE_SUCCESS = "공지를 성공적으로 삭제했습니다.";
 
     private ChatNoticeResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
+++ b/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
@@ -44,7 +44,7 @@ public class ChatNoticeController {
     public ResponseEntity<BaseResponse> createNewNotice(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long chatroomId,
-            @RequestBody ChatNoticeCreateRequest noticeCreateRequest
+            @RequestBody @Valid ChatNoticeCreateRequest noticeCreateRequest
     ) {
         NoticeCreateResult result = chatNoticeFacade.create(userDetails.getUsername(), chatroomId, noticeCreateRequest);
         if (!Objects.isNull(result.getBroadcastPayload())) {
@@ -60,7 +60,7 @@ public class ChatNoticeController {
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long chatroomId,
             @PathVariable Long noticeId,
-            @RequestBody ChatNoticeUpdateRequest noticeUpdateRequest
+            @RequestBody @Valid ChatNoticeUpdateRequest noticeUpdateRequest
     ) {
         NoticeUpdateResult result = chatNoticeFacade.update(
                 userDetails.getUsername(),
@@ -92,7 +92,6 @@ public class ChatNoticeController {
         return BaseResponse.toResponseEntity(ChatNoticeResponse.CHAT_NOTICE_DELETE_SUCCESS);
     }
 
-    @GetMapping
     public ResponseEntity<BaseResponse> getLatestNotice(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long chatroomId

--- a/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
+++ b/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
@@ -1,24 +1,34 @@
 package com.poortorich.chatnotice.controller;
 
 import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chat.realtime.payload.response.BasePayload;
 import com.poortorich.chatnotice.facade.ChatNoticeFacade;
+import com.poortorich.chatnotice.model.NoticeCreateResult;
+import com.poortorich.chatnotice.model.NoticeUpdateResult;
 import com.poortorich.chatnotice.request.ChatNoticeCreateRequest;
+import com.poortorich.chatnotice.request.ChatNoticeStatusUpdateRequest;
 import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
 import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
 import com.poortorich.global.response.BaseResponse;
 import com.poortorich.global.response.DataResponse;
+import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Objects;
 
 @RestController
 @RequestMapping("/chatrooms/{chatroomId}/notices")
@@ -28,14 +38,58 @@ public class ChatNoticeController {
     private final ChatFacade chatFacade;
     private final ChatNoticeFacade chatNoticeFacade;
 
+    private final SimpMessagingTemplate messagingTemplate;
+
     @PostMapping
     public ResponseEntity<BaseResponse> createNewNotice(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long chatroomId,
             @RequestBody ChatNoticeCreateRequest noticeCreateRequest
     ) {
-        chatNoticeFacade.create(userDetails.getUsername(), chatroomId, noticeCreateRequest);
-        return BaseResponse.toResponseEntity(ChatNoticeResponse.CHAT_NOTICE_CREATE_SUCCESS);
+        NoticeCreateResult result = chatNoticeFacade.create(userDetails.getUsername(), chatroomId, noticeCreateRequest);
+        if (!Objects.isNull(result.getBroadcastPayload())) {
+            messagingTemplate.convertAndSend(
+                    SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId,
+                    result.getBroadcastPayload());
+        }
+        return DataResponse.toResponseEntity(ChatNoticeResponse.CHAT_NOTICE_CREATE_SUCCESS, result.getApiResponse());
+    }
+
+    @PutMapping("/{noticeId}")
+    public ResponseEntity<BaseResponse> updateNotice(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId,
+            @PathVariable Long noticeId,
+            @RequestBody ChatNoticeUpdateRequest noticeUpdateRequest
+    ) {
+        NoticeUpdateResult result = chatNoticeFacade.update(
+                userDetails.getUsername(),
+                chatroomId,
+                noticeId,
+                noticeUpdateRequest);
+        if (!Objects.isNull(result.getBroadcastPayload())) {
+            messagingTemplate.convertAndSend(
+                    SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId,
+                    result.getBroadcastPayload()
+            );
+        }
+        return DataResponse.toResponseEntity(ChatNoticeResponse.CHAT_NOTICE_UPDATE_SUCCESS, result.getApiResponse());
+    }
+
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<BaseResponse> deleteNotice(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId,
+            @PathVariable Long noticeId
+    ) {
+        BasePayload basePayload = chatNoticeFacade.deleteNotice(userDetails.getUsername(), chatroomId, noticeId);
+
+        if (!Objects.isNull(basePayload)) {
+            messagingTemplate.convertAndSend(
+                    SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId,
+                    basePayload);
+        }
+        return BaseResponse.toResponseEntity(ChatNoticeResponse.CHAT_NOTICE_DELETE_SUCCESS);
     }
 
     @GetMapping
@@ -61,7 +115,7 @@ public class ChatNoticeController {
     public ResponseEntity<BaseResponse> updateNoticeStatus(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long chatroomId,
-            @RequestBody @Valid ChatNoticeUpdateRequest request
+            @RequestBody @Valid ChatNoticeStatusUpdateRequest request
     ) {
         chatFacade.updateNoticeStatus(userDetails.getUsername(), chatroomId, request);
         return BaseResponse.toResponseEntity(ChatNoticeResponse.UPDATE_NOTICE_STATUS_SUCCESS);

--- a/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
+++ b/src/main/java/com/poortorich/chatnotice/controller/ChatNoticeController.java
@@ -2,6 +2,7 @@ package com.poortorich.chatnotice.controller;
 
 import com.poortorich.chat.facade.ChatFacade;
 import com.poortorich.chatnotice.facade.ChatNoticeFacade;
+import com.poortorich.chatnotice.request.ChatNoticeCreateRequest;
 import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
 import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
 import com.poortorich.global.response.BaseResponse;
@@ -14,6 +15,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,6 +27,16 @@ public class ChatNoticeController {
 
     private final ChatFacade chatFacade;
     private final ChatNoticeFacade chatNoticeFacade;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse> createNewNotice(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId,
+            @RequestBody ChatNoticeCreateRequest noticeCreateRequest
+    ) {
+        chatNoticeFacade.create(userDetails.getUsername(), chatroomId, noticeCreateRequest);
+        return BaseResponse.toResponseEntity(ChatNoticeResponse.CHAT_NOTICE_CREATE_SUCCESS);
+    }
 
     @GetMapping
     public ResponseEntity<BaseResponse> getLatestNotice(

--- a/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
+++ b/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
@@ -18,6 +18,7 @@ import com.poortorich.chatnotice.response.PreviewNoticesResponse;
 import com.poortorich.chatnotice.service.ChatNoticeService;
 import com.poortorich.chatnotice.util.ChatNoticeBuilder;
 import com.poortorich.chatnotice.util.mapper.ChatNoticeDataMapper;
+import com.poortorich.chatnotice.validator.ChatNoticeValidator;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ public class ChatNoticeFacade {
 
     private final ChatNoticeDataMapper noticeDataMapper;
     private final ChatParticipantValidator participantValidator;
+    private final ChatNoticeValidator chatNoticeValidator;
 
     @Transactional
     public NoticeCreateResult create(String username, Long chatroomId, ChatNoticeCreateRequest noticeCreateRequest) {
@@ -67,6 +69,7 @@ public class ChatNoticeFacade {
         ChatParticipant chatParticipant = chatParticipantService.findByUserAndChatroom(user, chatroom);
 
         participantValidator.validateIsHost(chatParticipant);
+        chatNoticeValidator.validateNoticeBelongsToChatroom(noticeId, chatroom);
 
         ChatNotice chatNotice = chatNoticeService.update(noticeId, noticeUpdateRequest);
         boolean isLatestNotice = chatNoticeService.isLatestNotice(chatNotice);
@@ -111,6 +114,8 @@ public class ChatNoticeFacade {
         ChatParticipant chatParticipant = chatParticipantService.findByUserAndChatroom(user, chatroom);
 
         participantValidator.validateIsHost(chatParticipant);
+        chatNoticeValidator.validateNoticeBelongsToChatroom(noticeId, chatroom);
+
         ChatNotice chatNotice = chatNoticeService.findById(noticeId);
         boolean isLatestNotice = chatNoticeService.isLatestNotice(chatNotice);
         chatNoticeService.delete(noticeId);

--- a/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
+++ b/src/main/java/com/poortorich/chatnotice/facade/ChatNoticeFacade.java
@@ -75,7 +75,6 @@ public class ChatNoticeFacade {
         if (isLatestNotice) {
             List<ChatParticipant> participants = chatParticipantService.findAllByChatroom(chatroom);
             chatParticipantService.updateAllNoticeStatus(participants, NoticeStatus.DEFAULT);
-
         }
         return result;
     }
@@ -120,7 +119,7 @@ public class ChatNoticeFacade {
             List<ChatParticipant> participants = chatParticipantService.findAllByChatroom(chatroom);
             chatParticipantService.updateAllNoticeStatus(participants, NoticeStatus.PERMANENT_HIDDEN);
         }
-        
+
         return noticeDataMapper.mapToNoticeDeletePayload(isLatestNotice);
     }
 }

--- a/src/main/java/com/poortorich/chatnotice/model/NoticeCreateResult.java
+++ b/src/main/java/com/poortorich/chatnotice/model/NoticeCreateResult.java
@@ -1,0 +1,4 @@
+package com.poortorich.chatnotice.model;
+
+public class NoticeCreateResult {
+}

--- a/src/main/java/com/poortorich/chatnotice/model/NoticeCreateResult.java
+++ b/src/main/java/com/poortorich/chatnotice/model/NoticeCreateResult.java
@@ -1,4 +1,14 @@
 package com.poortorich.chatnotice.model;
 
+import com.poortorich.chat.realtime.payload.response.BasePayload;
+import com.poortorich.chatnotice.response.ChatNoticeCreateResponse;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
 public class NoticeCreateResult {
+
+    private final ChatNoticeCreateResponse apiResponse;
+    private final BasePayload broadcastPayload;
 }

--- a/src/main/java/com/poortorich/chatnotice/model/NoticeUpdateResult.java
+++ b/src/main/java/com/poortorich/chatnotice/model/NoticeUpdateResult.java
@@ -1,0 +1,15 @@
+package com.poortorich.chatnotice.model;
+
+
+import com.poortorich.chat.realtime.payload.response.BasePayload;
+import com.poortorich.chatnotice.response.ChatNoticeUpdateResponse;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class NoticeUpdateResult {
+
+    private final ChatNoticeUpdateResponse apiResponse;
+    private final BasePayload broadcastPayload;
+}

--- a/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
+++ b/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
@@ -16,4 +16,6 @@ public interface ChatNoticeRepository extends JpaRepository<ChatNotice, Long> {
     List<ChatNotice> findTop3ByChatroomOrderByCreatedDateDesc(Chatroom chatroom);
 
     Optional<ChatNotice> findByChatroomAndId(Chatroom chatroom, Long noticeId);
+
+    boolean existsByIdAndChatroom(Long noticeId, Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chatnotice/request/ChatNoticeCreateRequest.java
+++ b/src/main/java/com/poortorich/chatnotice/request/ChatNoticeCreateRequest.java
@@ -1,0 +1,4 @@
+package com.poortorich.chatnotice.request;
+
+public class ChatNoticeCreateRequest {
+}

--- a/src/main/java/com/poortorich/chatnotice/request/ChatNoticeCreateRequest.java
+++ b/src/main/java/com/poortorich/chatnotice/request/ChatNoticeCreateRequest.java
@@ -1,4 +1,14 @@
 package com.poortorich.chatnotice.request;
 
+import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class ChatNoticeCreateRequest {
+
+    @NotNull(message = ChatNoticeResponseMessage.NOTICE_CONTENT_REQUIRED)
+    private String content;
 }

--- a/src/main/java/com/poortorich/chatnotice/request/ChatNoticeStatusUpdateRequest.java
+++ b/src/main/java/com/poortorich/chatnotice/request/ChatNoticeStatusUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.poortorich.chatnotice.request;
+
+import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
+import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatNoticeStatusUpdateRequest {
+
+    @NotNull(message = ChatNoticeResponseMessage.NOTICE_STATUS_REQUIRED)
+    private String status;
+
+    public NoticeStatus parseStatus() {
+        try {
+            return NoticeStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(ChatNoticeResponse.NOTICE_STATUS_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/poortorich/chatnotice/request/ChatNoticeUpdateRequest.java
+++ b/src/main/java/com/poortorich/chatnotice/request/ChatNoticeUpdateRequest.java
@@ -1,9 +1,6 @@
 package com.poortorich.chatnotice.request;
 
-import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
-import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
-import com.poortorich.global.exceptions.BadRequestException;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,14 +9,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ChatNoticeUpdateRequest {
 
-    @NotNull(message = ChatNoticeResponseMessage.NOTICE_STATUS_REQUIRED)
-    private String status;
-
-    public NoticeStatus parseStatus() {
-        try {
-            return NoticeStatus.valueOf(status.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException(ChatNoticeResponse.NOTICE_STATUS_INVALID);
-        }
-    }
+    @NotNull(message = ChatNoticeResponseMessage.NOTICE_CONTENT_REQUIRED)
+    private final String content;
 }

--- a/src/main/java/com/poortorich/chatnotice/response/ChatNoticeCreateResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/ChatNoticeCreateResponse.java
@@ -1,4 +1,11 @@
 package com.poortorich.chatnotice.response;
 
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
 public class ChatNoticeCreateResponse {
+
+    private final Long noticeId;
 }

--- a/src/main/java/com/poortorich/chatnotice/response/ChatNoticeCreateResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/ChatNoticeCreateResponse.java
@@ -1,0 +1,4 @@
+package com.poortorich.chatnotice.response;
+
+public class ChatNoticeCreateResponse {
+}

--- a/src/main/java/com/poortorich/chatnotice/response/ChatNoticeUpdateResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/ChatNoticeUpdateResponse.java
@@ -1,0 +1,11 @@
+package com.poortorich.chatnotice.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ChatNoticeUpdateResponse {
+
+    private final Long noticeId;
+}

--- a/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
@@ -27,7 +27,8 @@ public enum ChatNoticeResponse implements Response {
             HttpStatus.INTERNAL_SERVER_ERROR,
             ChatNoticeResponseMessage.CHAT_NOTICE_UPDATE_FAILURE,
             null),
-    CHAT_NOTICE_DELETE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.CHAT_NOTICE_DELETE_SUCCESS, null);
+    CHAT_NOTICE_DELETE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.CHAT_NOTICE_DELETE_SUCCESS, null),
+    CHATROOM_NOTICE_MISMATCH(HttpStatus.BAD_REQUEST, ChatNoticeResponseMessage.CHATROOM_NOTICE_MISMATCH, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
@@ -15,7 +15,9 @@ public enum ChatNoticeResponse implements Response {
 
     NOTICE_STATUS_INVALID(HttpStatus.BAD_REQUEST, ChatNoticeResponseMessage.NOTICE_STATUS_INVALID, "status"),
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, ChatNoticeResponseMessage.NOTICE_NOT_FOUND, null),
-    CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, ChatNoticeResponseMessage.NOTICE_CONTENT_REQUIRED, null);
+    CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, ChatNoticeResponseMessage.NOTICE_CONTENT_REQUIRED, null),
+    CHAT_NOTICE_CREATE_SUCCESS(HttpStatus.CREATED, ChatNoticeResponseMessage.CHAT_NOTICE_CREATE_SUCCESS, null),
+    CHAT_NOTICE_CREATE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, ChatNoticeResponseMessage.CHAT_NOTICE_CREATE_FAILURE, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
+++ b/src/main/java/com/poortorich/chatnotice/response/enums/ChatNoticeResponse.java
@@ -17,7 +17,17 @@ public enum ChatNoticeResponse implements Response {
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, ChatNoticeResponseMessage.NOTICE_NOT_FOUND, null),
     CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, ChatNoticeResponseMessage.NOTICE_CONTENT_REQUIRED, null),
     CHAT_NOTICE_CREATE_SUCCESS(HttpStatus.CREATED, ChatNoticeResponseMessage.CHAT_NOTICE_CREATE_SUCCESS, null),
-    CHAT_NOTICE_CREATE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, ChatNoticeResponseMessage.CHAT_NOTICE_CREATE_FAILURE, null);
+
+    CHAT_NOTICE_CREATE_FAILURE(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ChatNoticeResponseMessage.CHAT_NOTICE_CREATE_FAILURE,
+            null),
+    CHAT_NOTICE_UPDATE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.CHAT_NOTICE_UPDATE_SUCCESS, null),
+    CHAT_NOTICE_UPDATE_FAILURE(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ChatNoticeResponseMessage.CHAT_NOTICE_UPDATE_FAILURE,
+            null),
+    CHAT_NOTICE_DELETE_SUCCESS(HttpStatus.OK, ChatNoticeResponseMessage.CHAT_NOTICE_DELETE_SUCCESS, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -1,12 +1,13 @@
 package com.poortorich.chatnotice.service;
 
+import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.realtime.model.PayloadContext;
 import com.poortorich.chat.realtime.payload.request.ChatNoticeRequestPayload;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.repository.ChatNoticeRepository;
+import com.poortorich.chatnotice.request.ChatNoticeCreateRequest;
 import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
-import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,15 +22,11 @@ public class ChatNoticeService {
 
     private final ChatNoticeRepository chatNoticeRepository;
 
-    public ChatNotice create(PayloadContext context, ChatNoticeRequestPayload requestPayload) {
-        if (Objects.isNull(requestPayload.getContent())) {
-            throw new BadRequestException(ChatNoticeResponse.CONTENT_REQUIRED);
-        }
-
+    public ChatNotice create(ChatParticipant author, ChatNoticeCreateRequest noticeCreateRequest) {
         ChatNotice notice = ChatNotice.builder()
-                .content(requestPayload.getContent())
-                .author(context.chatParticipant())
-                .chatroom(context.chatroom())
+                .content(noticeCreateRequest.getContent())
+                .author(author)
+                .chatroom(author.getChatroom())
                 .build();
 
         return chatNoticeRepository.save(notice);
@@ -55,14 +52,6 @@ public class ChatNoticeService {
         chatNotice.updateContent(requestPayload.getContent());
 
         return chatNoticeRepository.save(chatNotice);
-    }
-
-    public ChatNotice handleChatNotice(PayloadContext context, ChatNoticeRequestPayload requestPayload) {
-        return switch (requestPayload.getNoticeType()) {
-            case CREATE -> create(context, requestPayload);
-            case UPDATE -> update(context, requestPayload);
-            case DELETE -> delete(context);
-        };
     }
 
     public ChatNotice delete(PayloadContext context) {

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -52,10 +52,9 @@ public class ChatNoticeService {
         return latestChatNotice.isPresent() && latestChatNotice.get().getId().equals(chatNotice.getId());
     }
 
-    public ChatNotice delete(Long noticeId) {
+    public void delete(Long noticeId) {
         Optional<ChatNotice> chatNotice = chatNoticeRepository.findById(noticeId);
         chatNotice.ifPresent(chatNoticeRepository::delete);
-        return null;
     }
 
     public ChatNotice findNotice(Chatroom chatroom, Long noticeId) {

--- a/src/main/java/com/poortorich/chatnotice/util/mapper/ChatNoticeDataMapper.java
+++ b/src/main/java/com/poortorich/chatnotice/util/mapper/ChatNoticeDataMapper.java
@@ -1,4 +1,32 @@
 package com.poortorich.chatnotice.util.mapper;
 
+import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chat.realtime.payload.response.BasePayload;
+import com.poortorich.chat.realtime.payload.response.enums.PayloadType;
+import com.poortorich.chatnotice.entity.ChatNotice;
+import com.poortorich.chatnotice.model.NoticeCreateResult;
+import com.poortorich.chatnotice.response.ChatNoticeCreateResponse;
+import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
+import com.poortorich.chatnotice.util.ChatNoticeBuilder;
+import com.poortorich.global.exceptions.InternalServerErrorException;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
 public class ChatNoticeDataMapper {
+
+    public NoticeCreateResult mapToNoticeCreateResult(ChatNotice chatNotice) {
+        if (Objects.isNull(chatNotice)) {
+            throw new InternalServerErrorException(ChatNoticeResponse.CHAT_NOTICE_CREATE_FAILURE);
+        }
+
+        return NoticeCreateResult.builder()
+                .apiResponse(ChatNoticeCreateResponse.builder().noticeId(chatNotice.getId()).build())
+                .broadcastPayload(BasePayload.builder()
+                        .type(PayloadType.NOTICE)
+                        .payload(ChatNoticeBuilder.buildLatestNoticeResponse(NoticeStatus.DEFAULT, chatNotice))
+                        .build())
+                .build();
+    }
 }

--- a/src/main/java/com/poortorich/chatnotice/util/mapper/ChatNoticeDataMapper.java
+++ b/src/main/java/com/poortorich/chatnotice/util/mapper/ChatNoticeDataMapper.java
@@ -38,7 +38,7 @@ public class ChatNoticeDataMapper {
             throw new InternalServerErrorException(ChatNoticeResponse.CHAT_NOTICE_UPDATE_FAILURE);
         }
 
-        if (isLatestNotice) {
+        if (!isLatestNotice) {
             return NoticeUpdateResult.builder()
                     .apiResponse(ChatNoticeUpdateResponse.builder().noticeId(chatNotice.getId()).build())
                     .build();

--- a/src/main/java/com/poortorich/chatnotice/util/mapper/ChatNoticeDataMapper.java
+++ b/src/main/java/com/poortorich/chatnotice/util/mapper/ChatNoticeDataMapper.java
@@ -5,7 +5,10 @@ import com.poortorich.chat.realtime.payload.response.BasePayload;
 import com.poortorich.chat.realtime.payload.response.enums.PayloadType;
 import com.poortorich.chatnotice.entity.ChatNotice;
 import com.poortorich.chatnotice.model.NoticeCreateResult;
+import com.poortorich.chatnotice.model.NoticeUpdateResult;
 import com.poortorich.chatnotice.response.ChatNoticeCreateResponse;
+import com.poortorich.chatnotice.response.ChatNoticeUpdateResponse;
+import com.poortorich.chatnotice.response.LatestNoticeResponse;
 import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
 import com.poortorich.chatnotice.util.ChatNoticeBuilder;
 import com.poortorich.global.exceptions.InternalServerErrorException;
@@ -28,5 +31,37 @@ public class ChatNoticeDataMapper {
                         .payload(ChatNoticeBuilder.buildLatestNoticeResponse(NoticeStatus.DEFAULT, chatNotice))
                         .build())
                 .build();
+    }
+
+    public NoticeUpdateResult mapToNoticeUpdateResult(ChatNotice chatNotice, boolean isLatestNotice) {
+        if (Objects.isNull(chatNotice)) {
+            throw new InternalServerErrorException(ChatNoticeResponse.CHAT_NOTICE_UPDATE_FAILURE);
+        }
+
+        if (isLatestNotice) {
+            return NoticeUpdateResult.builder()
+                    .apiResponse(ChatNoticeUpdateResponse.builder().noticeId(chatNotice.getId()).build())
+                    .build();
+        }
+
+        return NoticeUpdateResult.builder()
+                .apiResponse(ChatNoticeUpdateResponse.builder().noticeId(chatNotice.getId()).build())
+                .broadcastPayload(BasePayload.builder()
+                        .type(PayloadType.NOTICE)
+                        .payload(ChatNoticeBuilder.buildLatestNoticeResponse(NoticeStatus.DEFAULT, chatNotice))
+                        .build())
+                .build();
+    }
+
+    public BasePayload mapToNoticeDeletePayload(boolean isLatestNotice) {
+        if (isLatestNotice) {
+            return BasePayload.builder()
+                    .type(PayloadType.NOTICE)
+                    .payload(LatestNoticeResponse.builder()
+                            .status(NoticeStatus.PERMANENT_HIDDEN.toString())
+                            .build())
+                    .build();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/poortorich/chatnotice/util/mapper/ChatNoticeDataMapper.java
+++ b/src/main/java/com/poortorich/chatnotice/util/mapper/ChatNoticeDataMapper.java
@@ -1,0 +1,4 @@
+package com.poortorich.chatnotice.util.mapper;
+
+public class ChatNoticeDataMapper {
+}

--- a/src/main/java/com/poortorich/chatnotice/validator/ChatNoticeValidator.java
+++ b/src/main/java/com/poortorich/chatnotice/validator/ChatNoticeValidator.java
@@ -1,0 +1,21 @@
+package com.poortorich.chatnotice.validator;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chatnotice.repository.ChatNoticeRepository;
+import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatNoticeValidator {
+
+    private final ChatNoticeRepository chatNoticeRepository;
+
+    public void validateNoticeBelongsToChatroom(Long noticeId, Chatroom chatroom) {
+        if (!chatNoticeRepository.existsByIdAndChatroom(noticeId, chatroom)) {
+            throw new BadRequestException(ChatNoticeResponse.CHATROOM_NOTICE_MISMATCH);
+        }
+    }
+}

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -16,7 +16,7 @@ import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
-import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
+import com.poortorich.chatnotice.request.ChatNoticeStatusUpdateRequest;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
 import com.poortorich.user.entity.User;
@@ -288,7 +288,7 @@ class ChatFacadeTest {
     void updateNoticeStatusSuccess() {
         String username = "testUser";
         Long chatroomId = 1L;
-        ChatNoticeUpdateRequest request = new ChatNoticeUpdateRequest("DEFAULT");
+        ChatNoticeStatusUpdateRequest request = new ChatNoticeStatusUpdateRequest("DEFAULT");
 
         when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
 

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -17,12 +17,8 @@ import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
-<<<<<<< HEAD
-import com.poortorich.chatnotice.request.ChatNoticeStatusUpdateRequest;
-=======
 import com.poortorich.chat.validator.ChatParticipantValidator;
-import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
->>>>>>> dev
+import com.poortorich.chatnotice.request.ChatNoticeStatusUpdateRequest;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.tag.service.TagService;
 import com.poortorich.user.entity.User;

--- a/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
@@ -6,7 +6,7 @@ import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.repository.ChatParticipantRepository;
 import com.poortorich.chat.response.enums.ChatResponse;
-import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
+import com.poortorich.chatnotice.request.ChatNoticeStatusUpdateRequest;
 import com.poortorich.chatnotice.response.enums.ChatNoticeResponse;
 import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.NotFoundException;
@@ -184,7 +184,7 @@ class ChatParticipantServiceTest {
     void updateNoticeStatusSuccess() {
         String username = "test";
         Long chatroomId = 1L;
-        ChatNoticeUpdateRequest request = new ChatNoticeUpdateRequest("TEMP_HIDDEN");
+        ChatNoticeStatusUpdateRequest request = new ChatNoticeStatusUpdateRequest("TEMP_HIDDEN");
         Chatroom chatroom = Chatroom.builder()
                 .id(chatroomId)
                 .build();
@@ -209,7 +209,7 @@ class ChatParticipantServiceTest {
     void updateNoticeStatusCurrentStatusPermanentHidden() {
         String username = "test";
         Long chatroomId = 1L;
-        ChatNoticeUpdateRequest request = new ChatNoticeUpdateRequest("TEMP_HIDDEN");
+        ChatNoticeStatusUpdateRequest request = new ChatNoticeStatusUpdateRequest("TEMP_HIDDEN");
         Chatroom chatroom = Chatroom.builder()
                 .id(chatroomId)
                 .build();
@@ -231,7 +231,7 @@ class ChatParticipantServiceTest {
     void updateNoticeStatusInvalidRequest() {
         String username = "test";
         Long chatroomId = 1L;
-        ChatNoticeUpdateRequest request = new ChatNoticeUpdateRequest("INVALID_REQUEST");
+        ChatNoticeStatusUpdateRequest request = new ChatNoticeStatusUpdateRequest("INVALID_REQUEST");
         Chatroom chatroom = Chatroom.builder()
                 .id(chatroomId)
                 .build();

--- a/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
+++ b/src/test/java/com/poortorich/chatnotice/controller/ChatNoticeControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.poortorich.chat.facade.ChatFacade;
 import com.poortorich.chatnotice.constants.ChatNoticeResponseMessage;
 import com.poortorich.chatnotice.facade.ChatNoticeFacade;
-import com.poortorich.chatnotice.request.ChatNoticeUpdateRequest;
+import com.poortorich.chatnotice.request.ChatNoticeStatusUpdateRequest;
 import com.poortorich.chatnotice.response.LatestNoticeResponse;
 import com.poortorich.chatnotice.response.NoticeDetailsResponse;
 import com.poortorich.chatnotice.response.PreviewNoticesResponse;
@@ -32,17 +32,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 class ChatNoticeControllerTest extends BaseSecurityTest {
 
+    private final String username = "test";
     @Autowired
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
-
     @MockitoBean
     private ChatFacade chatFacade;
     @MockitoBean
     private ChatNoticeFacade chatNoticeFacade;
-
-    private final String username = "test";
 
     @Test
     @WithMockUser(username = username)
@@ -65,7 +63,7 @@ class ChatNoticeControllerTest extends BaseSecurityTest {
     @DisplayName("공지 상태 변경 성공")
     void updateNoticeStatusSuccess() throws Exception {
         long chatroomId = 1L;
-        ChatNoticeUpdateRequest request = new ChatNoticeUpdateRequest("TEMP_HIDDEN");
+        ChatNoticeStatusUpdateRequest request = new ChatNoticeStatusUpdateRequest("TEMP_HIDDEN");
 
         mockMvc.perform(patch("/chatrooms/" + chatroomId + "/notices")
                         .content(objectMapper.writeValueAsString(request))
@@ -82,7 +80,7 @@ class ChatNoticeControllerTest extends BaseSecurityTest {
     @DisplayName("공지 상태 변경 입력값이 없는 경우 예외 발생")
     void updateNoticeStatusRequestNull() throws Exception {
         long chatroomId = 1L;
-        ChatNoticeUpdateRequest request = new ChatNoticeUpdateRequest(null);
+        ChatNoticeStatusUpdateRequest request = new ChatNoticeStatusUpdateRequest(null);
 
         mockMvc.perform(patch("/chatrooms/" + chatroomId + "/notices")
                         .content(objectMapper.writeValueAsString(request))


### PR DESCRIPTION
## #️⃣440
 
 ## 📝작업 내용
 - 공지 추가, 수정, 삭제 REST API를 추가했습니다.
 - 기존에 있던 발행 로직을 리팩터링하여 Publish 대신 REST API를 통해 공지를 추가/수정/삭제할 수 있습니다.
 - [ 변동된 점 ]
   -  기존 로직과 달리 모든 공지에 대해서 수정/삭제가 가능
   - 최근 공지에 한해서만 데이터가 브로드캐스트됨
  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 채팅방 공지 생성·수정·삭제 REST API 추가 및 생성/수정/삭제 시 구독자 대상 실시간 브로드캐스트 지원
- 리팩터
  - 공지 수정 요청이 상태 기반에서 내용(content) 기반으로 변경 및 공지 상태 업데이트 전용 요청 타입 도입
  - 실시간 컨트롤러에서 공지 처리 제거(메시지/읽음만 유지) 및 공지 흐름 간소화
- 기타
  - 공지 관련 응답 메시지·응답 타입 확장, 매핑/검증/저장소 검사 유틸 추가
- 테스트
  - 새로운 요청 타입과 엔드포인트 변경에 맞춰 테스트 케이스 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->