### PR TITLE
[#474] 참여중인 채팅방 목록 조회 API

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -54,6 +54,7 @@ public class ChatResponseMessage {
     public static final String CHAT_PARTICIPANT_ROLE_NOT_MEMBER = "이 기능은 일반 멤버만 사용/적용할 수 있습니다.";
     public static final String HOST_DELEGATION_SUCCESS = "방장이 성공적으로 위임되었습니다.";
     public static final String CHAT_PARTICIPANT_KICK_SUCCESS = "사용자 강제퇴장이 완료됐습니다.";
+    public static final String GET_MY_CHATROOMS_SUCCESS = "참여중인 채팅방 목록 조회가 완료되었습니다.";
 
     private ChatResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
+++ b/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
@@ -1,0 +1,4 @@
+package com.poortorich.chat.controller;
+
+public class UserChatroomController {
+}

--- a/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
+++ b/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
@@ -5,7 +5,6 @@ import com.poortorich.chat.response.MyChatroomsResponse;
 import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.global.response.BaseResponse;
 import com.poortorich.global.response.DataResponse;
-import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,7 +24,7 @@ public class UserChatroomController {
     @GetMapping("/me/chatrooms")
     public ResponseEntity<BaseResponse> getMyChatrooms(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam @Nullable Long cursor
+            @RequestParam(required = false) Long cursor
     ) {
         MyChatroomsResponse response = chatFacade.getMyChatrooms(userDetails.getUsername(), cursor);
         return DataResponse.toResponseEntity(ChatResponse.GET_MY_CHATROOMS_SUCCESS, response);

--- a/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
+++ b/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
@@ -1,4 +1,33 @@
 package com.poortorich.chat.controller;
 
+import com.poortorich.chat.facade.ChatFacade;
+import com.poortorich.chat.response.MyChatroomsResponse;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.global.response.BaseResponse;
+import com.poortorich.global.response.DataResponse;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/users")
+@RequiredArgsConstructor
 public class UserChatroomController {
+
+    private final ChatFacade chatFacade;
+
+    @GetMapping("/me/chatrooms")
+    public ResponseEntity<BaseResponse> getMyChatrooms(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam @Nullable Long cursor
+    ) {
+        MyChatroomsResponse response = chatFacade.getMyChatrooms(userDetails.getUsername(), cursor);
+        return DataResponse.toResponseEntity(ChatResponse.GET_MY_CHATROOMS_SUCCESS, response);
+    }
 }

--- a/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
+++ b/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
@@ -9,12 +9,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserChatroomController {

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -6,6 +6,7 @@ import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.model.ChatMessageResponse;
 import com.poortorich.chat.model.ChatPaginationContext;
+import com.poortorich.chat.model.ChatroomPaginationContext;
 import com.poortorich.chat.model.UserEnterChatroomResult;
 import com.poortorich.chat.realtime.payload.response.UserEnterProfileResponsePayload;
 import com.poortorich.chat.request.ChatroomCreateRequest;
@@ -31,6 +32,8 @@ import com.poortorich.chat.response.ChatroomUpdateResponse;
 import com.poortorich.chat.response.ChatroomsResponse;
 import com.poortorich.chat.response.HostDelegationResponse;
 import com.poortorich.chat.response.KickChatParticipantResponse;
+import com.poortorich.chat.response.MyChatroom;
+import com.poortorich.chat.response.MyChatroomsResponse;
 import com.poortorich.chat.response.SearchParticipantsResponse;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
@@ -38,6 +41,7 @@ import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.util.ChatBuilder;
 import com.poortorich.chat.util.detector.RankingStatusChangeDetector;
 import com.poortorich.chat.util.mapper.ChatMessageMapper;
+import com.poortorich.chat.util.mapper.ChatroomMapper;
 import com.poortorich.chat.util.provider.ChatPaginationProvider;
 import com.poortorich.chat.validator.ChatParticipantValidator;
 import com.poortorich.chat.validator.ChatroomValidator;
@@ -66,6 +70,7 @@ public class ChatFacade {
     private final TagService tagService;
 
     private final ChatMessageMapper chatMessageMapper;
+    private final ChatroomMapper chatroomMapper;
     private final ChatPaginationProvider paginationProvider;
     private final ChatroomValidator chatroomValidator;
     private final ChatParticipantValidator chatParticipantValidator;
@@ -268,7 +273,7 @@ public class ChatFacade {
     @Transactional
     public ChatMessagePageResponse getChatMessages(String username, Long chatroomId, Long cursor, Long pageSize) {
         User user = userService.findUserByUsername(username);
-        ChatPaginationContext context = paginationProvider.getContext(username, chatroomId, cursor, pageSize);
+        ChatPaginationContext context = paginationProvider.getChatMessagesContext(username, chatroomId, cursor, pageSize);
         chatParticipantValidator.validateIsParticipate(user, context.chatroom());
 
         Slice<ChatMessage> chatMessages = chatMessageService.getChatMessages(context);
@@ -288,6 +293,25 @@ public class ChatFacade {
                                 ChatParticipantProfile::getUserId,
                                 profile -> profile
                         )))
+                .build();
+    }
+
+    @Transactional
+    public MyChatroomsResponse getMyChatrooms(String username, Long cursor) {
+        ChatroomPaginationContext context = paginationProvider.getMyChatroomsContext(username, cursor);
+
+        Slice<ChatParticipant> participants = chatParticipantService.getMyParticipants(context);
+
+        Long nextCursor = paginationProvider.getChatroomNextCursor(participants);
+
+        List<MyChatroom> myChatrooms = participants.stream()
+                .map(chatroomMapper::mapToMyChatroom)
+                .toList();
+
+        return MyChatroomsResponse.builder()
+                .nextCursor(nextCursor)
+                .hasNext(participants.hasNext())
+                .chatrooms(myChatrooms)
                 .build();
     }
 

--- a/src/main/java/com/poortorich/chat/model/ChatroomPaginationContext.java
+++ b/src/main/java/com/poortorich/chat/model/ChatroomPaginationContext.java
@@ -1,0 +1,13 @@
+package com.poortorich.chat.model;
+
+import com.poortorich.user.entity.User;
+import lombok.Builder;
+import org.springframework.data.domain.PageRequest;
+
+@Builder
+public record ChatroomPaginationContext(
+        User user,
+        Long cursor,
+        PageRequest pageRequest
+) {
+}

--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -2,18 +2,24 @@ package com.poortorich.chat.repository;
 
 import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatMessageType;
 import com.poortorich.chat.entity.enums.MessageType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     Optional<ChatMessage> findTopByChatroomOrderBySentAtDesc(Chatroom chatroom);
+
+    Optional<ChatMessage> findTopByChatroomAndTypeInOrderBySentAtDesc(
+            Chatroom chatroom,
+            Collection<ChatMessageType> types);
 
     List<ChatMessage> findAllByChatroom(Chatroom chatroom);
 

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -3,6 +3,8 @@ package com.poortorich.chat.repository;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -125,4 +127,9 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             @Param("chatroom") Chatroom chatroom,
             @Param("nickname") String nickname
     );
+
+    Slice<ChatParticipant> findAllByUserAndIsParticipatedTrueAndChatroom_IdGreaterThanEqualOrderByChatroom_IdAsc(
+            User user,
+            Long cursor,
+            Pageable pageable);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -128,8 +128,15 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             @Param("nickname") String nickname
     );
 
-    Slice<ChatParticipant> findAllByUserAndIsParticipatedTrueAndChatroom_IdGreaterThanEqualOrderByChatroom_IdAsc(
-            User user,
-            Long cursor,
-            Pageable pageable);
+    @Query("""
+            SELECT cp
+            FROM ChatParticipant cp
+            JOIN FETCH cp.chatroom cr
+            JOIN FETCH cp.user u
+            WHERE u = :user
+            AND cp.isParticipated = true
+            AND cr.id >= :cursor
+            ORDER BY cr.id ASC
+            """)
+    Slice<ChatParticipant> findMyParticipants(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -14,63 +14,74 @@ import java.util.List;
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 
     @Query("""
-        SELECT c
-          FROM Chatroom c
-          JOIN ChatParticipant cp
-            ON cp.chatroom = c
-         WHERE cp.user = :user
-           AND cp.role = :role
-    """)
+                SELECT c
+                  FROM Chatroom c
+                  JOIN ChatParticipant cp
+                    ON cp.chatroom = c
+                 WHERE cp.user = :user
+                   AND cp.role = :role
+            """)
     List<Chatroom> findChatroomByUserAndRole(@Param("user") User user, @Param("role") ChatroomRole role);
 
     @Query("""
-        SELECT c
-          FROM Chatroom c
-          LEFT JOIN ChatMessage cm ON cm.chatroom = c
-          LEFT JOIN Like l ON l.chatroom = c AND l.likeStatus = true
-          LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipated = true
-        GROUP BY c.id
-        ORDER BY MAX(cm.sentAt) DESC,
-                 COUNT(DISTINCT l.id) DESC,
-                 COUNT(DISTINCT cp.id) DESC,
-                 c.createdDate DESC,
-                 c.id ASC
-    """)
+                SELECT c
+                  FROM Chatroom c
+                  LEFT JOIN ChatMessage cm ON cm.chatroom = c
+                  LEFT JOIN Like l ON l.chatroom = c AND l.likeStatus = true
+                  LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipated = true
+                GROUP BY c.id
+                ORDER BY MAX(cm.sentAt) DESC,
+                         COUNT(DISTINCT l.id) DESC,
+                         COUNT(DISTINCT cp.id) DESC,
+                         c.createdDate DESC,
+                         c.id ASC
+            """)
     List<Chatroom> findChatroomsSortByUpdatedAt();
 
     @Query("""
-        SELECT c
-          FROM Chatroom c
-        ORDER BY c.createdDate DESC
-    """)
+                SELECT c
+                  FROM Chatroom c
+                ORDER BY c.createdDate DESC
+            """)
     List<Chatroom> findChatroomsSortByCreatedAt();
 
     @Query("""
-        SELECT c
-          FROM Chatroom c
-          LEFT JOIN Like l ON l.chatroom = c AND l.likeStatus = true
-          LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipated = true
-        GROUP BY c.id
-        ORDER BY COUNT(DISTINCT l.id) DESC,
-                 COUNT(DISTINCT cp.id) DESC,
-                 c.createdDate DESC,
-                 c.id ASC
-    """)
+                SELECT c
+                  FROM Chatroom c
+                  LEFT JOIN Like l ON l.chatroom = c AND l.likeStatus = true
+                  LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipated = true
+                GROUP BY c.id
+                ORDER BY COUNT(DISTINCT l.id) DESC,
+                         COUNT(DISTINCT cp.id) DESC,
+                         c.createdDate DESC,
+                         c.id ASC
+            """)
     List<Chatroom> findChatroomsSortByLike();
 
     @Query("""
-        SELECT DISTINCT c
-          FROM Chatroom c
-          LEFT JOIN Tag t ON t.chatroom = c
-         INNER JOIN ChatParticipant cp ON cp.chatroom = c AND cp.role = 'HOST'
-        WHERE :keyword <> ''
-          AND (
-                 c.title LIKE CONCAT('%', :keyword, '%')
-              OR c.description LIKE CONCAT('%', :keyword, '%')
-              OR cp.user.nickname LIKE CONCAT('%', :keyword, '%')
-              OR (t.name IS NOT NULL AND t.name LIKE CONCAT('%', :keyword, '%'))
-          )
-        GROUP BY c.id
-    """)
+                SELECT DISTINCT c
+                  FROM Chatroom c
+                  LEFT JOIN Tag t ON t.chatroom = c
+                 INNER JOIN ChatParticipant cp ON cp.chatroom = c AND cp.role = 'HOST'
+                WHERE :keyword <> ''
+                  AND (
+                         c.title LIKE CONCAT('%', :keyword, '%')
+                      OR c.description LIKE CONCAT('%', :keyword, '%')
+                      OR cp.user.nickname LIKE CONCAT('%', :keyword, '%')
+                      OR (t.name IS NOT NULL AND t.name LIKE CONCAT('%', :keyword, '%'))
+                  )
+                GROUP BY c.id
+            """)
     List<Chatroom> searchChatrooms(String keyword);
+
+    @Query("""
+            SELECT c.id
+            FROM Chatroom c
+            JOIN ChatParticipant cp ON cp.chatroom = c
+            WHERE cp.user = :user
+            AND cp.isParticipated = true
+            ORDER BY c.id ASC
+            LIMIT 1
+            """)
+    Long findFirstChatroomIdByUser(@Param("user") User user);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -74,14 +74,14 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
             """)
     List<Chatroom> searchChatrooms(String keyword);
 
-    @Query("""
+    @Query(value = """
             SELECT c.id
-            FROM Chatroom c
-            JOIN ChatParticipant cp ON cp.chatroom = c
-            WHERE cp.user = :user
-            AND cp.isParticipated = true
+            FROM chatroom c
+            JOIN chat_participant cp ON cp.chatroom_id = c.id
+            WHERE cp.user_id = :userId
+            AND cp.is_participated = true
             ORDER BY c.id ASC
             LIMIT 1
-            """)
-    Long findFirstChatroomIdByUser(@Param("user") User user);
+            """, nativeQuery = true)
+    Long findFirstChatroomIdByUser(@Param("userId") Long userId);
 }

