### PR TITLE
[#485] 전체 랭킹 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -140,5 +140,11 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             """)
     Slice<ChatParticipant> findMyParticipants(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
 
-    List<ChatParticipant> findAllByIdIn(List<Long> chatParticipantIds);
+    @Query("""
+        SELECT cp
+         FROM ChatParticipant cp
+         JOIN FETCH cp.user u
+        WHERE cp.id In :ids
+    """)
+    List<ChatParticipant> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -139,4 +139,6 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             ORDER BY cr.id ASC
             """)
     Slice<ChatParticipant> findMyParticipants(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
+
+    List<ChatParticipant> findAllByIdIn(List<Long> chatParticipantIds);
 }

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -20,7 +20,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -182,5 +186,17 @@ public class ChatParticipantService {
                         context.user(),
                         context.cursor(),
                         context.pageRequest());
+    }
+
+    public List<ChatParticipant> findAllByIdIn(List<Long> chatParticipantIds) {
+        List<ChatParticipant> participants = chatParticipantRepository.findAllByIdIn(chatParticipantIds);
+
+        Map<Long, ChatParticipant> participantMap = participants.stream()
+                .collect(Collectors.toMap(ChatParticipant::getId, Function.identity()));
+
+        return chatParticipantIds.stream()
+                .map(participantMap::get)
+                .filter(Objects::nonNull)
+                .toList();
     }
 }

--- a/src/main/java/com/poortorich/chat/util/ChatBuilder.java
+++ b/src/main/java/com/poortorich/chat/util/ChatBuilder.java
@@ -130,4 +130,14 @@ public class ChatBuilder {
                 .rankingType(participantInfo.getRankingStatus().toString())
                 .build();
     }
+
+    public static ProfileResponse buildProfileResponse(ChatParticipant participantInfo, RankingStatus rankingStatus) {
+        return ProfileResponse.builder()
+                .userId(participantInfo.getUser().getId())
+                .profileImage(participantInfo.getUser().getProfileImage())
+                .nickname(participantInfo.getUser().getNickname())
+                .isHost(participantInfo.getRole().equals(ChatroomRole.HOST))
+                .rankingType(rankingStatus.toString())
+                .build();
+    }
 }

--- a/src/main/java/com/poortorich/ranking/constants/RankingResponseMessage.java
+++ b/src/main/java/com/poortorich/ranking/constants/RankingResponseMessage.java
@@ -8,4 +8,5 @@ public class RankingResponseMessage {
 
     public static final String GET_LATEST_RANKING_SUCCESS = "최신 랭킹 조회를 완료했습니다.";
     public static final String GET_LATEST_RANKING_NOT_FOUND = "랭킹이 집계되지 않았습니다.";
+    public static final String GET_ALL_RANKINGS_SUCCESS = "랭킹 목록 조회를 완료했습니다.";
 }

--- a/src/main/java/com/poortorich/ranking/controller/RankingController.java
+++ b/src/main/java/com/poortorich/ranking/controller/RankingController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,5 +31,17 @@ public class RankingController {
                 ? RankingResponse.GET_LATEST_RANKING_SUCCESS
                 : RankingResponse.GET_LATEST_RANKING_NOT_FOUND;
         return DataResponse.toResponseEntity(code, result.response());
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<BaseResponse> getAllRankings(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId,
+            @RequestParam(required = false) String cursor
+    ) {
+        return DataResponse.toResponseEntity(
+                RankingResponse.GET_ALL_RANKINGS_SUCCESS,
+                rankingFacade.getAllRankings(userDetails.getUsername(), chatroomId, cursor)
+        );
     }
 }

--- a/src/main/java/com/poortorich/ranking/entity/Ranking.java
+++ b/src/main/java/com/poortorich/ranking/entity/Ranking.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -27,7 +28,12 @@ import java.time.LocalDateTime;
 @DynamicUpdate
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "ranking")
+@Table(
+    name = "ranking",
+    indexes = {
+        @Index(name = "idx_chatroom_created_date", columnList = "chatroom_id, created_date")
+    }
+)
 public class Ranking {
 
     @Id

--- a/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
+++ b/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
@@ -116,6 +116,9 @@ public class RankingFacade {
 
     private Map<LocalDateTime, Ranking> getMondayRankings(Chatroom chatroom, String cursor) {
         List<LocalDateTime> mondays = getMondays(DateParser.parseDate(cursor).atStartOfDay(), getFloorMonday(chatroom));
+        if (mondays.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
         List<Ranking> rankings = rankingService.findAllRankings(chatroom, mondays);
 
         Map<LocalDateTime, Ranking> byDate = rankings.stream()
@@ -155,6 +158,10 @@ public class RankingFacade {
             String nextCursor,
             Map<LocalDateTime, Ranking> rankings
     ) {
+        if (rankings.isEmpty()) {
+            return AllRankingsResponse.builder().build();
+        }
+
         return AllRankingsResponse.builder()
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)

--- a/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
+++ b/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
@@ -2,11 +2,17 @@ package com.poortorich.ranking.facade;
 
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.chat.entity.enums.RankingStatus;
+import com.poortorich.chat.response.ProfileResponse;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
+import com.poortorich.chat.util.ChatBuilder;
 import com.poortorich.chat.validator.ChatParticipantValidator;
+import com.poortorich.global.date.util.DateParser;
 import com.poortorich.ranking.entity.Ranking;
+import com.poortorich.ranking.response.AllRankingsResponse;
 import com.poortorich.ranking.response.LatestRankingResponse;
+import com.poortorich.ranking.response.RankingInfoResponse;
 import com.poortorich.ranking.service.RankingService;
 import com.poortorich.ranking.util.RankingBuilder;
 import com.poortorich.user.entity.User;
@@ -18,6 +24,13 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +45,8 @@ public class RankingFacade {
             return new LatestRankingResult(false, response);
         }
     }
+
+    private static final int PAGE_SIZE = 21;
 
     private final UserService userService;
     private final ChatroomService chatroomService;
@@ -76,5 +91,120 @@ public class RankingFacade {
 
         LatestRankingResponse response = RankingBuilder.buildLatestRankingResponse(latestRanking, saver, flexer);
         return LatestRankingResult.found(response);
+    }
+
+    @Transactional(readOnly = true)
+    public AllRankingsResponse getAllRankings(String username, Long chatroomId, String cursor) {
+        User user = userService.findUserByUsername(username);
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+        chatParticipantValidator.validateIsParticipate(user, chatroom);
+
+        Map<LocalDateTime, Ranking> rankings = getMondayRankings(chatroom, cursor);
+
+        boolean hasNext = rankings.size() == PAGE_SIZE;
+        LocalDateTime lastKey = rankings.keySet()
+                .stream()
+                .reduce((first, second) -> second)
+                .orElse(null);
+
+        return buildAllRankingsResponse(
+                hasNext,
+                hasNext ? lastKey.toLocalDate().toString() : null,
+                rankings
+        );
+    }
+
+    private Map<LocalDateTime, Ranking> getMondayRankings(Chatroom chatroom, String cursor) {
+        List<LocalDateTime> mondays = getMondays(DateParser.parseDate(cursor).atStartOfDay(), getFloorMonday(chatroom));
+        List<Ranking> rankings = rankingService.findAllRankings(chatroom, mondays);
+
+        Map<LocalDateTime, Ranking> byDate = rankings.stream()
+                .collect(Collectors.toMap(Ranking::getCreatedDate, ranking -> ranking));
+
+        Map<LocalDateTime, Ranking> result = new LinkedHashMap<>();
+        for (LocalDateTime monday : mondays) {
+            result.put(monday, byDate.getOrDefault(monday, null));
+        }
+        return result;
+    }
+
+    private LocalDateTime getFloorMonday(Chatroom chatroom) {
+        return chatroom.getCreatedDate()
+                .with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY))
+                .toLocalDate()
+                .atStartOfDay();
+    }
+
+    private List<LocalDateTime> getMondays(LocalDateTime cursor, LocalDateTime floorMonday) {
+        LocalDateTime recentMonday = cursor
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                .toLocalDate()
+                .atStartOfDay();
+
+        List<LocalDateTime> mondays = IntStream.range(0, PAGE_SIZE)
+                .mapToObj(recentMonday::minusWeeks)
+                .toList();
+
+        return mondays.stream()
+                .filter(m -> !m.isBefore(floorMonday))
+                .toList();
+    }
+
+    private AllRankingsResponse buildAllRankingsResponse(
+            Boolean hasNext,
+            String nextCursor,
+            Map<LocalDateTime, Ranking> rankings
+    ) {
+        return AllRankingsResponse.builder()
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .rankings(rankings.entrySet().stream()
+                        .limit(rankings.size() - 1)
+                        .map(entry -> buildRankingInfoResponse(entry.getKey(), entry.getValue()))
+                        .toList())
+                .build();
+    }
+
+    private RankingInfoResponse buildRankingInfoResponse(LocalDateTime rankingAt, Ranking ranking) {
+        if (ranking == null) {
+            return RankingInfoResponse.builder()
+                    .rankingAt(rankingAt.toLocalDate().toString())
+                    .saverRankings(List.of())
+                    .flexerRankings(List.of())
+                    .build();
+        }
+
+        return RankingInfoResponse.builder()
+                .rankingId(ranking.getId())
+                .rankingAt(rankingAt.toLocalDate().toString())
+                .saverRankings(buildProfileResponse(
+                        Arrays.asList(ranking.getSaverFirst(), ranking.getSaverSecond(), ranking.getSaverThird()),
+                        RankingStatus.SAVER)
+                )
+                .flexerRankings(buildProfileResponse(
+                        Arrays.asList(ranking.getFlexerFirst(), ranking.getFlexerSecond(), ranking.getFlexerThird()),
+                        RankingStatus.FLEXER)
+                )
+                .build();
+    }
+
+    private List<ProfileResponse> buildProfileResponse(List<Long> chatParticipantIds, RankingStatus type) {
+        List<ChatParticipant> participants = chatParticipantService.findAllByIdIn(chatParticipantIds);
+
+        return IntStream.range(0, chatParticipantIds.size())
+                .mapToObj(i -> {
+                    ChatParticipant chatParticipant = participants.stream()
+                            .filter(p -> Objects.equals(p.getId(), chatParticipantIds.get(i)))
+                            .findFirst()
+                            .orElse(null);
+
+                    if (chatParticipant == null) {
+                        return null;
+                    }
+
+                    return ChatBuilder.buildProfileResponse(chatParticipant, i == 0 ? type : RankingStatus.NONE);
+                })
+                .filter(Objects::nonNull)
+                .toList();
     }
 }

--- a/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
@@ -3,9 +3,11 @@ package com.poortorich.ranking.repository;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.ranking.entity.Ranking;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,4 +18,13 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
             LocalDateTime startDate,
             LocalDateTime endDate
     );
+
+    @Query("""
+        SELECT r
+          FROM Ranking r
+         WHERE r.chatroom = :chatroom
+           AND r.createdDate IN :mondays
+         ORDER BY r.createdDate DESC
+    """)
+    List<Ranking> findAllByChatroomWithDateIn(Chatroom chatroom, List<LocalDateTime> mondays);
 }

--- a/src/main/java/com/poortorich/ranking/response/AllRankingsResponse.java
+++ b/src/main/java/com/poortorich/ranking/response/AllRankingsResponse.java
@@ -1,0 +1,19 @@
+package com.poortorich.ranking.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AllRankingsResponse {
+
+    private Boolean hasNext;
+    private String nextCursor;
+    private List<RankingInfoResponse> rankings;
+}

--- a/src/main/java/com/poortorich/ranking/response/RankingInfoResponse.java
+++ b/src/main/java/com/poortorich/ranking/response/RankingInfoResponse.java
@@ -1,0 +1,21 @@
+package com.poortorich.ranking.response;
+
+import com.poortorich.chat.response.ProfileResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankingInfoResponse {
+
+    private Long rankingId;
+    private String rankingAt;
+    private List<ProfileResponse> saverRankings;
+    private List<ProfileResponse> flexerRankings;
+}

--- a/src/main/java/com/poortorich/ranking/response/enums/RankingResponse.java
+++ b/src/main/java/com/poortorich/ranking/response/enums/RankingResponse.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum RankingResponse implements Response {
 
     GET_LATEST_RANKING_SUCCESS(HttpStatus.OK, RankingResponseMessage.GET_LATEST_RANKING_SUCCESS, null),
-    GET_LATEST_RANKING_NOT_FOUND(HttpStatus.OK, RankingResponseMessage.GET_LATEST_RANKING_NOT_FOUND, null);
+    GET_LATEST_RANKING_NOT_FOUND(HttpStatus.OK, RankingResponseMessage.GET_LATEST_RANKING_NOT_FOUND, null),
+    GET_ALL_RANKINGS_SUCCESS(HttpStatus.OK, RankingResponseMessage.GET_ALL_RANKINGS_SUCCESS, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/ranking/service/RankingService.java
+++ b/src/main/java/com/poortorich/ranking/service/RankingService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +18,9 @@ public class RankingService {
     public Ranking findLatestRanking(Chatroom chatroom, LocalDateTime start, LocalDateTime end) {
         return rankingRepository.findFirstByChatroomAndCreatedDateBetweenOrderByCreatedDateDesc(chatroom, start, end)
                 .orElse(null);
+    }
+
+    public List<Ranking> findAllRankings(Chatroom chatroom, List<LocalDateTime> mondays) {
+        return rankingRepository.findAllByChatroomWithDateIn(chatroom, mondays);
     }
 }

--- a/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
@@ -338,4 +338,21 @@ class ChatParticipantServiceTest {
         assertThat(result).hasSize(4);
         assertThat(result).containsExactly(member1, member2, member3, member4);
     }
+
+    @Test
+    @DisplayName("채팅방 참여자 아이디 목록으로 채팅방 참여자 조회 성공")
+    void findAllByIdInSuccess() {
+        List<Long> ids = List.of(1L, 2L, 3L);
+        ChatParticipant participant1 = ChatParticipant.builder().id(1L).build();
+        ChatParticipant participant2 = ChatParticipant.builder().id(2L).build();
+        ChatParticipant participant3 = ChatParticipant.builder().id(3L).build();
+
+        when(chatParticipantRepository.findAllByIdIn(ids))
+                .thenReturn(List.of(participant1, participant2, participant3));
+
+        List<ChatParticipant> result = chatParticipantService.findAllByIdIn(ids);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactly(participant1, participant2, participant3);
+    }
 }

--- a/src/test/java/com/poortorich/ranking/controller/RankingControllerTest.java
+++ b/src/test/java/com/poortorich/ranking/controller/RankingControllerTest.java
@@ -2,6 +2,7 @@ package com.poortorich.ranking.controller;
 
 import com.poortorich.global.config.BaseSecurityTest;
 import com.poortorich.ranking.facade.RankingFacade;
+import com.poortorich.ranking.response.AllRankingsResponse;
 import com.poortorich.ranking.response.LatestRankingResponse;
 import com.poortorich.ranking.response.enums.RankingResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -64,5 +65,22 @@ class RankingControllerTest extends BaseSecurityTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
                         .value(RankingResponse.GET_LATEST_RANKING_NOT_FOUND.getMessage()));
+    }
+
+    @Test
+    @WithMockUser(username = username)
+    @DisplayName("전체 랭킹 목록 조회 성공")
+    void getAllRankingsSuccess() throws Exception {
+        Long chatroomId = 1L;
+        String cursor = "2025-08-18";
+
+        when(rankingFacade.getAllRankings(username, chatroomId, cursor))
+                .thenReturn(AllRankingsResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/rankings/all")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(RankingResponse.GET_ALL_RANKINGS_SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/poortorich/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/poortorich/ranking/service/RankingServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,5 +60,20 @@ class RankingServiceTest {
         Ranking result = rankingService.findLatestRanking(chatroom, lastMonday, now);
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("전체 랭킹 목록 조회 구현")
+    void getAllRankingsSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        List<LocalDateTime> mondays = List.of(lastMonday);
+        Ranking ranking = Ranking.builder().chatroom(chatroom).build();
+
+        when(rankingRepository.findAllByChatroomWithDateIn(chatroom, mondays)).thenReturn(List.of(ranking));
+
+        List<Ranking> result = rankingService.findAllRankings(chatroom, mondays);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getChatroom()).isEqualTo(chatroom);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#485
 
 ## 📝작업 내용
 
- 전체 랭킹 목록 조회
  - cursor : date 값
  - 채팅방 개설일까지의 전체 랭킹을 조회
  - 해당 날짜에 ranking 데이터가 없는 경우 null 반환
  - facade 테스트코드는 이후 구현 예정
 
 ### 스크린샷

<img width="1044" height="621" alt="image" src="https://github.com/user-attachments/assets/778409b5-3d17-455a-bdd9-972d57dfc760" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 전체 랭킹 조회 API 추가: GET /chatrooms/{chatroomId}/rankings/all (인증 필요, cursor로 페이지네이션)
  - 주차별 묶음 랭킹 반환(각 랭킹에 날짜·저장왕/플렉스왕 프로필 목록 포함) 및 hasNext/nextCursor 제공
  - 프로필 응답 생성 시 명시적 랭킹 상태 지정 지원
  - 다수 참가자 일괄 조회 지원

- Performance
  - 랭킹 테이블에 chatroom_id + created_date 복합 인덱스 추가로 조회 성능 개선

- Tests
  - 전체 랭킹 및 참가자 일괄 조회 경로에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->