### PR TITLE
[#446] 최신 사진 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/photo/constants/PhotoResponseMessage.java
+++ b/src/main/java/com/poortorich/photo/constants/PhotoResponseMessage.java
@@ -3,6 +3,8 @@ package com.poortorich.photo.constants;
 public class PhotoResponseMessage {
 
     public static final String UPLOAD_PHOTO_SUCCESS = "이미지 전송에 성공했습니다.";
+    public static final String GET_PREVIEW_PHOTOS_SUCCESS = "최신 사진 목록 조회를 완료했습니다.";
+
     public static final String PHOTO_REQUIRED = "이미지는 필수값입니다.";
 
     private PhotoResponseMessage() {

--- a/src/main/java/com/poortorich/photo/controller/PhotoController.java
+++ b/src/main/java/com/poortorich/photo/controller/PhotoController.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,6 +32,17 @@ public class PhotoController {
         return DataResponse.toResponseEntity(
                 PhotoResponse.UPLOAD_PHOTO_SUCCESS,
                 photoFacade.uploadPhoto(userDetails.getUsername(), chatroomId, request)
+        );
+    }
+
+    @GetMapping("/preview")
+    public ResponseEntity<BaseResponse> getPreviewPhotos(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId
+    ) {
+        return DataResponse.toResponseEntity(
+                PhotoResponse.GET_PREVIEW_PHOTOS_SUCCESS,
+                photoFacade.getPreviewPhotos(userDetails.getUsername(), chatroomId)
         );
     }
 }

--- a/src/main/java/com/poortorich/photo/facade/PhotoFacade.java
+++ b/src/main/java/com/poortorich/photo/facade/PhotoFacade.java
@@ -4,10 +4,13 @@ import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.validator.ChatParticipantValidator;
 import com.poortorich.global.exceptions.BadRequestException;
+import com.poortorich.photo.entity.Photo;
 import com.poortorich.photo.request.PhotoUploadRequest;
 import com.poortorich.photo.response.PhotoUploadResponse;
+import com.poortorich.photo.response.PreviewPhotosResponse;
 import com.poortorich.photo.response.enums.PhotoResponse;
 import com.poortorich.photo.service.PhotoService;
+import com.poortorich.photo.util.PhotoBuilder;
 import com.poortorich.s3.service.FileUploadService;
 import com.poortorich.user.entity.User;
 import com.poortorich.user.service.UserService;
@@ -15,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +49,13 @@ public class PhotoFacade {
         if (photo == null || photo.isEmpty()) {
             throw new BadRequestException(PhotoResponse.PHOTO_REQUIRED);
         }
+    }
+
+    public PreviewPhotosResponse getPreviewPhotos(String username, Long chatroomId) {
+        User user = userService.findUserByUsername(username);
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+        chatParticipantValidator.validateIsParticipate(user, chatroom);
+
+        return PhotoBuilder.buildPhotosResponse(photoService.getPreviewPhotos(chatroom));
     }
 }

--- a/src/main/java/com/poortorich/photo/facade/PhotoFacade.java
+++ b/src/main/java/com/poortorich/photo/facade/PhotoFacade.java
@@ -51,6 +51,7 @@ public class PhotoFacade {
         }
     }
 
