### PR TITLE
[#477] 참여중인 채팅방 목록 구독

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,27 @@
-### 배포 환경
-#FROM openjdk:21-jdk-slim
-#
-#ARG JAR_FILE=./build/libs/*.jar
-#
-#COPY ${JAR_FILE} /app.jar
-#
-#ENTRYPOINT ["java", "-jar", "/app.jar" ]
-
-## 개발 환경
-# 1단계: builder
-FROM gradle:8.4.0-jdk21 AS builder
-
-WORKDIR /app
-
-COPY . .
-
-RUN gradle bootJar --no-daemon
-
-# 2단계: runtime
+## 배포 환경
 FROM openjdk:21-jdk-slim
 
-WORKDIR /app
+ARG JAR_FILE=./build/libs/*.jar
 
-COPY --from=builder /app/build/libs/*.jar app.jar
+COPY ${JAR_FILE} /app.jar
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar" ]
+
+### 개발 환경
+## 1단계: builder
+#FROM gradle:8.4.0-jdk21 AS builder
+#
+#WORKDIR /app
+#
+#COPY . .
+#
+#RUN gradle bootJar --no-daemon
+#
+## 2단계: runtime
+#FROM openjdk:21-jdk-slim
+#
+#WORKDIR /app
+#
+#COPY --from=builder /app/build/libs/*.jar app.jar
+#
+#ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,27 @@
-## 배포 환경
-FROM openjdk:21-jdk-slim
-
-ARG JAR_FILE=./build/libs/*.jar
-
-COPY ${JAR_FILE} /app.jar
-
-ENTRYPOINT ["java", "-jar", "/app.jar" ]
-
-### 개발 환경
-## 1단계: builder
-#FROM gradle:8.4.0-jdk21 AS builder
-#
-#WORKDIR /app
-#
-#COPY . .
-#
-#RUN gradle bootJar --no-daemon
-#
-## 2단계: runtime
+### 배포 환경
 #FROM openjdk:21-jdk-slim
 #
-#WORKDIR /app
+#ARG JAR_FILE=./build/libs/*.jar
 #
-#COPY --from=builder /app/build/libs/*.jar app.jar
+#COPY ${JAR_FILE} /app.jar
 #
-#ENTRYPOINT ["java", "-jar", "app.jar"]
+#ENTRYPOINT ["java", "-jar", "/app.jar" ]
+
+## 개발 환경
+# 1단계: builder
+FROM gradle:8.4.0-jdk21 AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN gradle bootJar --no-daemon
+
+# 2단계: runtime
+FROM openjdk:21-jdk-slim
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -7,6 +7,7 @@ import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.model.ChatMessageResponse;
 import com.poortorich.chat.model.ChatPaginationContext;
 import com.poortorich.chat.model.UserEnterChatroomResult;
+import com.poortorich.chat.realtime.event.chatroom.detector.ChatroomUpdateDetector;
 import com.poortorich.chat.realtime.payload.response.UserEnterProfileResponsePayload;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.request.ChatroomEnterRequest;
@@ -70,6 +71,7 @@ public class ChatFacade {
     private final ChatroomValidator chatroomValidator;
     private final ChatParticipantValidator chatParticipantValidator;
     private final RankingStatusChangeDetector rankingStatusChangeDetector;
+    private final ChatroomUpdateDetector chatroomUpdateDetector;
 
     @Transactional
     public ChatroomCreateResponse createChatroom(
@@ -211,6 +213,8 @@ public class ChatFacade {
                 chatroom.getIsRankingEnabled(),
                 chatroomUpdateRequest.getIsRankingEnabled());
 
+        chatroomUpdateDetector.detect(chatroom, chatroomUpdateRequest, newChatroomImage);
+
         chatroom.updateChatroom(chatroomUpdateRequest, newChatroomImage);
         tagService.updateTag(chatroomUpdateRequest.getHashtags(), chatroom);
 
@@ -233,7 +237,6 @@ public class ChatFacade {
         } else {
             chatParticipant.leave();
         }
-
         return ChatroomLeaveResponse.builder().deleteChatroomId(chatroomId).build();
     }
 

--- a/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEvent.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEvent.java
@@ -1,0 +1,12 @@
+package com.poortorich.chat.realtime.event.chatroom;
+
+import com.poortorich.chat.entity.Chatroom;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatroomUpdateEvent {
+
+    private final Chatroom chatroom;
+}

--- a/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEventListener.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEventListener.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class ChatroomUpdateEventListner {
+public class ChatroomUpdateEventListener {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final ChatParticipantService chatParticipantService;

--- a/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEventListner.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEventListner.java
@@ -1,0 +1,28 @@
+package com.poortorich.chat.realtime.event.chatroom;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.service.ChatParticipantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ChatroomUpdateEventListner {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatParticipantService chatParticipantService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onChatroomUpdated(ChatroomUpdateEvent event) {
+        List<ChatParticipant> participants = chatParticipantService.findAllByChatroom(event.getChatroom());
+
+        participants.forEach(participant -> {
+            
+        });
+    }
+}

--- a/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEventListner.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEventListner.java
@@ -1,6 +1,8 @@
 package com.poortorich.chat.realtime.event.chatroom;
 
 import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.realtime.payload.response.BasePayload;
+import com.poortorich.chat.realtime.payload.response.enums.PayloadType;
 import com.poortorich.chat.response.MyChatroom;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.util.mapper.ChatroomMapper;
@@ -26,11 +28,47 @@ public class ChatroomUpdateEventListner {
         List<ChatParticipant> participants = chatParticipantService.findAllByChatroom(event.getChatroom());
 
         participants.forEach(participant -> {
-            MyChatroom myChatroom = chatroomMapper.mapToMyChatroom(participant);
+            BasePayload basePayload = BasePayload.builder()
+                    .type(PayloadType.JOINED_CHATROOMS_UPDATED)
+                    .payload(chatroomMapper.mapToMyChatroom(participant))
+                    .build();
 
             messagingTemplate.convertAndSend(
-                    SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + participant.getUser().getId(),
-                    myChatroom);
+                    SubscribeEndpoint.JOINED_CHATROOM_LIST_PREFIX + participant.getUser().getId(),
+                    basePayload);
         });
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onChatParticipantUpdated(ParticipantUpdateEvent event) {
+        ChatParticipant participant = event.getParticipant();
+
+        BasePayload basePayload = BasePayload.builder()
+                .type(PayloadType.JOINED_CHATROOMS_UPDATED)
+                .payload(chatroomMapper.mapToMyChatroom(participant))
+                .build();
+
+        messagingTemplate.convertAndSend(
+                SubscribeEndpoint.JOINED_CHATROOM_LIST_PREFIX + participant.getUser().getId(),
+                basePayload);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onUserChatroomUpdated(UserChatroomUpdateEvent event) {
+        List<ChatParticipant> participants = chatParticipantService.findAllByUser(event.getUser());
+
+        List<MyChatroom> myChatrooms = participants.stream()
+                .map(chatroomMapper::mapToMyChatroom)
+                .toList();
+
+        BasePayload basePayload = BasePayload.builder()
+                .type(PayloadType.JOINED_CHATROOMS_UPDATED)
+                .payload(myChatrooms)
+                .build();
+
+        messagingTemplate.convertAndSend(
+                SubscribeEndpoint.JOINED_CHATROOM_LIST_PREFIX + event.getUser().getId(),
+                basePayload
+        );
     }
 }

--- a/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEventListner.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatroom/ChatroomUpdateEventListner.java
@@ -1,7 +1,10 @@
 package com.poortorich.chat.realtime.event.chatroom;
 
 import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.response.MyChatroom;
 import com.poortorich.chat.service.ChatParticipantService;
+import com.poortorich.chat.util.mapper.ChatroomMapper;
+import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
@@ -16,13 +19,18 @@ public class ChatroomUpdateEventListner {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final ChatParticipantService chatParticipantService;
+    private final ChatroomMapper chatroomMapper;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onChatroomUpdated(ChatroomUpdateEvent event) {
         List<ChatParticipant> participants = chatParticipantService.findAllByChatroom(event.getChatroom());
 
         participants.forEach(participant -> {
-            
+            MyChatroom myChatroom = chatroomMapper.mapToMyChatroom(participant);
+
+            messagingTemplate.convertAndSend(
+                    SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + participant.getUser().getId(),
+                    myChatroom);
         });
     }
 }

--- a/src/main/java/com/poortorich/chat/realtime/event/chatroom/ParticipantUpdateEvent.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatroom/ParticipantUpdateEvent.java
@@ -1,0 +1,12 @@
+package com.poortorich.chat.realtime.event.chatroom;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ParticipantUpdateEvent {
+
+    private final ChatParticipant participant;
+}

--- a/src/main/java/com/poortorich/chat/realtime/event/chatroom/UserChatroomUpdateEvent.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatroom/UserChatroomUpdateEvent.java
@@ -1,0 +1,12 @@
+package com.poortorich.chat.realtime.event.chatroom;
+
+import com.poortorich.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserChatroomUpdateEvent {
+
+    private final User user;
+}

--- a/src/main/java/com/poortorich/chat/realtime/event/chatroom/detector/ChatroomUpdateDetector.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatroom/detector/ChatroomUpdateDetector.java
@@ -1,0 +1,32 @@
+package com.poortorich.chat.realtime.event.chatroom.detector;
+
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.realtime.event.chatroom.ChatroomUpdateEvent;
+import com.poortorich.chat.request.ChatroomUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class ChatroomUpdateDetector {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void detect(Chatroom chatroom, ChatroomUpdateRequest chatroomUpdateRequest, String newImage) {
+        if (isTitleChanged(chatroom.getTitle(), chatroomUpdateRequest.getChatroomTitle())
+                || isImageChanged(chatroom.getImage(), newImage)) {
+            eventPublisher.publishEvent(new ChatroomUpdateEvent(chatroom));
+        }
+    }
+
+    private boolean isTitleChanged(String currentTitle, String newTitle) {
+        return !Objects.equals(currentTitle, newTitle);
+    }
+
+    private boolean isImageChanged(String currentImage, String newImage) {
+        return !Objects.equals(currentImage, newImage);
+    }
+}

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -74,6 +74,7 @@ public class ChatRealTimeFacade {
         return chatroomLeaveManager.leaveChatroom(context);
     }
 
+    @Transactional
     public BasePayload createUserChatMessage(String username, ChatMessageRequestPayload chatMessagePayload) {
         PayloadContext context = payloadCollector.getPayloadContext(
                 username,
@@ -128,7 +129,7 @@ public class ChatRealTimeFacade {
         List<BasePayload> broadcastPayloads = unreadChatMessageService.markAllMessageAsRead(contexts);
 
         eventPublisher.publishEvent(new UserChatroomUpdateEvent(contexts.getFirst().user()));
-        
+
         return MarkAllChatroomAsReadResult.builder()
                 .apiResponse(MarkAllChatroomAsReadResponse.builder().chatroomIds(chatroomIds).build())
                 .broadcastPayloads(broadcastPayloads)

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -5,6 +5,8 @@ import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatMessageType;
 import com.poortorich.chat.model.MarkAllChatroomAsReadResult;
 import com.poortorich.chat.realtime.collect.ChatPayloadCollector;
+import com.poortorich.chat.realtime.event.chatroom.ChatroomUpdateEvent;
+import com.poortorich.chat.realtime.event.chatroom.UserChatroomUpdateEvent;
 import com.poortorich.chat.realtime.event.user.HostDelegationEvent;
 import com.poortorich.chat.realtime.model.PayloadContext;
 import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
@@ -87,6 +89,8 @@ public class ChatRealTimeFacade {
         UserChatMessagePayload chatMessage = chatMessageService
                 .saveUserChatMessage(chatParticipant, chatMembers, chatMessagePayload);
 
+        eventPublisher.publishEvent(new ChatroomUpdateEvent(chatroom));
+
         return chatMessage.mapToBasePayload();
     }
 
@@ -123,6 +127,8 @@ public class ChatRealTimeFacade {
 
         List<BasePayload> broadcastPayloads = unreadChatMessageService.markAllMessageAsRead(contexts);
 
+        eventPublisher.publishEvent(new UserChatroomUpdateEvent(contexts.getFirst().user()));
+        
         return MarkAllChatroomAsReadResult.builder()
                 .apiResponse(MarkAllChatroomAsReadResponse.builder().chatroomIds(chatroomIds).build())
                 .broadcastPayloads(broadcastPayloads)

--- a/src/main/java/com/poortorich/chat/realtime/payload/response/enums/PayloadType.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/response/enums/PayloadType.java
@@ -6,5 +6,6 @@ public enum PayloadType implements EventType {
 
     NOTICE,
     USER_JOINED,
-    USER_UPDATED
+    USER_UPDATED,
+    JOINED_CHATROOMS_UPDATED
 }

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
@@ -14,7 +14,7 @@ public class ChatMessageContentMapper {
     private static final String PHOTO_MESSAGE = "사진을 보냈습니다.";
 
     public String mapToContent(ChatMessage chatMessage) {
-        if (Objects.isNull(chatMessage)) {
+        if (Objects.isNull(chatMessage) || Objects.isNull(chatMessage.getMessageType())) {
             return null;
         }
         

--- a/src/main/java/com/poortorich/websocket/stomp/command/subscribe/endpoint/SubscribeEndpoint.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/subscribe/endpoint/SubscribeEndpoint.java
@@ -5,6 +5,7 @@ import java.util.List;
 public class SubscribeEndpoint {
 
     public static final String CHATROOM_SUBSCRIBE_PREFIX = "/sub/chatroom/";
+    public static final String JOINED_CHATROOM_LIST_PREFIX = "/sub/chat/summary";
 
-    public static final List<String> SUB_PREFIXES = List.of(CHATROOM_SUBSCRIBE_PREFIX);
+    public static final List<String> SUB_PREFIXES = List.of(CHATROOM_SUBSCRIBE_PREFIX, JOINED_CHATROOM_LIST_PREFIX);
 }

--- a/src/main/java/com/poortorich/websocket/stomp/command/subscribe/endpoint/SubscribeEndpoint.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/subscribe/endpoint/SubscribeEndpoint.java
@@ -5,7 +5,7 @@ import java.util.List;
 public class SubscribeEndpoint {
 
     public static final String CHATROOM_SUBSCRIBE_PREFIX = "/sub/chatroom/";
-    public static final String JOINED_CHATROOM_LIST_PREFIX = "/sub/chat/summary";
+    public static final String JOINED_CHATROOM_LIST_PREFIX = "/sub/chat/summary/";
 
     public static final List<String> SUB_PREFIXES = List.of(CHATROOM_SUBSCRIBE_PREFIX, JOINED_CHATROOM_LIST_PREFIX);
 }

--- a/src/main/java/com/poortorich/websocket/stomp/command/subscribe/handler/StompSubscribeHandler.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/subscribe/handler/StompSubscribeHandler.java
@@ -1,21 +1,22 @@
 package com.poortorich.websocket.stomp.command.subscribe.handler;
 
-import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.repository.ChatroomRepository;
-import com.poortorich.chat.response.enums.ChatResponse;
 import com.poortorich.chat.validator.ChatroomValidator;
+import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.NotFoundException;
-import com.poortorich.user.entity.User;
 import com.poortorich.user.repository.UserRepository;
-import com.poortorich.user.response.enums.UserResponse;
+import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
 import com.poortorich.websocket.stomp.command.subscribe.util.SubscribeEndpointExtractor;
 import com.poortorich.websocket.stomp.command.subscribe.validator.SubscribeValidator;
+import com.poortorich.websocket.stomp.response.StompResponse;
 import com.poortorich.websocket.stomp.service.SubscribeService;
 import com.poortorich.websocket.stomp.util.StompSessionManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
+
+import java.util.Objects;
 
 @Slf4j
 @Component
@@ -34,19 +35,19 @@ public class StompSubscribeHandler {
     public void handle(StompHeaderAccessor accessor) {
         log.info("[SUBSCRIBE]: 구독 시작---------------------------");
         subscribeValidator.validateEndPoint(accessor);
-        Long chatroomId = endpointExtractor.getChatroomId(accessor.getDestination());
-        Chatroom chatroom = chatroomRepository.findById(chatroomId)
-                .orElseThrow(() -> new NotFoundException(ChatResponse.CHATROOM_NOT_FOUND));
-        log.info("[SUBSCRIBE]: 유효한 채팅방 엔드포인트: {}", chatroomId);
 
-        String username = sessionManager.getUsername(accessor);
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
-        log.info("[SUBSCRIBE]: 유저 조회 성공: {}", username);
+        String destination = accessor.getDestination();
+        if (Objects.isNull(destination)) {
+            throw new NotFoundException(StompResponse.DESTINATION_NOT_FOUND);
+        }
 
-        chatroomValidator.validateSubscribe(user, chatroom);
-        log.info("[SUBSCRIBE]: 유저 `{}`가 채팅방[{}] 구독 완료", username, chatroom.getId());
-
-        subscribeService.subscribe(chatroomId, username, accessor.getSessionId(), accessor.getSubscriptionId());
+        if (destination.startsWith(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX)) {
+            subscribeValidator.validateChatroomSubscribe(accessor);
+        } else if (destination.startsWith(SubscribeEndpoint.JOINED_CHATROOM_LIST_PREFIX)) {
+            subscribeValidator.validateJoinedChatroomSubscribe(accessor);
+        } else {
+            throw new BadRequestException(StompResponse.DESTINATION_INVALID);
+        }
+        log.info("[SUBSCRIBE]: 구독 종료---------------------------");
     }
 }

--- a/src/main/java/com/poortorich/websocket/stomp/command/subscribe/handler/StompSubscribeHandler.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/subscribe/handler/StompSubscribeHandler.java
@@ -3,7 +3,6 @@ package com.poortorich.websocket.stomp.command.subscribe.handler;
 import com.poortorich.chat.repository.ChatroomRepository;
 import com.poortorich.chat.validator.ChatroomValidator;
 import com.poortorich.global.exceptions.BadRequestException;
-import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.user.repository.UserRepository;
 import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
 import com.poortorich.websocket.stomp.command.subscribe.util.SubscribeEndpointExtractor;
@@ -15,8 +14,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
-
-import java.util.Objects;
 
 @Slf4j
 @Component
@@ -37,9 +34,6 @@ public class StompSubscribeHandler {
         subscribeValidator.validateEndPoint(accessor);
 
         String destination = accessor.getDestination();
-        if (Objects.isNull(destination)) {
-            throw new NotFoundException(StompResponse.DESTINATION_NOT_FOUND);
-        }
 
         if (destination.startsWith(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX)) {
             subscribeValidator.validateChatroomSubscribe(accessor);

--- a/src/main/java/com/poortorich/websocket/stomp/command/subscribe/util/SubscribeEndpointExtractor.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/subscribe/util/SubscribeEndpointExtractor.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SubscribeEndpointExtractor {
 
-    public Long getChatroomId(String endpoint) {
+    public Long getDestinationValue(String endpoint) {
         return SubscribeEndpoint.SUB_PREFIXES.stream()
                 .filter(endpoint::startsWith)
                 .findFirst()

--- a/src/main/java/com/poortorich/websocket/stomp/command/subscribe/validator/SubscribeValidator.java
+++ b/src/main/java/com/poortorich/websocket/stomp/command/subscribe/validator/SubscribeValidator.java
@@ -1,18 +1,38 @@
 package com.poortorich.websocket.stomp.command.subscribe.validator;
 
+import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.repository.ChatroomRepository;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.chat.validator.ChatroomValidator;
+import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.user.entity.User;
+import com.poortorich.user.repository.UserRepository;
+import com.poortorich.user.response.enums.UserResponse;
 import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
+import com.poortorich.websocket.stomp.command.subscribe.util.SubscribeEndpointExtractor;
 import com.poortorich.websocket.stomp.response.StompResponse;
+import com.poortorich.websocket.stomp.service.SubscribeService;
+import com.poortorich.websocket.stomp.util.StompSessionManager;
 import com.poortorich.websocket.stomp.validator.StompValidator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SubscribeValidator {
 
+    private final UserRepository userRepository;
+    private final ChatroomRepository chatroomRepository;
+    private final ChatroomValidator chatroomValidator;
+
+    private final SubscribeService subscribeService;
+    private final StompSessionManager sessionManager;
     private final StompValidator stompValidator;
+    private final SubscribeEndpointExtractor endpointExtractor;
 
     public void validateEndPoint(StompHeaderAccessor accessor) {
         stompValidator.validateDestination(accessor);
@@ -26,5 +46,38 @@ public class SubscribeValidator {
     private boolean hasMatchingPrefix(String subPath) {
         return SubscribeEndpoint.SUB_PREFIXES.stream()
                 .anyMatch(subPath::startsWith);
+    }
+
+    public void validateChatroomSubscribe(StompHeaderAccessor accessor) {
+        Long chatroomId = endpointExtractor.getDestinationValue(accessor.getDestination());
+        Chatroom chatroom = chatroomRepository.findById(chatroomId)
+                .orElseThrow(() -> new NotFoundException(ChatResponse.CHATROOM_NOT_FOUND));
+        log.info("[SUBSCRIBE]: 유효한 채팅방 엔드포인트: {}", chatroomId);
+
+        String username = sessionManager.getUsername(accessor);
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
+
+        log.info("[SUBSCRIBE]: 유저 조회 성공: {}", username);
+
+        chatroomValidator.validateSubscribe(user, chatroom);
+        log.info("[SUBSCRIBE]: 유저 `{}`가 채팅방[{}] 구독 완료", username, chatroom.getId());
+
+        subscribeService.subscribe(chatroomId, username, accessor.getSessionId(), accessor.getSubscriptionId());
+    }
+
+    public void validateJoinedChatroomSubscribe(StompHeaderAccessor accessor) {
+        Long userId = endpointExtractor.getDestinationValue(accessor.getDestination());
+        log.info("[SUBSCRIBE]: 구독하려는 회원 아이디 추출 성공 {}", userId);
+
+        User subscriber = userRepository.findByUsername(sessionManager.getUsername(accessor))
+                .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND));
+        log.info("[SUBSCRIBE]: 구독 유저 조회 성공: {}", subscriber.getUsername());
+
+        log.info("[SUBSCRIBE]: 구독자의 아이디[{}]가 요청 경로 아이디[{}]와 일치하는지 검사", subscriber.getId(), userId);
+        if (!subscriber.getId().equals(userId)) {
+            throw new BadRequestException(StompResponse.DESTINATION_INVALID);
+        }
+        log.info("[SUBSCRIBE]: 유저[{}]가 참여중인 채팅 목록 구독 완료", subscriber.getUsername());
     }
 }


### PR DESCRIPTION
## #️⃣477
 
 ## 📝작업 내용
 
채팅방이 갱신될 때 사용자가 참여중인 채팅방 목록 구독 엔드포인트로 새로 갱신된 데이터를 브로드캐스트해줍니다.

- 모든 채팅방 참석자
  - 편집
  - 메시지 발행
  - 입장
  - 퇴장
  - 강제 퇴장
- 특정 참석자에게만
  - 방장 위임
- 한 사용자에게만
  - 안읽은 메시지 모두 읽음 처리
  
 ### 스크린샷 (선택)
 
 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 내 채팅방 목록 조회 API 추가(커서 기반 페이징 지원).
  - 참여 중인 채팅방 목록에 대한 실시간 갱신 도입(입장/퇴장, 위임/강퇴, 메시지 작성/읽음, 방 정보 변경 시 자동 업데이트).
  - STOMP 구독 엔드포인트에 참여중 목록 토픽 추가(/sub/chat/summary/{userId}) 및 구독 검증 지원.
  - 채팅 메시지 타입별 사람이 읽기 쉬운 요약 콘텐츠 매핑(사진/텍스트/랭킹).

- 리팩터링
  - 구독 처리 흐름을 목적지 기반 검증 중심으로 단순화하고 예외 처리 개선.
  - 내부 이벤트 기반 구조로 업데이트 감지 및 전파 일원화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->