### PR TITLE
[#470] 이전 채팅 조회 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
@@ -62,6 +62,10 @@ public class ChatParticipant {
     @Column(name = "created_date")
     private LocalDateTime createdDate;
 
+    @CreationTimestamp
+    @Column(name = "joinAt")
+    private LocalDateTime joinAt;
+
     @UpdateTimestamp
     @Column(name = "updated_date")
     private LocalDateTime updatedDate;
@@ -77,6 +81,7 @@ public class ChatParticipant {
     public void restoreParticipation() {
         this.isParticipated = Boolean.TRUE;
         this.leaveTime = null;
+        this.joinAt = LocalDateTime.now();
     }
 
     public void leave() {

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -167,7 +167,7 @@ public class ChatMessageService {
         return chatMessageRepository.findByChatroomAndIdLessThanEqualAndSentAtAfterOrderByIdDesc(
                 context.chatroom(),
                 context.cursor(),
-                context.chatParticipant().getCreatedDate(),
+                context.chatParticipant().getJoinAt(),
                 context.pageRequest());
     }
 


### PR DESCRIPTION
## #️⃣470
 
 ## 📝작업 내용
 - 채팅방을 나갔다 들어온 경우에도 이전 메시지가 조회되는 현상 수정
   - 채팅방 최초 입장 이후 메시지가 지속적으로 보이는 문제 발생
   - joinAt 필드를 추가하여 채팅을 나갔다 들어오면 값이 갱신되고 이 값을 기준으로 메시지를 조회하도록 수정
 
