### PR TITLE
[#457] 사용자 강제퇴장 API

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -53,6 +53,7 @@ public class ChatResponseMessage {
     public static final String TARGET_USER_ID_IS_NULL = "방장을 위임할 회원 아이디는 필수 값입니다.";
     public static final String CHAT_PARTICIPANT_ROLE_NOT_MEMBER = "이 기능은 일반 멤버만 사용/적용할 수 있습니다.";
     public static final String HOST_DELEGATION_SUCCESS = "방장이 성공적으로 위임되었습니다.";
+    public static final String CHAT_PARTICIPANT_KICK_SUCCESS = "사용자 강제퇴장이 완료됐습니다.";
 
     private ChatResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -17,6 +17,7 @@ import com.poortorich.chat.response.ChatroomCreateResponse;
 import com.poortorich.chat.response.ChatroomLeaveAllResponse;
 import com.poortorich.chat.response.ChatroomLeaveResponse;
 import com.poortorich.chat.response.ChatroomUpdateResponse;
+import com.poortorich.chat.response.KickChatParticipantResponse;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.response.BaseResponse;
 import com.poortorich.global.response.DataResponse;
@@ -236,5 +237,17 @@ public class ChatController {
                 });
 
         return DataResponse.toResponseEntity(ChatResponse.MARK_ALL_CHATROOM_AS_READ_SUCCESS, result.getApiResponse());
+    }
+
+    @DeleteMapping("/{chatroomId}/members/{userId}")
+    public ResponseEntity<BaseResponse> kickChatParticipant(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId,
+            @PathVariable Long userId
+    ) {
+        KickChatParticipantResponse apiResponse = chatFacade.kickChatParticipant(
+                userDetails.getUsername(),
+                chatroomId,
+                userId);
     }
 }

--- a/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
@@ -79,7 +79,7 @@ public class ChatParticipant {
         this.leaveTime = null;
     }
 
