### PR TITLE
[#481] 사용자 프로필 조회 API userId 필드 추가

### DIFF
--- a/src/main/java/com/poortorich/user/response/UserDetailResponse.java
+++ b/src/main/java/com/poortorich/user/response/UserDetailResponse.java
@@ -6,7 +6,8 @@ import lombok.Data;
 @Data
 @Builder
 public class UserDetailResponse {
-
+    
+    private Long userId;
     private String profileImage;
     private Boolean isDefaultProfile;
     private String name;

--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -59,6 +59,7 @@ public class UserService {
         }
 
         return UserDetailResponse.builder()
+                .userId(user.getId())
                 .profileImage(profileImage)
                 .isDefaultProfile(isDefaultProfile)
                 .name(user.getName())


### PR DESCRIPTION
## #️⃣481
 
 ## 📝작업 내용
- 사용자 프로필 상세 조회 시 userId 필드를 추가하였습니다. 
 
 ### 스크린샷 (선택)
 
<img width="377" height="339" alt="image" src="https://github.com/user-attachments/assets/f897621b-eade-4ac3-b112-bd827580c6a5" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 사용자 상세 조회 API 응답에 사용자 ID(userId)가 추가되었습니다. 클라이언트는 고유 식별자를 직접 활용해 사용자 매핑 및 추적을 더 쉽게 수행할 수 있습니다.
  * 기존 응답 필드와 동작은 그대로 유지되며, 하위 호환성이 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->