--- a/src/main/java/com/poortorich/chat/repository/UnreadChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/UnreadChatMessageRepository.java
@@ -48,4 +48,6 @@ public interface UnreadChatMessageRepository extends JpaRepository<UnreadChatMes
             AND u.user IN :users
             """)
     void markAllMessageAsRead(@Param("chatrooms") List<Chatroom> chatrooms, @Param("users") List<User> users);
+
+    Long countByUserAndChatroom(User user, Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chat/response/MyChatroom.java
+++ b/src/main/java/com/poortorich/chat/response/MyChatroom.java
@@ -1,0 +1,20 @@
+package com.poortorich.chat.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class MyChatroom {
+
+    private final Long chatroomId;
+    private final String chatroomImage;
+    private final Boolean isHost;
+    private final String chatroomTitle;
+    private final Long currentMemberCount;
+    private final String lastMessage;
+    private final LocalDateTime lastMessageTime;
+    private final Long unreadMessageCount;
+}

--- a/src/main/java/com/poortorich/chat/response/MyChatroomsResponse.java
+++ b/src/main/java/com/poortorich/chat/response/MyChatroomsResponse.java
@@ -1,0 +1,15 @@
+package com.poortorich.chat.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class MyChatroomsResponse {
+
+    private boolean hasNext;
+    private Long nextCursor;
+    private List<MyChatroom> chatrooms;
+}

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -44,7 +44,8 @@ public enum ChatResponse implements Response {
     MARK_ALL_CHATROOM_AS_READ_SUCCESS(HttpStatus.OK, ChatResponseMessage.MARK_ALL_CHATROOM_AS_READ_SUCCESS, null),
     CHAT_PARTICIPANT_ROLE_NOT_MEMBER(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHAT_PARTICIPANT_ROLE_NOT_MEMBER, null),
     HOST_DELEGATION_SUCCESS(HttpStatus.OK, ChatResponseMessage.HOST_DELEGATION_SUCCESS, null),
-    CHAT_PARTICIPANT_KICK_SUCCESS(HttpStatus.OK, ChatResponseMessage.CHAT_PARTICIPANT_KICK_SUCCESS, null);
+    CHAT_PARTICIPANT_KICK_SUCCESS(HttpStatus.OK, ChatResponseMessage.CHAT_PARTICIPANT_KICK_SUCCESS, null),
+    GET_MY_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_MY_CHATROOMS_SUCCESS, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -3,6 +3,7 @@ package com.poortorich.chat.service;
 import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatMessageType;
 import com.poortorich.chat.model.ChatPaginationContext;
 import com.poortorich.chat.realtime.builder.RankingStatusChatMessageBuilder;
 import com.poortorich.chat.realtime.builder.SystemMessageBuilder;
@@ -225,8 +226,11 @@ public class ChatMessageService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public ChatMessage getLastMessage(Chatroom chatroom) {
-        return chatMessageRepository.findTopByChatroomOrderBySentAtDesc(chatroom)
+        return chatMessageRepository.findTopByChatroomAndTypeInOrderBySentAtDesc(
+                        chatroom,
+                        List.of(ChatMessageType.CHAT_MESSAGE, ChatMessageType.RANKING_MESSAGE))
                 .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_MESSAGE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -20,8 +20,6 @@ import com.poortorich.chat.realtime.payload.response.UserChatMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserEnterResponsePayload;
 import com.poortorich.chat.realtime.payload.response.UserLeaveResponsePayload;
 import com.poortorich.chat.repository.ChatMessageRepository;
-import com.poortorich.chat.response.enums.ChatResponse;
-import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -33,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -227,10 +226,9 @@ public class ChatMessageService {
     }
 
     @Transactional(readOnly = true)
-    public ChatMessage getLastMessage(Chatroom chatroom) {
+    public Optional<ChatMessage> getLastMessage(Chatroom chatroom) {
         return chatMessageRepository.findTopByChatroomAndTypeInOrderBySentAtDesc(
-                        chatroom,
-                        List.of(ChatMessageType.CHAT_MESSAGE, ChatMessageType.RANKING_MESSAGE))
-                .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_MESSAGE_NOT_FOUND));
+                chatroom,
+                List.of(ChatMessageType.CHAT_MESSAGE, ChatMessageType.RANKING_MESSAGE));
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -19,6 +19,8 @@ import com.poortorich.chat.realtime.payload.response.UserChatMessagePayload;
 import com.poortorich.chat.realtime.payload.response.UserEnterResponsePayload;
 import com.poortorich.chat.realtime.payload.response.UserLeaveResponsePayload;
 import com.poortorich.chat.repository.ChatMessageRepository;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -221,5 +223,10 @@ public class ChatMessageService {
                 .type(kickMessage.getType())
                 .sentAt(kickMessage.getSentAt())
                 .build();
+    }
+
+    public ChatMessage getLastMessage(Chatroom chatroom) {
+        return chatMessageRepository.findTopByChatroomOrderBySentAtDesc(chatroom)
+                .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_MESSAGE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -178,7 +178,7 @@ public class ChatParticipantService {
 
     public Slice<ChatParticipant> getMyParticipants(ChatroomPaginationContext context) {
         return chatParticipantRepository
-                .findAllByUserAndIsParticipatedTrueAndChatroom_IdGreaterThanEqualOrderByChatroom_IdAsc(
+                .findMyParticipants(
                         context.user(),
                         context.cursor(),
                         context.pageRequest());

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -4,6 +4,7 @@ import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.entity.enums.NoticeStatus;
+import com.poortorich.chat.model.ChatroomPaginationContext;
 import com.poortorich.chat.repository.ChatParticipantRepository;
 import com.poortorich.chat.response.ChatParticipantProfile;
 import com.poortorich.chat.response.enums.ChatResponse;
@@ -14,6 +15,7 @@ import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.user.entity.User;
 import com.poortorich.websocket.stomp.service.SubscribeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -172,5 +174,13 @@ public class ChatParticipantService {
     public void kickChatParticipant(ChatParticipant kickChatParticipant) {
         kickChatParticipant.kick();
         kickChatParticipant.leave();
+    }
+
+    public Slice<ChatParticipant> getMyParticipants(ChatroomPaginationContext context) {
+        return chatParticipantRepository
+                .findAllByUserAndIsParticipatedTrueAndChatroom_IdGreaterThanEqualOrderByChatroom_IdAsc(
+                        context.user(),
+                        context.cursor(),
+                        context.pageRequest());
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatroomService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatroomService.java
@@ -93,6 +93,6 @@ public class ChatroomService {
     }
 
     public Long getFirstChatroomIdByUser(User user) {
-        return chatroomRepository.findFirstChatroomIdByUser(user);
+        return chatroomRepository.findFirstChatroomIdByUser(user.getId());
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatroomService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatroomService.java
@@ -10,11 +10,12 @@ import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.chat.util.ChatBuilder;
 import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.user.entity.User;
-import java.util.Comparator;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -89,5 +90,9 @@ public class ChatroomService {
     @Transactional
     public void deleteById(Long chatroomId) {
         chatroomRepository.deleteById(chatroomId);
+    }
+
+    public Long getFirstChatroomIdByUser(User user) {
+        return chatroomRepository.findFirstChatroomIdByUser(user);
     }
 }

--- a/src/main/java/com/poortorich/chat/service/UnreadChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/UnreadChatMessageService.java
@@ -78,4 +78,8 @@ public class UnreadChatMessageService {
                         .mapToBasePayload())
                 .toList();
     }
+
+    public Long countByUnreadChatMessage(User user, Chatroom chatroom) {
+        return unreadChatMessageRepository.countByUserAndChatroom(user, chatroom);
+    }
 }

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
@@ -1,4 +1,22 @@
 package com.poortorich.chat.util.mapper;
 
+import com.poortorich.chat.entity.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class ChatMessageContentMapper {
+
+    private static final String RANKING_MESSAGE = "랭킹이 집계되었습니다.";
+    private static final String PHOTO_MESSAGE = "사진을 보냈습니다.";
+
+    public String mapToContent(ChatMessage chatMessage) {
+        return switch (chatMessage.getMessageType()) {
+            case PHOTO -> PHOTO_MESSAGE;
+            case TEXT -> chatMessage.getContent();
+            case RANKING -> RANKING_MESSAGE;
+            default -> null;
+        };
+    }
 }

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
@@ -1,0 +1,4 @@
+package com.poortorich.chat.util.mapper;
+
+public class ChatMessageContentMapper {
+}

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
@@ -4,6 +4,8 @@ import com.poortorich.chat.entity.ChatMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
+
 @Component
 @RequiredArgsConstructor
 public class ChatMessageContentMapper {
@@ -12,6 +14,10 @@ public class ChatMessageContentMapper {
     private static final String PHOTO_MESSAGE = "사진을 보냈습니다.";
 
     public String mapToContent(ChatMessage chatMessage) {
+        if (Objects.isNull(chatMessage)) {
+            return null;
+        }
+        
         return switch (chatMessage.getMessageType()) {
             case PHOTO -> PHOTO_MESSAGE;
             case TEXT -> chatMessage.getContent();

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
@@ -19,6 +19,8 @@ public class ChatroomMapper {
     private final ChatMessageService chatMessageService;
     private final ChatParticipantService chatParticipantService;
 
+    private final ChatMessageContentMapper contentMapper;
+
     public MyChatroom mapToMyChatroom(ChatParticipant participant) {
         Chatroom chatroom = participant.getChatroom();
 
@@ -33,7 +35,7 @@ public class ChatroomMapper {
                 .isHost(ChatroomRole.HOST.equals(participant.getRole()))
                 .chatroomTitle(chatroom.getTitle())
                 .currentMemberCount(chatParticipantService.countByChatroom(chatroom))
-                .lastMessage(lastMessage.getContent())
+                .lastMessage(contentMapper.mapToContent(lastMessage))
                 .lastMessageTime(lastMessage.getSentAt())
                 .unreadMessageCount(unreadMessageCount)
                 .build();

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
@@ -1,0 +1,4 @@
+package com.poortorich.chat.util.mapper;
+
+public class ChatroomMapper {
+}

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
@@ -1,4 +1,41 @@
 package com.poortorich.chat.util.mapper;
 
+import com.poortorich.chat.entity.ChatMessage;
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.response.MyChatroom;
+import com.poortorich.chat.service.ChatMessageService;
+import com.poortorich.chat.service.ChatParticipantService;
+import com.poortorich.chat.service.UnreadChatMessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class ChatroomMapper {
+
+    private final UnreadChatMessageService unreadChatMessageService;
+    private final ChatMessageService chatMessageService;
+    private final ChatParticipantService chatParticipantService;
+
+    public MyChatroom mapToMyChatroom(ChatParticipant participant) {
+        Chatroom chatroom = participant.getChatroom();
+
+        ChatMessage lastMessage = chatMessageService.getLastMessage(participant.getChatroom());
+        Long unreadMessageCount = unreadChatMessageService.countByUnreadChatMessage(
+                participant.getUser(),
+                participant.getChatroom());
+
+        return MyChatroom.builder()
+                .chatroomId(chatroom.getId())
+                .chatroomImage(chatroom.getImage())
+                .isHost(ChatroomRole.HOST.equals(participant.getRole()))
+                .chatroomTitle(chatroom.getTitle())
+                .currentMemberCount(chatParticipantService.countByChatroom(chatroom))
+                .lastMessage(lastMessage.getContent())
+                .lastMessageTime(lastMessage.getSentAt())
+                .unreadMessageCount(unreadMessageCount)
+                .build();
+    }
 }

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
@@ -11,6 +11,8 @@ import com.poortorich.chat.service.UnreadChatMessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class ChatroomMapper {
@@ -24,7 +26,7 @@ public class ChatroomMapper {
     public MyChatroom mapToMyChatroom(ChatParticipant participant) {
         Chatroom chatroom = participant.getChatroom();
 
-        ChatMessage lastMessage = chatMessageService.getLastMessage(participant.getChatroom());
+        Optional<ChatMessage> lastMessage = chatMessageService.getLastMessage(participant.getChatroom());
         Long unreadMessageCount = unreadChatMessageService.countByUnreadChatMessage(
                 participant.getUser(),
                 participant.getChatroom());
@@ -35,8 +37,8 @@ public class ChatroomMapper {
                 .isHost(ChatroomRole.HOST.equals(participant.getRole()))
                 .chatroomTitle(chatroom.getTitle())
                 .currentMemberCount(chatParticipantService.countByChatroom(chatroom))
-                .lastMessage(contentMapper.mapToContent(lastMessage))
-                .lastMessageTime(lastMessage.getSentAt())
+                .lastMessage(lastMessage.map(contentMapper::mapToContent).orElse(null))
+                .lastMessageTime(lastMessage.map(ChatMessage::getSentAt).orElse(null))
                 .unreadMessageCount(unreadMessageCount)
                 .build();
     }

--- a/src/main/java/com/poortorich/chat/util/provider/ChatPaginationProvider.java
+++ b/src/main/java/com/poortorich/chat/util/provider/ChatPaginationProvider.java
@@ -4,6 +4,7 @@ import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.model.ChatPaginationContext;
+import com.poortorich.chat.model.ChatroomPaginationContext;
 import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
@@ -25,7 +26,7 @@ public class ChatPaginationProvider {
     private final ChatParticipantService chatParticipantService;
     private final UserService userService;
 
-    public ChatPaginationContext getContext(String username, Long chatroomId, Long cursor, Long pageSize) {
+    public ChatPaginationContext getChatMessagesContext(String username, Long chatroomId, Long cursor, Long pageSize) {
         User user = userService.findUserByUsername(username);
         Chatroom chatroom = chatroomService.findById(chatroomId);
         ChatParticipant chatParticipant = chatParticipantService.findByUserAndChatroom(user, chatroom);
@@ -37,11 +38,22 @@ public class ChatPaginationProvider {
                 .build();
     }
 
-    public Long getNextCursor(Slice<ChatMessage> chatMessages) {
-        if (chatMessages.hasContent()) {
-            return chatMessages.getContent().getLast().getId() - 1;
+    public ChatroomPaginationContext getMyChatroomsContext(String username, Long cursor) {
+        User user = userService.findUserByUsername(username);
+
+        return ChatroomPaginationContext.builder()
+                .user(user)
+                .cursor(getChatroomCursor(user, cursor))
+                .pageRequest(getPageRequest(20L))
+                .build();
+    }
+
+    private Long getChatroomCursor(User user, Long cursor) {
+        if (!Objects.isNull(cursor)) {
+            return cursor;
         }
-        return null;
+
+        return chatroomService.getFirstChatroomIdByUser(user);
     }
 
     private Long getCursor(Chatroom chatroom, Long cursor) {
@@ -50,6 +62,21 @@ public class ChatPaginationProvider {
         }
 
         return chatMessageService.getLatestMessageId(chatroom);
+    }
+
+
+    public Long getNextCursor(Slice<ChatMessage> chatMessages) {
+        if (chatMessages.hasContent()) {
+            return chatMessages.getContent().getLast().getId() - 1;
+        }
+        return null;
+    }
+
+    public Long getChatroomNextCursor(Slice<ChatParticipant> chatrooms) {
+        if (chatrooms.hasContent()) {
+            return chatrooms.getContent().getLast().getId();
+        }
+        return null;
     }
 
     private PageRequest getPageRequest(Long pageSize) {

--- a/src/main/java/com/poortorich/chat/util/provider/ChatPaginationProvider.java
+++ b/src/main/java/com/poortorich/chat/util/provider/ChatPaginationProvider.java
@@ -72,9 +72,9 @@ public class ChatPaginationProvider {
         return null;
     }
 
-    public Long getChatroomNextCursor(Slice<ChatParticipant> chatrooms) {
-        if (chatrooms.hasContent()) {
-            return chatrooms.getContent().getLast().getId();
+    public Long getChatroomNextCursor(Slice<ChatParticipant> participants) {
+        if (participants.hasContent()) {
+            return participants.getContent().getLast().getChatroom().getId() + 1;
         }
         return null;
     }


### PR DESCRIPTION
## #️⃣474
 
 ## 📝작업 내용
 - 참여중인 채팅방 목록을 페이지네이션하여 제공합니다.

 
 ### 스크린샷 (선택)
 
<img width="1146" height="494" alt="image" src="https://github.com/user-attachments/assets/5b0e8508-c785-4d45-8349-b9be7295ea04" />

 ## 💬리뷰 요구사항(선택)
마지막 메시지 Content 조회에서 null인 경우가 존재(`RANKING_STATUS`가 마지막 메시지로 조회되는 경우)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 내 채팅방 목록 조회 API 추가(/users/me/chatrooms): 로그인 사용자의 참여중인 채팅방 목록을 반환합니다.
  - 커서 기반 페이징 지원: hasNext와 nextCursor로 무한 스크롤 형태의 단계적 로딩 가능.
  - 채팅방 항목에 ID, 이미지, 호스트 여부, 제목, 현재 인원, 마지막 메시지·시간, 안 읽은 메시지 수 포함.
  - 마지막 메시지 유형에 따른 간결한 미리보기 텍스트 제공.
  - 조회 성공 시 일관된 성공 응답 메시지 반환.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->