### PR TITLE
[#465] 최신 랭킹 조회 API 수정

### DIFF
--- a/src/main/java/com/poortorich/ranking/controller/RankingController.java
+++ b/src/main/java/com/poortorich/ranking/controller/RankingController.java
@@ -20,7 +20,7 @@ public class RankingController {
 
     private final RankingFacade rankingFacade;
 
-    @GetMapping
+    @GetMapping("/preview")
     public ResponseEntity<BaseResponse> getLatestRanking(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long chatroomId

--- a/src/test/java/com/poortorich/ranking/controller/RankingControllerTest.java
+++ b/src/test/java/com/poortorich/ranking/controller/RankingControllerTest.java
@@ -42,7 +42,7 @@ class RankingControllerTest extends BaseSecurityTest {
                 RankingFacade.LatestRankingResult.found(LatestRankingResponse.builder().build())
         );
 
-        mockMvc.perform(get("/chatrooms/" + chatroomId + "/rankings")
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/rankings/preview")
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
@@ -59,7 +59,7 @@ class RankingControllerTest extends BaseSecurityTest {
                 RankingFacade.LatestRankingResult.notFound(LatestRankingResponse.builder().build())
         );
 
-        mockMvc.perform(get("/chatrooms/" + chatroomId + "/rankings")
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/rankings/preview")
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#465
 
 ## 📝작업 내용
 
- 누락된 endpoint 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - API 엔드포인트 경로를 /chatrooms/{chatroomId}/rankings → /chatrooms/{chatroomId}/rankings/preview 로 변경했습니다. 응답 형식과 상태 코드는 동일합니다.
- Tests
  - 테스트를 새로운 엔드포인트 경로에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->