### PR TITLE
[#499] 전체 채팅방 목록 조회 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -60,6 +60,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -133,6 +134,7 @@ public class ChatFacade {
 
     private List<ChatroomResponse> getChatroomResponses(List<Chatroom> chatrooms) {
         return chatrooms.stream()
+                .filter(Objects::nonNull)
                 .map(chatroom ->
                         ChatBuilder.buildChatroomResponse(
                                 chatroom,

--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -13,12 +13,15 @@ import java.util.List;
 @Repository
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 
+    List<Chatroom> findAllByIdInAndIsClosedFalse(List<Long> chatroomId);
+
     @Query("""
                 SELECT c
                   FROM Chatroom c
                   JOIN ChatParticipant cp
                     ON cp.chatroom = c
-                 WHERE cp.user = :user
+                WHERE c.isClosed = false
+                   AND cp.user = :user
                    AND cp.role = :role
             """)
     List<Chatroom> findChatroomByUserAndRole(@Param("user") User user, @Param("role") ChatroomRole role);
@@ -29,6 +32,7 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
                   LEFT JOIN ChatMessage cm ON cm.chatroom = c
                   LEFT JOIN Like l ON l.chatroom = c AND l.likeStatus = true
                   LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipated = true
+                WHERE c.isClosed = false
                 GROUP BY c.id
                 ORDER BY MAX(cm.sentAt) DESC,
                          COUNT(DISTINCT l.id) DESC,
@@ -41,6 +45,7 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
     @Query("""
                 SELECT c
                   FROM Chatroom c
+                WHERE c.isClosed = false
                 ORDER BY c.createdDate DESC
             """)
     List<Chatroom> findChatroomsSortByCreatedAt();
@@ -50,6 +55,7 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
                   FROM Chatroom c
                   LEFT JOIN Like l ON l.chatroom = c AND l.likeStatus = true
                   LEFT JOIN ChatParticipant cp ON cp.chatroom = c AND cp.isParticipated = true
+                WHERE c.isClosed = false
                 GROUP BY c.id
                 ORDER BY COUNT(DISTINCT l.id) DESC,
                          COUNT(DISTINCT cp.id) DESC,
@@ -63,7 +69,8 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
                   FROM Chatroom c
                   LEFT JOIN Tag t ON t.chatroom = c
                  INNER JOIN ChatParticipant cp ON cp.chatroom = c AND cp.role = 'HOST'
-                WHERE :keyword <> ''
+                WHERE c.isClosed = false
+                  AND :keyword <> ''
                   AND (
                          c.title LIKE CONCAT('%', :keyword, '%')
                       OR c.description LIKE CONCAT('%', :keyword, '%')

--- a/src/main/java/com/poortorich/chat/service/ChatroomService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatroomService.java
@@ -54,7 +54,7 @@ public class ChatroomService {
     }
 
     private List<Chatroom> findByIds(List<Long> chatroomIds) {
-        List<Chatroom> chatrooms = chatroomRepository.findAllById(chatroomIds);
+        List<Chatroom> chatrooms = chatroomRepository.findAllByIdInAndIsClosedFalse(chatroomIds);
         chatrooms.sort(Comparator.comparingInt(c -> chatroomIds.indexOf(c.getId())));
         return chatrooms;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#499
 
 ## 📝작업 내용
 
- null 처리 추가
- 종료된 채팅방 조회 오류 수정
  - 채팅방을 조회하는 로직에 `WHERE c.isClosed = false` query 추가 
