### PR TITLE
[#479] 채팅 메시지 사진 발행 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -56,6 +56,7 @@ public class ChatResponseMessage {
     public static final String CHAT_PARTICIPANT_KICK_SUCCESS = "사용자 강제퇴장이 완료됐습니다.";
     public static final String GET_MY_CHATROOMS_SUCCESS = "참여중인 채팅방 목록 조회가 완료되었습니다.";
     public static final String CHATROOM_IS_CLOSED = "채팅방이 종료되었습니다.";
+    public static final String MESSAGE_TYPE_INVALID = "유효하지 않은 메시지 타입입니다.";
 
     private ChatResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chat/realtime/builder/UserChatMessageBuilder.java
+++ b/src/main/java/com/poortorich/chat/realtime/builder/UserChatMessageBuilder.java
@@ -4,18 +4,54 @@ import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.enums.ChatMessageType;
 import com.poortorich.chat.realtime.payload.request.ChatMessageRequestPayload;
+import com.poortorich.chat.response.enums.ChatResponse;
+import com.poortorich.global.exceptions.BadRequestException;
+import com.poortorich.global.exceptions.NotFoundException;
+import com.poortorich.photo.repository.PhotoRepository;
+import com.poortorich.photo.response.enums.PhotoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class UserChatMessageBuilder {
 
-    private UserChatMessageBuilder() {
+    private final PhotoRepository photoRepository;
+
+    public ChatMessage buildChatMessage(
+            ChatParticipant chatParticipant,
+            ChatMessageRequestPayload chatMessageRequestPayload
+    ) {
+        return switch (chatMessageRequestPayload.getMessageType()) {
+            case TEXT -> buildTextChatMessage(chatParticipant, chatMessageRequestPayload);
+            case PHOTO -> buildPhotoChatMessage(chatParticipant, chatMessageRequestPayload);
+            default -> throw new BadRequestException(ChatResponse.MESSAGE_TYPE_INVALID);
+        };
     }
 
-    public static ChatMessage buildChatMessage(
+    private ChatMessage buildTextChatMessage(
             ChatParticipant chatParticipant,
             ChatMessageRequestPayload chatMessageRequestPayload
     ) {
         return ChatMessage.builder()
                 .userId(chatParticipant.getUser().getId())
+                .type(ChatMessageType.CHAT_MESSAGE)
+                .messageType(chatMessageRequestPayload.getMessageType())
+                .content(chatMessageRequestPayload.getContent())
+                .chatroom(chatParticipant.getChatroom())
+                .build();
+    }
+
+    private ChatMessage buildPhotoChatMessage(
+            ChatParticipant chatParticipant,
+            ChatMessageRequestPayload chatMessageRequestPayload
+    ) {
+        Long photoId = photoRepository.findByPhotoUrl(chatMessageRequestPayload.getContent())
+                .orElseThrow(() -> new NotFoundException(PhotoResponse.PHOTO_NOT_FOUND)).getId();
+
+        return ChatMessage.builder()
+                .userId(chatParticipant.getUser().getId())
+                .photoId(photoId)
                 .type(ChatMessageType.CHAT_MESSAGE)
                 .messageType(chatMessageRequestPayload.getMessageType())
                 .content(chatMessageRequestPayload.getContent())

--- a/src/main/java/com/poortorich/chat/realtime/payload/response/UserChatMessagePayload.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/response/UserChatMessagePayload.java
@@ -1,5 +1,6 @@
 package com.poortorich.chat.realtime.payload.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.poortorich.chat.entity.enums.ChatMessageType;
 import com.poortorich.chat.entity.enums.MessageType;
 import com.poortorich.chat.model.ChatMessageResponse;
@@ -12,14 +13,17 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 @Builder
+@EqualsAndHashCode(callSuper = false)
 public class UserChatMessagePayload extends ChatMessageResponse implements ResponsePayload {
 
     private Long messageId;
     private Long chatroomId;
     private Long senderId;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long photoId;
+
     private MessageType messageType;
     private String content;
     private LocalDateTime sentAt;

--- a/src/main/java/com/poortorich/chat/realtime/payload/response/UserChatMessagePayload.java
+++ b/src/main/java/com/poortorich/chat/realtime/payload/response/UserChatMessagePayload.java
@@ -19,6 +19,7 @@ public class UserChatMessagePayload extends ChatMessageResponse implements Respo
     private Long messageId;
     private Long chatroomId;
     private Long senderId;
+    private Long photoId;
     private MessageType messageType;
     private String content;
     private LocalDateTime sentAt;

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -46,7 +46,8 @@ public enum ChatResponse implements Response {
     HOST_DELEGATION_SUCCESS(HttpStatus.OK, ChatResponseMessage.HOST_DELEGATION_SUCCESS, null),
     CHAT_PARTICIPANT_KICK_SUCCESS(HttpStatus.OK, ChatResponseMessage.CHAT_PARTICIPANT_KICK_SUCCESS, null),
     GET_MY_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_MY_CHATROOMS_SUCCESS, null),
-    CHATROOM_IS_CLOSED(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_IS_CLOSED, null);
+    CHATROOM_IS_CLOSED(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_IS_CLOSED, null),
+    MESSAGE_TYPE_INVALID(HttpStatus.BAD_REQUEST, ChatResponseMessage.MESSAGE_TYPE_INVALID, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -40,6 +40,7 @@ public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
     private final UnreadChatMessageService unreadChatMessageService;
 
+    private final UserChatMessageBuilder userChatMessageBuilder;
     private final DateChangeDetector dateChangeDetector;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -89,7 +90,7 @@ public class ChatMessageService {
     ) {
         dateChangeDetector.detect(chatParticipant.getChatroom());
         ChatMessage chatMessage = chatMessageRepository.save(
-                UserChatMessageBuilder.buildChatMessage(chatParticipant, chatMessageRequestPayload));
+                userChatMessageBuilder.buildChatMessage(chatParticipant, chatMessageRequestPayload));
 
         List<Long> unreadBy = unreadChatMessageService.saveUnreadMember(chatMessage, chatMembers);
 

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -98,6 +98,7 @@ public class ChatMessageService {
                 .messageId(chatMessage.getId())
                 .chatroomId(chatMessage.getChatroom().getId())
                 .senderId(chatMessage.getUserId())
+                .photoId(chatMessage.getPhotoId())
                 .messageType(chatMessage.getMessageType())
                 .content(chatMessage.getContent())
                 .sentAt(chatMessage.getSentAt())

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatMessageMapper.java
@@ -106,6 +106,7 @@ public class ChatMessageMapper {
                 .messageId(chatMessage.getId())
                 .chatroomId(chatMessage.getChatroom().getId())
                 .senderId(chatMessage.getUserId())
+                .photoId(chatMessage.getPhotoId())
                 .messageType(chatMessage.getMessageType())
                 .content(chatMessage.getContent())
                 .sentAt(chatMessage.getSentAt())

--- a/src/main/java/com/poortorich/photo/constants/PhotoResponseMessage.java
+++ b/src/main/java/com/poortorich/photo/constants/PhotoResponseMessage.java
@@ -7,6 +7,7 @@ public class PhotoResponseMessage {
     public static final String GET_ALL_PHOTOS_SUCCESS = "사진 목록 조회를 완료했습니다.";
 
     public static final String PHOTO_REQUIRED = "이미지는 필수값입니다.";
+    public static final String PHOTO_NOT_FOUND = "이미지를 찾을 수 없습니다.";
 
     private PhotoResponseMessage() {
     }

--- a/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
@@ -18,19 +19,21 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     List<Photo> findTop10ByChatroomOrderByCreatedDateDescIdAsc(Chatroom chatroom);
 
     @Query("""
-        SELECT p
-          FROM Photo p
-         WHERE p.chatroom = :chatroom
-           AND (
-                  p.createdDate < :date
-               OR (p.createdDate = :date AND p.id < :id)
-           )
-         ORDER BY p.createdDate DESC, p.id DESC
-    """)
+                SELECT p
+                  FROM Photo p
+                 WHERE p.chatroom = :chatroom
+                   AND (
+                          p.createdDate < :date
+                       OR (p.createdDate = :date AND p.id < :id)
+                   )
+                 ORDER BY p.createdDate DESC, p.id DESC
+            """)
     Slice<Photo> findAllByChatroomAndCursor(
             @Param("chatroom") Chatroom chatroom,
             @Param("date") LocalDateTime date,
             @Param("id") Long id,
             Pageable pageable
     );
+
+    Optional<Photo> findByPhotoUrl(String content);
 }

--- a/src/main/java/com/poortorich/photo/response/enums/PhotoResponse.java
+++ b/src/main/java/com/poortorich/photo/response/enums/PhotoResponse.java
@@ -14,7 +14,8 @@ public enum PhotoResponse implements Response {
     GET_PREVIEW_PHOTOS_SUCCESS(HttpStatus.OK, PhotoResponseMessage.GET_PREVIEW_PHOTOS_SUCCESS, null),
     GET_ALL_PHOTOS_SUCCESS(HttpStatus.OK, PhotoResponseMessage.GET_ALL_PHOTOS_SUCCESS, null),
 
-    PHOTO_REQUIRED(HttpStatus.BAD_REQUEST, PhotoResponseMessage.PHOTO_REQUIRED , "photo");
+    PHOTO_REQUIRED(HttpStatus.BAD_REQUEST, PhotoResponseMessage.PHOTO_REQUIRED, "photo"),
+    PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, PhotoResponseMessage.PHOTO_NOT_FOUND, null);
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## #️⃣479
 
 ## 📝작업 내용
 - 사진 발행 시 ChatMessage Entity에 photoId 필드 값을 추가하는 작업을 수행
 - 채팅 메시지 브로드캐스트 시 `messageType`이 `PHOTO`인 경우 photoId를 제공
 - 이전 채팅 조회에서 `messageType`이 `PHOTO`인 경우 photoId를 제공

### 참고사항
```
S3에 사진을 업로드할 때 파일명을 UUID로 고유하게 저장하므로 photoUrl로 조회가 가능하다고 판단하였음
```
 
 ### 스크린샷 (선택)
 
<img width="1520" height="94" alt="image" src="https://github.com/user-attachments/assets/5a59703a-6f04-459c-a601-fa6517d7b8cc" />
<img width="676" height="844" alt="image" src="https://github.com/user-attachments/assets/4402dc02-15b1-43b9-b097-055e409f0ea9" />
<img width="430" height="360" alt="image" src="https://github.com/user-attachments/assets/ba885184-4683-4723-b6ff-ae4b966e9378" />

 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