+    @Transactional(readOnly = true)
     public PreviewPhotosResponse getPreviewPhotos(String username, Long chatroomId) {
         User user = userService.findUserByUsername(username);
         Chatroom chatroom = chatroomService.findById(chatroomId);

--- a/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
@@ -1,9 +1,14 @@
 package com.poortorich.photo.repository;
 
+import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.photo.entity.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
+
+    List<Photo> findTop10ByChatroomOrderByCreatedDateDesc(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
-    List<Photo> findTop10ByChatroomOrderByCreatedDateDesc(Chatroom chatroom);
+    List<Photo> findTop10ByChatroomOrderByCreatedDateDescIdAsc(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/photo/response/PhotoInfoResponse.java
+++ b/src/main/java/com/poortorich/photo/response/PhotoInfoResponse.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PhotoResponse {
+public class PhotoInfoResponse {
 
     private Long photoId;
     private String photoUrl;

--- a/src/main/java/com/poortorich/photo/response/PhotoResponse.java
+++ b/src/main/java/com/poortorich/photo/response/PhotoResponse.java
@@ -1,0 +1,16 @@
+package com.poortorich.photo.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoResponse {
+
+    private Long photoId;
+    private String photoUrl;
+}

--- a/src/main/java/com/poortorich/photo/response/PreviewPhotosResponse.java
+++ b/src/main/java/com/poortorich/photo/response/PreviewPhotosResponse.java
@@ -1,0 +1,17 @@
+package com.poortorich.photo.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreviewPhotosResponse {
+
+    private List<PhotoResponse> photos;
+}

--- a/src/main/java/com/poortorich/photo/response/PreviewPhotosResponse.java
+++ b/src/main/java/com/poortorich/photo/response/PreviewPhotosResponse.java
@@ -13,5 +13,5 @@ import java.util.List;
 @AllArgsConstructor
 public class PreviewPhotosResponse {
 
-    private List<PhotoResponse> photos;
+    private List<PhotoInfoResponse> photos;
 }

--- a/src/main/java/com/poortorich/photo/response/enums/PhotoResponse.java
+++ b/src/main/java/com/poortorich/photo/response/enums/PhotoResponse.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum PhotoResponse implements Response {
 
     UPLOAD_PHOTO_SUCCESS(HttpStatus.CREATED, PhotoResponseMessage.UPLOAD_PHOTO_SUCCESS, null),
+    GET_PREVIEW_PHOTOS_SUCCESS(HttpStatus.OK, PhotoResponseMessage.GET_PREVIEW_PHOTOS_SUCCESS, null),
 
     PHOTO_REQUIRED(HttpStatus.BAD_REQUEST, PhotoResponseMessage.PHOTO_REQUIRED , "photo");
 

--- a/src/main/java/com/poortorich/photo/service/PhotoService.java
+++ b/src/main/java/com/poortorich/photo/service/PhotoService.java
@@ -25,6 +25,6 @@ public class PhotoService {
     }
 
     public List<Photo> getPreviewPhotos(Chatroom chatroom) {
-        return photoRepository.findTop10ByChatroomOrderByCreatedDateDesc(chatroom);
+        return photoRepository.findTop10ByChatroomOrderByCreatedDateDescIdAsc(chatroom);
     }
 }

--- a/src/main/java/com/poortorich/photo/service/PhotoService.java
+++ b/src/main/java/com/poortorich/photo/service/PhotoService.java
@@ -7,6 +7,8 @@ import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PhotoService {
@@ -20,5 +22,9 @@ public class PhotoService {
                 .photoUrl(photoUrl)
                 .build();
         photoRepository.save(photo);
+    }
+
+    public List<Photo> getPreviewPhotos(Chatroom chatroom) {
+        return photoRepository.findTop10ByChatroomOrderByCreatedDateDesc(chatroom);
     }
 }

--- a/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
+++ b/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
@@ -1,0 +1,30 @@
+package com.poortorich.photo.util;
+
+import com.poortorich.photo.entity.Photo;
+import com.poortorich.photo.response.PhotoResponse;
+import com.poortorich.photo.response.PreviewPhotosResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PhotoBuilder {
+
+    public static PreviewPhotosResponse buildPhotosResponse(List<Photo> previewPhotos) {
+        return PreviewPhotosResponse.builder()
+                .photos(previewPhotos.stream()
+                        .filter(Objects::nonNull)
+                        .map(PhotoBuilder::buildPhotoResponse)
+                        .toList())
+                .build();
+    }
+
+    private static PhotoResponse buildPhotoResponse(Photo photo) {
+        return PhotoResponse.builder()
+                .photoId(photo.getId())
+                .photoUrl(photo.getPhotoUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
+++ b/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
@@ -1,7 +1,7 @@
 package com.poortorich.photo.util;
 
 import com.poortorich.photo.entity.Photo;
-import com.poortorich.photo.response.PhotoResponse;
+import com.poortorich.photo.response.PhotoInfoResponse;
 import com.poortorich.photo.response.PreviewPhotosResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -16,13 +16,13 @@ public class PhotoBuilder {
         return PreviewPhotosResponse.builder()
                 .photos(previewPhotos.stream()
                         .filter(Objects::nonNull)
-                        .map(PhotoBuilder::buildPhotoResponse)
+                        .map(PhotoBuilder::buildPhotoInfoResponse)
                         .toList())
                 .build();
     }
 
-    private static PhotoResponse buildPhotoResponse(Photo photo) {
-        return PhotoResponse.builder()
+    private static PhotoInfoResponse buildPhotoInfoResponse(Photo photo) {
+        return PhotoInfoResponse.builder()
                 .photoId(photo.getId())
                 .photoUrl(photo.getPhotoUrl())
                 .build();

--- a/src/test/java/com/poortorich/photo/controller/PhotoControllerTest.java
+++ b/src/test/java/com/poortorich/photo/controller/PhotoControllerTest.java
@@ -5,12 +5,12 @@ import com.poortorich.global.config.BaseSecurityTest;
 import com.poortorich.photo.facade.PhotoFacade;
 import com.poortorich.photo.request.PhotoUploadRequest;
 import com.poortorich.photo.response.PhotoUploadResponse;
+import com.poortorich.photo.response.PreviewPhotosResponse;
 import com.poortorich.photo.response.enums.PhotoResponse;
 import com.poortorich.s3.util.S3TestFileGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -19,19 +19,21 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.multipart.MultipartFile;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PhotoController.class)
 @ExtendWith(MockitoExtension.class)
 class PhotoControllerTest extends BaseSecurityTest {
+
+    private static final String USERNAME = "test";
 
     @Autowired
     private MockMvc mockMvc;
@@ -41,15 +43,13 @@ class PhotoControllerTest extends BaseSecurityTest {
     @MockitoBean
     private PhotoFacade photoFacade;
 
-    private final String username = "test";
-
     @Test
-    @WithMockUser(username = username)
+    @WithMockUser(username = USERNAME)
     @DisplayName("채팅방 이미지 업로드 성공")
     void uploadPhotoSuccess() throws Exception {
         Long chatroomId = 1L;
         MockMultipartFile photo = S3TestFileGenerator.createJpegFile();
-        when(photoFacade.uploadPhoto(eq(username), eq(chatroomId), any(PhotoUploadRequest.class)))
+        when(photoFacade.uploadPhoto(eq(USERNAME), eq(chatroomId), any(PhotoUploadRequest.class)))
                 .thenReturn(PhotoUploadResponse.builder().build());
 
         mockMvc.perform(multipart("/chatrooms/" + chatroomId + "/photos")
@@ -59,5 +59,21 @@ class PhotoControllerTest extends BaseSecurityTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message")
                         .value(PhotoResponse.UPLOAD_PHOTO_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @WithMockUser(username = USERNAME)
+    @DisplayName("최신 사진 목록 조회 성공")
+    void getPreviewPhotosSuccess() throws Exception {
+        Long chatroomId = 1L;
+
+        when(photoFacade.getPreviewPhotos(eq(USERNAME), eq(chatroomId)))
+                .thenReturn(PreviewPhotosResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/photos/preview")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(PhotoResponse.GET_PREVIEW_PHOTOS_SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/poortorich/photo/service/PhotoServiceTest.java
+++ b/src/test/java/com/poortorich/photo/service/PhotoServiceTest.java
@@ -58,7 +58,7 @@ class PhotoServiceTest {
         Photo photo4 = Photo.builder().build();
         Photo photo5 = Photo.builder().build();
 
-        when(photoRepository.findTop10ByChatroomOrderByCreatedDateDesc(chatroom))
+        when(photoRepository.findTop10ByChatroomOrderByCreatedDateDescIdAsc(chatroom))
                 .thenReturn(List.of(photo1, photo2, photo3, photo4, photo5));
 
         List<Photo> result = photoService.getPreviewPhotos(chatroom);

--- a/src/test/java/com/poortorich/photo/service/PhotoServiceTest.java
+++ b/src/test/java/com/poortorich/photo/service/PhotoServiceTest.java
@@ -13,8 +13,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PhotoServiceTest {
@@ -43,5 +46,25 @@ class PhotoServiceTest {
         assertThat(savedPhoto.getUser()).isEqualTo(user);
         assertThat(savedPhoto.getChatroom()).isEqualTo(chatroom);
         assertThat(savedPhoto.getPhotoUrl()).isEqualTo(photoUrl);
+    }
+
+    @Test
+    @DisplayName("최신 사진 목록 조회 성공")
+    void getPreviewPhotosSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        Photo photo1 = Photo.builder().build();
+        Photo photo2 = Photo.builder().build();
+        Photo photo3 = Photo.builder().build();
+        Photo photo4 = Photo.builder().build();
+        Photo photo5 = Photo.builder().build();
+
+        when(photoRepository.findTop10ByChatroomOrderByCreatedDateDesc(chatroom))
+                .thenReturn(List.of(photo1, photo2, photo3, photo4, photo5));
+
+        List<Photo> result = photoService.getPreviewPhotos(chatroom);
+
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(5);
+        assertThat(result).containsExactly(photo1, photo2, photo3, photo4, photo5);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#446
 
 ## 📝작업 내용
 
- 최신 사진 목록 조회
  - 채팅방의 최근 사진 10개 반환
  - 채팅방 참여자가 아닌 경우 예외
 
 ### 스크린샷

<img width="1043" height="563" alt="스크린샷 2025-08-21 오후 9 53 13" src="https://github.com/user-attachments/assets/f6874798-c955-41b2-bb6c-01f63b93a5c9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 채팅방별 최신 사진 미리보기 조회 API 추가(최대 10개, 최신순). 각 항목은 사진 ID와 URL을 포함하며, 성공 시 “최신 사진 목록 조회를 완료했습니다.” 메시지를 반환합니다.

- 테스트
  - 컨트롤러, 퍼사드, 서비스에 미리보기 조회 성공 시나리오 테스트를 추가하여 응답 메시지와 결과 목록 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->