### PR TITLE
[#494] 사진 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/poortorich/photo/constants/PhotoResponseMessage.java
+++ b/src/main/java/com/poortorich/photo/constants/PhotoResponseMessage.java
@@ -5,6 +5,7 @@ public class PhotoResponseMessage {
     public static final String UPLOAD_PHOTO_SUCCESS = "이미지 전송에 성공했습니다.";
     public static final String GET_PREVIEW_PHOTOS_SUCCESS = "최신 사진 목록 조회를 완료했습니다.";
     public static final String GET_ALL_PHOTOS_SUCCESS = "사진 목록 조회를 완료했습니다.";
+    public static final String GET_PHOTO_DETAILS_SUCCESS = "사진 상세 조회를 완료했습니다.";
 
     public static final String PHOTO_REQUIRED = "이미지는 필수값입니다.";
     public static final String PHOTO_NOT_FOUND = "이미지를 찾을 수 없습니다.";

--- a/src/main/java/com/poortorich/photo/controller/PhotoController.java
+++ b/src/main/java/com/poortorich/photo/controller/PhotoController.java
@@ -61,4 +61,16 @@ public class PhotoController {
                 photoFacade.getAllPhotosByCursor(userDetails.getUsername(), chatroomId, date, id)
         );
     }
+
+    @GetMapping("/{photoId}")
+    public ResponseEntity<BaseResponse> getPhotoDetails(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId,
+            @PathVariable Long photoId
+    ) {
+        return DataResponse.toResponseEntity(
+                PhotoResponse.GET_PHOTO_DETAILS_SUCCESS,
+                photoFacade.getPhotoDetails(userDetails.getUsername(), chatroomId, photoId)
+        );
+    }
 }

--- a/src/main/java/com/poortorich/photo/facade/PhotoFacade.java
+++ b/src/main/java/com/poortorich/photo/facade/PhotoFacade.java
@@ -9,6 +9,7 @@ import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.photo.entity.Photo;
 import com.poortorich.photo.request.PhotoUploadRequest;
 import com.poortorich.photo.response.AllPhotosResponse;
+import com.poortorich.photo.response.PhotoDetailsResponse;
 import com.poortorich.photo.response.PhotoUploadResponse;
 import com.poortorich.photo.response.PreviewPhotosResponse;
 import com.poortorich.photo.response.enums.PhotoResponse;
@@ -85,6 +86,21 @@ public class PhotoFacade {
                 photos.hasNext() ? nextDate : null,
                 photos.hasNext() ? photos.getContent().getLast().getId() : null,
                 photos.getContent()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public PhotoDetailsResponse getPhotoDetails(String username, Long chatroomId, Long photoId) {
+        User user = userService.findUserByUsername(username);
+        Chatroom chatroom = chatroomService.findById(chatroomId);
+        chatParticipantValidator.validateIsParticipate(user, chatroom);
+
+        Photo photo = photoService.findByChatroomAndId(chatroom, photoId);
+
+        return PhotoBuilder.buildPhotoDetailsResponse(
+                photo,
+                photoService.findPrevPhotoId(chatroom, photo),
+                photoService.findNextPhotoId(chatroom, photo)
         );
     }
 }

--- a/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
@@ -49,7 +49,11 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
           )
         ORDER BY p.createdDate DESC , p.id DESC
     """)
-    List<Long> findPrevPhotoId(Chatroom chatroom, LocalDateTime createdDate, Long id);
+    List<Long> findPrevPhotoId(
+            @Param("chatroom") Chatroom chatroom,
+            @Param("createdDate") LocalDateTime createdDate,
+            @Param("id") Long id
+    );
 
     @Query("""
         SELECT p.id