-    public void softDelete() {
+    public void leave() {
         this.isParticipated = Boolean.FALSE;
         this.leaveTime = LocalDateTime.now();
     }
@@ -90,5 +90,9 @@ public class ChatParticipant {
 
     public void updateChatroomRole(ChatroomRole chatroomRole) {
         this.role = chatroomRole;
+    }
+
+    public void kick() {
+        this.role = ChatroomRole.BANNED;
     }
 }

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -349,6 +349,7 @@ public class ChatFacade {
 
         return KickChatParticipantResponse.builder()
                 .kickUserId(kickChatParticipant.getUser().getId())
+                .kickChatParticipant(kickChatParticipant)
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -222,6 +222,7 @@ public class ChatFacade {
                 .build();
     }
 
+    @Transactional
     public ChatroomLeaveResponse leaveChatroom(String username, Long chatroomId) {
         User user = userService.findUserByUsername(username);
         Chatroom chatroom = chatroomService.findById(chatroomId);
@@ -337,6 +338,7 @@ public class ChatFacade {
                 .build();
     }
 
+    @Transactional
     public KickChatParticipantResponse kickChatParticipant(String username, Long chatroomId, Long userId) {
         ChatParticipant host = chatParticipantService.findByUsernameAndChatroomId(username, chatroomId);
         ChatParticipant kickChatParticipant = chatParticipantService.findByUserIdAndChatroomId(userId, chatroomId);

--- a/src/main/java/com/poortorich/chat/realtime/builder/SystemMessageBuilder.java
+++ b/src/main/java/com/poortorich/chat/realtime/builder/SystemMessageBuilder.java
@@ -15,6 +15,7 @@ public class SystemMessageBuilder {
     private static final String LEAVE_CONTENT_SUFFIX = "님이 퇴장했습니다.";
     private static final String CHATROOM_CLOSED_BY_HOST = "방장이 채팅방을 종료했습니다. 더 이상 대화를 할 수 없으며, 채팅방을 나가면 다시 입장할 수 없게됩니다.";
     private static final String HOST_DELEGATION_CONTENT_FORMAT = "방장이 %s님에서 %s님으로 변경되었습니다.";
+    private static final String KICK_CONTENT_SUFFIX = "님이 강제퇴장되었습니다.";
 
     public static ChatMessage buildEnterMessage(User user, Chatroom chatroom) {
         return ChatMessage.builder()
@@ -61,6 +62,16 @@ public class SystemMessageBuilder {
                                 HOST_DELEGATION_CONTENT_FORMAT,
                                 prevHost.getUser().getNickname(), newHost.getUser().getNickname()))
                 .chatroom(prevHost.getChatroom())
+                .build();
+    }
+
+    public static ChatMessage buildKickChatParticipantMessage(ChatParticipant kickChatParticipant) {
+        return ChatMessage.builder()
+                .userId(kickChatParticipant.getUser().getId())
+                .messageType(MessageType.LEAVE)
+                .type(ChatMessageType.SYSTEM_MESSAGE)
+                .content(kickChatParticipant.getUser().getNickname() + KICK_CONTENT_SUFFIX)
+                .chatroom(kickChatParticipant.getChatroom())
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -136,4 +136,9 @@ public class ChatRealTimeFacade {
         eventPublisher.publishEvent(new HostDelegationEvent(prevHost, newHost));
         return payload.mapToBasePayload();
     }
+
+    @Transactional
+    public BasePayload createUserKickMessage(ChatParticipant kickChatParticipant) {
+        return chatMessageService.saveKickChatParticipantMessage(kickChatParticipant).mapToBasePayload();
+    }
 }

--- a/src/main/java/com/poortorich/chat/realtime/payload/response/KickChatParticipantMessagePayload.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/response/KickChatParticipantMessagePayload.java
@@ -1,0 +1,31 @@
+package com.poortorich.chat.realtime.payload.response;
+
+import com.poortorich.chat.entity.enums.ChatMessageType;
+import com.poortorich.chat.entity.enums.MessageType;
+import com.poortorich.chat.model.ChatMessageResponse;
+import com.poortorich.chat.realtime.payload.interfaces.ResponsePayload;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class KickChatParticipantMessagePayload extends ChatMessageResponse implements ResponsePayload {
+
+    private Long userId;
+    private Long messageId;
+    private Long chatroomId;
+    private MessageType messageType;
+    private ChatMessageType type;
+    private String content;
+    private LocalDateTime sentAt;
+
+    @Override
+    public BasePayload mapToBasePayload() {
+        return BasePayload.builder()
+                .type(ChatMessageType.SYSTEM_MESSAGE)
+                .payload(this)
+                .build();
+    }
+}

--- a/src/main/java/com/poortorich/chat/response/KickChatParticipantResponse.java
+++ b/src/main/java/com/poortorich/chat/response/KickChatParticipantResponse.java
@@ -1,0 +1,11 @@
+package com.poortorich.chat.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class KickChatParticipantResponse {
+
+    private Long kickUserId;
+}

--- a/src/main/java/com/poortorich/chat/response/KickChatParticipantResponse.java
+++ b/src/main/java/com/poortorich/chat/response/KickChatParticipantResponse.java
@@ -1,11 +1,18 @@
 package com.poortorich.chat.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.poortorich.chat.entity.ChatParticipant;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 @Builder
 public class KickChatParticipantResponse {
 
     private Long kickUserId;
+
+    @JsonIgnore
+    @ToString.Exclude
+    private ChatParticipant kickChatParticipant;
 }

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -43,7 +43,8 @@ public enum ChatResponse implements Response {
     GET_CHAT_MESSAGE_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_CHAT_MESSAGE_SUCCESS, null),
     MARK_ALL_CHATROOM_AS_READ_SUCCESS(HttpStatus.OK, ChatResponseMessage.MARK_ALL_CHATROOM_AS_READ_SUCCESS, null),
     CHAT_PARTICIPANT_ROLE_NOT_MEMBER(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHAT_PARTICIPANT_ROLE_NOT_MEMBER, null),
-    HOST_DELEGATION_SUCCESS(HttpStatus.OK, ChatResponseMessage.HOST_DELEGATION_SUCCESS, null);
+    HOST_DELEGATION_SUCCESS(HttpStatus.OK, ChatResponseMessage.HOST_DELEGATION_SUCCESS, null),
+    CHAT_PARTICIPANT_KICK_SUCCESS(HttpStatus.OK, ChatResponseMessage.CHAT_PARTICIPANT_KICK_SUCCESS, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -205,6 +205,7 @@ public class ChatMessageService {
                 .build();
     }
 
+    @Transactional
     public KickChatParticipantMessagePayload saveKickChatParticipantMessage(ChatParticipant kickChatParticipant) {
         dateChangeDetector.detect(kickChatParticipant.getChatroom());
 

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -13,6 +13,7 @@ import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
 import com.poortorich.chat.realtime.payload.response.ChatroomClosedResponsePayload;
 import com.poortorich.chat.realtime.payload.response.DateChangeMessagePayload;
 import com.poortorich.chat.realtime.payload.response.HostDelegationMessagePayload;
+import com.poortorich.chat.realtime.payload.response.KickChatParticipantMessagePayload;
 import com.poortorich.chat.realtime.payload.response.RankingStatusMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserChatMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserEnterResponsePayload;
@@ -201,6 +202,23 @@ public class ChatMessageService {
                 .type(savedHostDelegationMessage.getType())
                 .content(savedHostDelegationMessage.getContent())
                 .sentAt(savedHostDelegationMessage.getSentAt())
+                .build();
+    }
+
+    public KickChatParticipantMessagePayload saveKickChatParticipantMessage(ChatParticipant kickChatParticipant) {
+        dateChangeDetector.detect(kickChatParticipant.getChatroom());
+
+        ChatMessage kickMessage = SystemMessageBuilder.buildKickChatParticipantMessage(kickChatParticipant);
+        kickMessage = chatMessageRepository.save(kickMessage);
+
+        return KickChatParticipantMessagePayload.builder()
+                .userId(kickMessage.getUserId())
+                .messageId(kickMessage.getId())
+                .chatroomId(kickMessage.getChatroom().getId())
+                .content(kickMessage.getContent())
+                .messageType(kickMessage.getMessageType())
+                .type(kickMessage.getType())
+                .sentAt(kickMessage.getSentAt())
                 .build();
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -167,4 +167,10 @@ public class ChatParticipantService {
 
         return chatParticipantRepository.searchByChatroomAndNickname(chatroom, nickname);
     }
+
+    @Transactional
+    public void kickChatParticipant(ChatParticipant kickChatParticipant) {
+        kickChatParticipant.kick();
+        kickChatParticipant.leave();
+    }
 }

--- a/src/main/java/com/poortorich/tag/service/TagService.java
+++ b/src/main/java/com/poortorich/tag/service/TagService.java
@@ -3,10 +3,11 @@ package com.poortorich.tag.service;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.tag.entity.Tag;
 import com.poortorich.tag.repository.TagRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## #️⃣457
 
 ## 📝작업 내용
 
- 사용자를 강제퇴장합니다.
- 요청자는 HOST이고 대상자는 MEMBER임을 검증합니다.
- 강제퇴장(ChatroomRole을 `BANNED`로 설정 후 퇴장)
- 퇴장되었다는 메시지를 빌드하여 브로드캐스트합니다.
 
 ### 스크린샷 (선택)
<img width="1626" height="305" alt="image" src="https://github.com/user-attachments/assets/5f8dccd3-4d8f-4966-a967-3d59acd8cb5d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 채팅방 호스트가 특정 참가자를 강제퇴장(kick)할 수 있는 기능을 추가했습니다.
  * 강제퇴장 시 해당 참가자는 퇴장 처리되고 접근이 제한(차단 상태)됩니다.
  * 강제퇴장 발생 시 채팅방에 시스템 메시지로 실시간 알림이 전송됩니다(닉네임 기반 안내 포함).
  * 강제퇴장 결과를 반환하는 API 응답이 추가되며, 성공 메시지("사용자 강제퇴장이 완료됐습니다.")가 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->