### PR TITLE
[#462] 실시간 읽음 처리 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/websocket/stomp/command/disconnect/handler/StompDisconnectHandler.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/disconnect/handler/StompDisconnectHandler.java
@@ -1,13 +1,24 @@
 package com.poortorich.websocket.stomp.command.disconnect.handler;
 
+import com.poortorich.websocket.stomp.service.SubscribeService;
+import com.poortorich.websocket.stomp.util.StompSessionManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class StompDisconnectHandler {
 
-    public void handle() {
+    private final StompSessionManager sessionManager;
+    private final SubscribeService subscribeService;
+    private final StringRedisTemplate redisTemplate;
 
+    public void handle(StompHeaderAccessor accessor) {
+        String username = sessionManager.getUsername(accessor);
+        String sessionId = accessor.getSessionId();
+
+        subscribeService.unsubscribeAll(username, sessionId);
     }
 }

--- a/src/main/java/com/poortorich/websocket/stomp/command/disconnect/handler/StompDisconnectHandler.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/disconnect/handler/StompDisconnectHandler.java
@@ -19,6 +19,6 @@ public class StompDisconnectHandler {
         String username = sessionManager.getUsername(accessor);
         String sessionId = accessor.getSessionId();
 
-        subscribeService.unsubscribeAll(username, sessionId);
+        subscribeService.cleanupSession(username, sessionId);
     }
 }

--- a/src/main/java/com/poortorich/websocket/stomp/interceptor/StompInterceptor.java
+++ b/src/main/java/com/poortorich/websocket/stomp/interceptor/StompInterceptor.java
@@ -43,7 +43,7 @@ public class StompInterceptor implements ChannelInterceptor {
             } else if (StompCommand.UNSUBSCRIBE.equals(command)) {
                 unsubscribeHandler.handle(accessor);
             } else if (StompCommand.DISCONNECT.equals(command)) {
-                disconnectHandler.handle();
+                disconnectHandler.handle(accessor);
             }
         } catch (Exception e) {
             log.info("[WebSocket 연결 실패] {}", e.getStackTrace()[0]);


### PR DESCRIPTION
## #️⃣462
 
 ## 📝작업 내용
 - 실시간 읽음 처리 로직을 수정했습니다.
 
 ### 스크린샷 (선택)
 
 ## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 연결 종료 시 사용자명+세션 정보를 이용해 해당 세션의 모든 채팅방 구독을 정리하는 자동 정리 기능을 추가했습니다.
* **버그 수정**
  * 구독 정보 저장 방식을 단일 값으로 일관되게 변경하여 누적 저장으로 인한 잘못된 상태를 방지했습니다.
  * 구독 정리 과정의 예외 처리를 강화해 내부 오류 영향 범위를 축소했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->