@@ -61,5 +65,9 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
           )
         ORDER BY p.createdDate ASC , p.id ASC
     """)
-    List<Long> findNextPhotoId(Chatroom chatroom, LocalDateTime createdDate, Long id);
+    List<Long> findNextPhotoId(
+            @Param("chatroom") Chatroom chatroom,
+            @Param("createdDate") LocalDateTime createdDate,
+            @Param("id") Long id
+    );
 }

--- a/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
@@ -36,4 +36,30 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     );
 
     Optional<Photo> findByPhotoUrl(String content);
+
+    Optional<Photo> findByChatroomAndId(Chatroom chatroom, Long photoId);
+
+    @Query("""
+        SELECT p.id
+          FROM Photo p
+        WHERE p.chatroom = :chatroom
+          AND (
+               p.createdDate < :createdDate
+               OR (p.createdDate = :createdDate AND p.id < :id)
+          )
+        ORDER BY p.createdDate DESC , p.id DESC
+    """)
+    List<Long> findPrevPhotoId(Chatroom chatroom, LocalDateTime createdDate, Long id);
+
+    @Query("""
+        SELECT p.id
+          FROM Photo p
+        WHERE p.chatroom = :chatroom
+          AND (
+               p.createdDate > :createdDate
+               OR (p.createdDate = :createdDate AND p.id > :id)
+          )
+        ORDER BY p.createdDate ASC , p.id ASC
+    """)
+    List<Long> findNextPhotoId(Chatroom chatroom, LocalDateTime createdDate, Long id);
 }

--- a/src/main/java/com/poortorich/photo/response/PhotoDetailsResponse.java
+++ b/src/main/java/com/poortorich/photo/response/PhotoDetailsResponse.java
@@ -1,0 +1,20 @@
+package com.poortorich.photo.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoDetailsResponse {
+
+    private Long photoId;
+    private String photoUrl;
+    private String uploadedAt;
+    private UploadedUserResponse uploadedBy;
+    private Long prevPhotoId;
+    private Long nextPhotoId;
+}

--- a/src/main/java/com/poortorich/photo/response/UploadedUserResponse.java
+++ b/src/main/java/com/poortorich/photo/response/UploadedUserResponse.java
@@ -1,0 +1,16 @@
+package com.poortorich.photo.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UploadedUserResponse {
+
+    private Long userId;
+    private String nickname;
+}

--- a/src/main/java/com/poortorich/photo/response/enums/PhotoResponse.java
+++ b/src/main/java/com/poortorich/photo/response/enums/PhotoResponse.java
@@ -13,6 +13,7 @@ public enum PhotoResponse implements Response {
     UPLOAD_PHOTO_SUCCESS(HttpStatus.CREATED, PhotoResponseMessage.UPLOAD_PHOTO_SUCCESS, null),
     GET_PREVIEW_PHOTOS_SUCCESS(HttpStatus.OK, PhotoResponseMessage.GET_PREVIEW_PHOTOS_SUCCESS, null),
     GET_ALL_PHOTOS_SUCCESS(HttpStatus.OK, PhotoResponseMessage.GET_ALL_PHOTOS_SUCCESS, null),
+    GET_PHOTO_DETAILS_SUCCESS(HttpStatus.OK, PhotoResponseMessage.GET_PHOTO_DETAILS_SUCCESS, null),
 
     PHOTO_REQUIRED(HttpStatus.BAD_REQUEST, PhotoResponseMessage.PHOTO_REQUIRED, "photo"),
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, PhotoResponseMessage.PHOTO_NOT_FOUND, null);

--- a/src/main/java/com/poortorich/photo/service/PhotoService.java
+++ b/src/main/java/com/poortorich/photo/service/PhotoService.java
@@ -1,10 +1,13 @@
 package com.poortorich.photo.service;
 
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.photo.entity.Photo;
 import com.poortorich.photo.repository.PhotoRepository;
+import com.poortorich.photo.response.enums.PhotoResponse;
 import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -33,5 +36,22 @@ public class PhotoService {
 
     public Slice<Photo> getAllPhotosByCursor(Chatroom chatroom, LocalDateTime date, Long id, Pageable pageable) {
         return photoRepository.findAllByChatroomAndCursor(chatroom, date, id, pageable);
+    }
+
+    public Photo findByChatroomAndId(Chatroom chatroom, Long photoId) {
+        return photoRepository.findByChatroomAndId(chatroom, photoId)
+                .orElseThrow(() -> new BadRequestException(PhotoResponse.PHOTO_NOT_FOUND));
+    }
+
+    public Long findPrevPhotoId(Chatroom chatroom, Photo currentPhoto) {
+        return photoRepository.findPrevPhotoId(chatroom, currentPhoto.getCreatedDate(), currentPhoto.getId()).stream()
+                .findFirst()
+                .orElse(null);
+    }
+
+    public Long findNextPhotoId(Chatroom chatroom, Photo currentPhoto) {
+        return photoRepository.findNextPhotoId(chatroom, currentPhoto.getCreatedDate(), currentPhoto.getId()).stream()
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
+++ b/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
@@ -3,8 +3,11 @@ package com.poortorich.photo.util;
 import com.poortorich.photo.entity.Photo;
 import com.poortorich.photo.response.AllPhotosResponse;
 import com.poortorich.photo.response.PhotoCursorResponse;
+import com.poortorich.photo.response.PhotoDetailsResponse;
 import com.poortorich.photo.response.PhotoInfoResponse;
 import com.poortorich.photo.response.PreviewPhotosResponse;
+import com.poortorich.photo.response.UploadedUserResponse;
+import com.poortorich.user.entity.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -58,6 +61,24 @@ public class PhotoBuilder {
                 .photoId(photo.getId())
                 .photoUrl(photo.getPhotoUrl())
                 .uploadedAt(photo.getCreatedDate().toLocalDate().toString())
+                .build();
+    }
+
+    public static PhotoDetailsResponse buildPhotoDetailsResponse(Photo photo, Long prevPhotoId, Long nextPhotoId) {
+        return PhotoDetailsResponse.builder()
+                .photoId(photo.getId())
+                .photoUrl(photo.getPhotoUrl())
+                .uploadedAt(photo.getCreatedDate().toString())
+                .uploadedBy(buildUploadedUserResponse(photo.getUser()))
+                .prevPhotoId(prevPhotoId)
+                .nextPhotoId(nextPhotoId)
+                .build();
+    }
+
+    private static UploadedUserResponse buildUploadedUserResponse(User user) {
+        return UploadedUserResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
                 .build();
     }
 }

--- a/src/test/java/com/poortorich/photo/controller/PhotoControllerTest.java
+++ b/src/test/java/com/poortorich/photo/controller/PhotoControllerTest.java
@@ -5,6 +5,7 @@ import com.poortorich.global.config.BaseSecurityTest;
 import com.poortorich.photo.facade.PhotoFacade;
 import com.poortorich.photo.request.PhotoUploadRequest;
 import com.poortorich.photo.response.AllPhotosResponse;
+import com.poortorich.photo.response.PhotoDetailsResponse;
 import com.poortorich.photo.response.PhotoUploadResponse;
 import com.poortorich.photo.response.PreviewPhotosResponse;
 import com.poortorich.photo.response.enums.PhotoResponse;
@@ -91,5 +92,22 @@ class PhotoControllerTest extends BaseSecurityTest {
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value(PhotoResponse.GET_ALL_PHOTOS_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @WithMockUser(username = USERNAME)
+    @DisplayName("사진 상세 조회 성공")
+    void getPhotoDetailsSuccess() throws Exception {
+        Long chatroomId = 1L;
+        Long photoId = 1L;
+
+        when(photoFacade.getPhotoDetails(USERNAME, chatroomId, photoId))
+                .thenReturn(PhotoDetailsResponse.builder().build());
+
+        mockMvc.perform(get("/chatrooms/" + chatroomId + "/photos/" + photoId)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value(PhotoResponse.GET_PHOTO_DETAILS_SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/poortorich/photo/facade/PhotoFacadeTest.java
+++ b/src/test/java/com/poortorich/photo/facade/PhotoFacadeTest.java
@@ -9,6 +9,7 @@ import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.photo.entity.Photo;
 import com.poortorich.photo.request.PhotoUploadRequest;
 import com.poortorich.photo.response.AllPhotosResponse;
+import com.poortorich.photo.response.PhotoDetailsResponse;
 import com.poortorich.photo.response.PhotoUploadResponse;
 import com.poortorich.photo.response.PreviewPhotosResponse;
 import com.poortorich.photo.response.enums.PhotoResponse;
@@ -224,5 +225,45 @@ class PhotoFacadeTest {
         assertThat(result.getPhotos().get(1).getPhotoUrl()).isEqualTo(photo2.getPhotoUrl());
         assertThat(result.getPhotos().get(2).getPhotoId()).isEqualTo(photo1.getId());
         assertThat(result.getPhotos().get(2).getPhotoUrl()).isEqualTo(photo1.getPhotoUrl());
+    }
+
+    @Test
+    @DisplayName("사진 상세 조회 성공")
+    void getPhotoDetailsSuccess() {
+        String username = "test";
+        Long chatroomId = 1L;
+        Long photoId = 2L;
+        Chatroom chatroom = Chatroom.builder().id(chatroomId).build();
+        User user = User.builder()
+                .id(1L)
+                .username(username)
+                .nickname(username)
+                .build();
+        Photo photo = Photo.builder()
+                .id(photoId)
+                .user(user)
+                .chatroom(chatroom)
+                .photoUrl("photo2.com")
+                .createdDate(LocalDateTime.of(2025, 8, 20, 0, 0, 0))
+                .build();
+        Long prevPhotoId = 1L;
+        Long nextPhotoId = 3L;
+
+        when(userService.findUserByUsername(username)).thenReturn(user);
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(photoService.findByChatroomAndId(chatroom, photoId)).thenReturn(photo);
+        when(photoService.findPrevPhotoId(chatroom, photo)).thenReturn(prevPhotoId);
+        when(photoService.findNextPhotoId(chatroom, photo)).thenReturn(nextPhotoId);
+
+        PhotoDetailsResponse result = photoFacade.getPhotoDetails(username, chatroomId, photoId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getPhotoId()).isEqualTo(photo.getId());
+        assertThat(result.getPhotoUrl()).isEqualTo(photo.getPhotoUrl());
+        assertThat(result.getUploadedAt()).isEqualTo(photo.getCreatedDate().toString());
+        assertThat(result.getUploadedBy().getUserId()).isEqualTo(photo.getUser().getId());
+        assertThat(result.getUploadedBy().getNickname()).isEqualTo(photo.getUser().getNickname());
+        assertThat(result.getPrevPhotoId()).isEqualTo(prevPhotoId);
+        assertThat(result.getNextPhotoId()).isEqualTo(nextPhotoId);
     }
 }

--- a/src/test/java/com/poortorich/photo/service/PhotoServiceTest.java
+++ b/src/test/java/com/poortorich/photo/service/PhotoServiceTest.java
@@ -169,9 +169,9 @@ class PhotoServiceTest {
                 .createdDate(createdDate)
                 .build();
 
-        when(photoRepository.findPrevPhotoId(chatroom, createdDate, currentPhotoId)).thenReturn(List.of(nextPhotoId));
+        when(photoRepository.findNextPhotoId(chatroom, createdDate, currentPhotoId)).thenReturn(List.of(nextPhotoId));
 
-        Long result = photoService.findPrevPhotoId(chatroom, currentPhoto);
+        Long result = photoService.findNextPhotoId(chatroom, currentPhoto);
 
         assertThat(result).isNotNull();
         assertThat(result).isEqualTo(nextPhotoId);

--- a/src/test/java/com/poortorich/photo/service/PhotoServiceTest.java
+++ b/src/test/java/com/poortorich/photo/service/PhotoServiceTest.java
@@ -1,8 +1,10 @@
 package com.poortorich.photo.service;
 
 import com.poortorich.chat.entity.Chatroom;
+import com.poortorich.global.exceptions.BadRequestException;
 import com.poortorich.photo.entity.Photo;
 import com.poortorich.photo.repository.PhotoRepository;
+import com.poortorich.photo.response.enums.PhotoResponse;
 import com.poortorich.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,8 +21,10 @@ import org.springframework.data.domain.SliceImpl;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -97,5 +101,79 @@ class PhotoServiceTest {
         assertThat(result).hasSize(3);
         assertThat(result).containsExactly(photo3, photo2, photo1);
         assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("채팅방과 사진 아이디로 사진 조회 성공")
+    void findByChatroomAndIdSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        Long photoId = 1L;
+        Photo photo = Photo.builder()
+                .id(photoId)
+                .chatroom(chatroom)
+                .build();
+
+        when(photoRepository.findByChatroomAndId(chatroom, photoId)).thenReturn(Optional.of(photo));
+
+        Photo result = photoService.findByChatroomAndId(chatroom, photoId);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(photo);
+        assertThat(result.getId()).isEqualTo(photoId);
+    }
+
+    @Test
+    @DisplayName("채팅방과 사진 아이디로 사진 조회 실패")
+    void findByChatroomAndIdFail() {
+        Chatroom chatroom = Chatroom.builder().build();
+        Long photoId = 1L;
+
+        when(photoRepository.findByChatroomAndId(chatroom, photoId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> photoService.findByChatroomAndId(chatroom, photoId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(PhotoResponse.PHOTO_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("이전 사진 아이디 조회 성공")
+    void findPrevPhotoIdSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        Long prevPhotoId = 1L;
+        Long currentPhotoId = 2L;
+        LocalDateTime createdDate = LocalDateTime.of(2025, 8, 26, 0, 0, 0);
+        Photo currentPhoto = Photo.builder()
+                .id(currentPhotoId)
+                .chatroom(chatroom)
+                .createdDate(createdDate)
+                .build();
+
+        when(photoRepository.findPrevPhotoId(chatroom, createdDate, currentPhotoId)).thenReturn(List.of(prevPhotoId));
+
+        Long result = photoService.findPrevPhotoId(chatroom, currentPhoto);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(prevPhotoId);
+    }
+
+    @Test
+    @DisplayName("다음 사진 아이디 조회 성공")
+    void findNextPhotoIdSuccess() {
+        Chatroom chatroom = Chatroom.builder().build();
+        Long nextPhotoId = 3L;
+        Long currentPhotoId = 2L;
+        LocalDateTime createdDate = LocalDateTime.of(2025, 8, 26, 0, 0, 0);
+        Photo currentPhoto = Photo.builder()
+                .id(currentPhotoId)
+                .chatroom(chatroom)
+                .createdDate(createdDate)
+                .build();
+
+        when(photoRepository.findPrevPhotoId(chatroom, createdDate, currentPhotoId)).thenReturn(List.of(nextPhotoId));
+
+        Long result = photoService.findPrevPhotoId(chatroom, currentPhoto);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(nextPhotoId);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#494 
 
 ## 📝작업 내용
 
- 사진 상세 조회
  - 사진 아이디와 채팅방 정보로 사진 조회
  - 현재 사진의 이전 사진과 이후 사진을 각각 조회 후 반환
 
 ### 스크린샷

<img width="1039" height="455" alt="image" src="https://github.com/user-attachments/assets/e2509b0f-608e-4d44-a9cb-e8c6eb4d17bc" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 채팅방 내 특정 사진의 상세 조회 API가 추가되었습니다. 사진 URL, 업로드 시각, 업로더 정보와 함께 이전/다음 사진 ID를 제공해 상세 화면에서 좌우 탐색이 가능합니다.
  - 조회 성공 메시지 및 일관된 응답 코드가 추가되었습니다.
- **테스트**
  - 컨트롤러·페이스드·서비스 레벨 테스트가 추가되어 상세 조회 흐름과 예외 처리를 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->