### PR TITLE
[#500] 참여중인 채팅방 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatMessageContentMapper.java
@@ -1,9 +1,12 @@
 package com.poortorich.chat.util.mapper;
 
 import com.poortorich.chat.entity.ChatMessage;
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.entity.enums.ChatroomRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Component
@@ -12,17 +15,33 @@ public class ChatMessageContentMapper {
 
     private static final String RANKING_MESSAGE = "랭킹이 집계되었습니다.";
     private static final String PHOTO_MESSAGE = "사진을 보냈습니다.";
+    private static final String EMPTY_MESSAGE = "";
+    private static final String CHATROOM_CREATED_MESSAGE = "새로운 채팅방이 생성되었습니다.";
 
     public String mapToContent(ChatMessage chatMessage) {
         if (Objects.isNull(chatMessage) || Objects.isNull(chatMessage.getMessageType())) {
             return null;
         }
-        
+
         return switch (chatMessage.getMessageType()) {
             case PHOTO -> PHOTO_MESSAGE;
             case TEXT -> chatMessage.getContent();
             case RANKING -> RANKING_MESSAGE;
             default -> null;
         };
+    }
+
+    public String mapToContent(ChatParticipant participant) {
+        if (ChatroomRole.HOST.equals(participant.getRole())) {
+            return CHATROOM_CREATED_MESSAGE;
+        }
+        return EMPTY_MESSAGE;
+    }
+
+    public LocalDateTime mapToTime(ChatParticipant participant) {
+        if (ChatroomRole.HOST.equals(participant.getRole())) {
+            return participant.getChatroom().getCreatedDate();
+        }
+        return participant.getJoinAt();
     }
 }

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
@@ -38,9 +38,9 @@ public class ChatroomMapper {
                 .chatroomTitle(chatroom.getTitle())
                 .currentMemberCount(chatParticipantService.countByChatroom(chatroom))
                 .lastMessage(lastMessage.map(contentMapper::mapToContent)
-                        .orElse(contentMapper.mapToContent(participant)))
+                        .orElseGet(() -> contentMapper.mapToContent(participant)))
                 .lastMessageTime(lastMessage.map(ChatMessage::getSentAt)
-                        .orElse(contentMapper.mapToTime(participant)))
+                        .orElseGet(() -> contentMapper.mapToTime(participant)))
                 .unreadMessageCount(unreadMessageCount)
                 .build();
     }

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
@@ -37,8 +37,10 @@ public class ChatroomMapper {
                 .isHost(ChatroomRole.HOST.equals(participant.getRole()))
                 .chatroomTitle(chatroom.getTitle())
                 .currentMemberCount(chatParticipantService.countByChatroom(chatroom))
-                .lastMessage(lastMessage.map(contentMapper::mapToContent).orElse(null))
-                .lastMessageTime(lastMessage.map(ChatMessage::getSentAt).orElse(null))
+                .lastMessage(lastMessage.map(contentMapper::mapToContent)
+                        .orElse(contentMapper.mapToContent(participant)))
+                .lastMessageTime(lastMessage.map(ChatMessage::getSentAt)
+                        .orElse(contentMapper.mapToTime(participant)))
                 .unreadMessageCount(unreadMessageCount)
                 .build();
     }


### PR DESCRIPTION
## #️⃣500
 
 ## 📝작업 내용
 - 마지막 메시지와 시간을 매핑하는 로직을 추가했습니다.
 - 요청한 사용자가 `HOST`인 경우와 아닌 경우로 나누었으며 클라이언트가 요구한 메시지를 제공하도록 수정했습니다.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 채팅방에 마지막 메시지가 없어도 목록과 미리보기에서 기본 메시지와 시간이 항상 표시됩니다.
  * 방장에게는 “채팅방 생성” 안내가 기본 메시지로 표시되며, 시간은 방 개설 시각을 사용합니다.
  * 일반 참여자는 빈 메시지로 표시되며, 시간은 참여 시각을 사용합니다.
* 버그 수정
  * 마지막 메시지나 시간이 비어 보이거나 null로 노출되던 문제를 해결해 표시 일관성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->