### PR TITLE
[#492] 날짜 메시지 발행 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/realtime/event/datechange/DateChangeEvent.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/datechange/DateChangeEvent.java
@@ -1,6 +1,5 @@
 package com.poortorich.chat.realtime.event.datechange;
 
-import com.poortorich.chat.entity.Chatroom;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,5 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class DateChangeEvent {
 
-    private final Chatroom chatroom;
+    private final Long chatroomId;
 }

--- a/src/main/java/com/poortorich/chat/realtime/event/datechange/DateChangeEventListner.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/datechange/DateChangeEventListner.java
@@ -1,7 +1,9 @@
 package com.poortorich.chat.realtime.event.datechange;
 
+import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.realtime.payload.response.DateChangeMessagePayload;
 import com.poortorich.chat.service.ChatMessageService;
+import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -16,13 +18,15 @@ public class DateChangeEventListner {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final ChatMessageService chatMessageService;
+    private final ChatroomService chatroomService;
 
     @EventListener
     public void onDateChanged(DateChangeEvent event) {
-        DateChangeMessagePayload payload = chatMessageService.saveDateChangeMessage(event.getChatroom());
+        Chatroom chatroom = chatroomService.findById(event.getChatroomId());
+        DateChangeMessagePayload payload = chatMessageService.saveDateChangeMessage(chatroom);
 
         if (!Objects.isNull(payload)) {
-            messagingTemplate.convertAndSend(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + event.getChatroom().getId(),
+            messagingTemplate.convertAndSend(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroom.getId(),
                     payload.mapToBasePayload());
         }
     }

--- a/src/main/java/com/poortorich/chat/realtime/event/datechange/detector/DateChangeDetector.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/datechange/detector/DateChangeDetector.java
@@ -21,7 +21,7 @@ public class DateChangeDetector {
         String currentDate = LocalDate.now().toString();
 
         if (!chatMessageRepository.existsByContentAndMessageTypeAndChatroom(currentDate, MessageType.DATE, chatroom)) {
-            eventPublisher.publishEvent(new DateChangeEvent(chatroom));
+            eventPublisher.publishEvent(new DateChangeEvent(chatroom.getId()));
         }
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -177,10 +177,10 @@ public class ChatMessageService {
 
     @Transactional
     public RankingStatusMessagePayload saveRankingStatusMessage(PayloadContext context) {
+        dateChangeDetector.detect(context.chatroom());
         ChatMessage rankingStatusChatMessage = RankingStatusChatMessageBuilder.buildRankingStatusMessage(
                 context.chatroom());
 
-        dateChangeDetector.detect(context.chatroom());
         ChatMessage savedRankingStatusChatMessage = chatMessageRepository.save(rankingStatusChatMessage);
 
         return RankingStatusMessagePayload.builder()


### PR DESCRIPTION
## #️⃣492
 ## 📝작업 내용
 - 이벤트를 Chatroom이 아닌 chatroomId로 전달하도록 수정
 
 ### 스크린샷 (선택)
 
 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 리팩터링
  - 실시간 날짜 변경 이벤트에서 전체 객체 대신 ID만 전달하도록 경량화해 처리 흐름을 단순화했습니다.
  - 이벤트 리스너가 ID로 대상을 조회하도록 변경해 의존성 구성을 명확히 했습니다.
  - 날짜 변경 감지 호출 시점을 메시지 생성 전에 배치해 이벤트 전파 순서를 일관화했습니다.
- 사용자 영향
  - 날짜 변경 알림의 안정성과 일관성이 향상되었으며, 전송 지연 가능성이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->