### PR TITLE
[#504] 채팅방 나가기 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -177,9 +177,7 @@ public class ChatController {
     ) {
         ChatroomLeaveResponse response = chatFacade.leaveChatroom(userDetails.getUsername(), chatroomId);
 
-        BasePayload basePayload = realTimeFacade.createUserLeaveSystemMessage(
-                userDetails.getUsername(),
-                chatroomId);
+        BasePayload basePayload = realTimeFacade.createUserLeaveSystemMessage(userDetails.getUsername(), chatroomId);
 
         if (!Objects.isNull(basePayload)) {
             messagingTemplate.convertAndSend(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId, basePayload);

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -177,10 +177,16 @@ public class ChatController {
     ) {
         ChatroomLeaveResponse response = chatFacade.leaveChatroom(userDetails.getUsername(), chatroomId);
 
-        BasePayload basePayload = realTimeFacade.createUserLeaveSystemMessage(userDetails.getUsername(), chatroomId);
+        BasePayload leavePayload = realTimeFacade.createUserLeaveSystemMessage(userDetails.getUsername(), chatroomId);
+        BasePayload closedPayload = realTimeFacade.createChatroomClosedMessageOrDeleteAll(
+                userDetails.getUsername(),
+                chatroomId);
 
-        if (!Objects.isNull(basePayload)) {
-            messagingTemplate.convertAndSend(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId, basePayload);
+        if (!Objects.isNull(leavePayload)) {
+            messagingTemplate.convertAndSend(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId, leavePayload);
+        }
+        if (!Objects.isNull(closedPayload)) {
+            messagingTemplate.convertAndSend(SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId, closedPayload);
         }
         return DataResponse.toResponseEntity(ChatResponse.CHATROOM_LEAVE_SUCCESS, response);
     }

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -70,7 +70,11 @@ public class ChatRealTimeFacade {
 
     public BasePayload createUserLeaveSystemMessage(String username, Long chatroomId) {
         PayloadContext context = payloadCollector.getPayloadContext(username, chatroomId);
+        return chatMessageService.saveUserLeaveMessage(context.user(), context.chatroom()).mapToBasePayload();
+    }
 
+    public BasePayload createChatroomClosedMessageOrDeleteAll(String username, Long chatroomId) {
+        PayloadContext context = payloadCollector.getPayloadContext(username, chatroomId);
         return chatroomLeaveManager.leaveChatroom(context);
     }
 

--- a/src/main/java/com/poortorich/chat/service/UnreadChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/UnreadChatMessageService.java
@@ -83,6 +83,7 @@ public class UnreadChatMessageService {
         return unreadChatMessageRepository.countByUserAndChatroom(user, chatroom);
     }
 
+    @Transactional
     public void deleteAllByChatroom(Chatroom chatroom) {
         unreadChatMessageRepository.deleteAllByChatroom(chatroom);
     }

--- a/src/main/java/com/poortorich/chat/util/manager/ChatroomLeaveManager.java
+++ b/src/main/java/com/poortorich/chat/util/manager/ChatroomLeaveManager.java
@@ -9,6 +9,8 @@ import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.service.UnreadChatMessageService;
+import com.poortorich.photo.service.PhotoService;
+import com.poortorich.ranking.service.RankingService;
 import com.poortorich.tag.service.TagService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -22,6 +24,8 @@ public class ChatroomLeaveManager {
     private final ChatParticipantService chatParticipantService;
     private final ChatMessageService chatMessageService;
     private final TagService tagService;
+    private final PhotoService photoService;
+    private final RankingService rankingService;
     private final UnreadChatMessageService unreadChatMessageService;
 
     public BasePayload leaveChatroom(PayloadContext payloadContext) {
@@ -40,6 +44,8 @@ public class ChatroomLeaveManager {
 
         if (chatParticipantService.isAllParticipantLeft(chatroom)) {
             unreadChatMessageService.deleteAllByChatroom(chatroom);
+            photoService.deleteAllByChatroom(chatroom);
+            rankingService.deleteAllByChatroom(chatroom);
             chatMessageService.deleteAllByChatroom(chatroom);
             tagService.deleteAllByChatroom(chatroom);
             chatParticipantService.deleteAllByChatroom(chatroom);

--- a/src/main/java/com/poortorich/chat/util/manager/ChatroomLeaveManager.java
+++ b/src/main/java/com/poortorich/chat/util/manager/ChatroomLeaveManager.java
@@ -9,6 +9,7 @@ import com.poortorich.chat.service.ChatMessageService;
 import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.service.UnreadChatMessageService;
+import com.poortorich.chatnotice.service.ChatNoticeService;
 import com.poortorich.photo.service.PhotoService;
 import com.poortorich.ranking.service.RankingService;
 import com.poortorich.tag.service.TagService;
@@ -26,15 +27,14 @@ public class ChatroomLeaveManager {
     private final TagService tagService;
     private final PhotoService photoService;
     private final RankingService rankingService;
+    private final ChatNoticeService chatNoticeService;
     private final UnreadChatMessageService unreadChatMessageService;
 
     public BasePayload leaveChatroom(PayloadContext payloadContext) {
         if (payloadContext.chatroom().getIsClosed()) {
             return getClosedMessageOrDeleteAll(payloadContext);
         }
-
-        return chatMessageService.saveUserLeaveMessage(payloadContext.user(), payloadContext.chatroom())
-                .mapToBasePayload();
+        return null;
     }
 
     @Transactional
@@ -43,11 +43,12 @@ public class ChatroomLeaveManager {
         ChatParticipant participant = payloadContext.chatParticipant();
 
         if (chatParticipantService.isAllParticipantLeft(chatroom)) {
+            tagService.deleteAllByChatroom(chatroom);
             unreadChatMessageService.deleteAllByChatroom(chatroom);
+            chatMessageService.deleteAllByChatroom(chatroom);
             photoService.deleteAllByChatroom(chatroom);
             rankingService.deleteAllByChatroom(chatroom);
-            chatMessageService.deleteAllByChatroom(chatroom);
-            tagService.deleteAllByChatroom(chatroom);
+            chatNoticeService.deleteAllByChatroom(chatroom);
             chatParticipantService.deleteAllByChatroom(chatroom);
             chatroomService.deleteById(chatroom.getId());
             return null;

--- a/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
+++ b/src/main/java/com/poortorich/chatnotice/repository/ChatNoticeRepository.java
@@ -22,4 +22,6 @@ public interface ChatNoticeRepository extends JpaRepository<ChatNotice, Long> {
     Optional<ChatNotice> findByChatroomAndId(Chatroom chatroom, Long noticeId);
 
     boolean existsByIdAndChatroom(Long noticeId, Chatroom chatroom);
+
+    void deleteAllByChatroom(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
+++ b/src/main/java/com/poortorich/chatnotice/service/ChatNoticeService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -71,5 +72,10 @@ public class ChatNoticeService {
     public ChatNotice findById(Long noticeId) {
         return chatNoticeRepository.findById(noticeId)
                 .orElseThrow(() -> new NotFoundException(ChatNoticeResponse.NOTICE_NOT_FOUND));
+    }
+
+    @Transactional
+    public void deleteAllByChatroom(Chatroom chatroom) {
+        chatNoticeRepository.deleteAllByChatroom(chatroom);
     }
 }

--- a/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/poortorich/photo/repository/PhotoRepository.java
@@ -40,15 +40,15 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     Optional<Photo> findByChatroomAndId(Chatroom chatroom, Long photoId);
 
     @Query("""
-        SELECT p.id
-          FROM Photo p
-        WHERE p.chatroom = :chatroom
-          AND (
-               p.createdDate < :createdDate
-               OR (p.createdDate = :createdDate AND p.id < :id)
-          )
-        ORDER BY p.createdDate DESC , p.id DESC
-    """)
+                SELECT p.id
+                  FROM Photo p
+                WHERE p.chatroom = :chatroom
+                  AND (
+                       p.createdDate < :createdDate
+                       OR (p.createdDate = :createdDate AND p.id < :id)
+                  )
+                ORDER BY p.createdDate DESC , p.id DESC
+            """)
     List<Long> findPrevPhotoId(
             @Param("chatroom") Chatroom chatroom,
             @Param("createdDate") LocalDateTime createdDate,
@@ -56,18 +56,20 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     );
 
     @Query("""
-        SELECT p.id
-          FROM Photo p
-        WHERE p.chatroom = :chatroom
-          AND (
-               p.createdDate > :createdDate
-               OR (p.createdDate = :createdDate AND p.id > :id)
-          )
-        ORDER BY p.createdDate ASC , p.id ASC
-    """)
+                SELECT p.id
+                  FROM Photo p
+                WHERE p.chatroom = :chatroom
+                  AND (
+                       p.createdDate > :createdDate
+                       OR (p.createdDate = :createdDate AND p.id > :id)
+                  )
+                ORDER BY p.createdDate ASC , p.id ASC
+            """)
     List<Long> findNextPhotoId(
             @Param("chatroom") Chatroom chatroom,
             @Param("createdDate") LocalDateTime createdDate,
             @Param("id") Long id
     );
+
+    void deleteAllByChatroom(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/photo/service/PhotoService.java
+++ b/src/main/java/com/poortorich/photo/service/PhotoService.java
@@ -7,10 +7,10 @@ import com.poortorich.photo.repository.PhotoRepository;
 import com.poortorich.photo.response.enums.PhotoResponse;
 import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -53,5 +53,10 @@ public class PhotoService {
         return photoRepository.findNextPhotoId(chatroom, currentPhoto.getCreatedDate(), currentPhoto.getId()).stream()
                 .findFirst()
                 .orElse(null);
+    }
+
+    @Transactional
+    public void deleteAllByChatroom(Chatroom chatroom) {
+        photoRepository.deleteAllByChatroom(chatroom);
     }
 }

--- a/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
@@ -20,11 +20,13 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
     );
 
     @Query("""
-        SELECT r
-          FROM Ranking r
-         WHERE r.chatroom = :chatroom
-           AND r.createdDate IN :mondays
-         ORDER BY r.createdDate DESC
-    """)
+                SELECT r
+                  FROM Ranking r
+                 WHERE r.chatroom = :chatroom
+                   AND r.createdDate IN :mondays
+                 ORDER BY r.createdDate DESC
+            """)
     List<Ranking> findAllByChatroomWithDateIn(Chatroom chatroom, List<LocalDateTime> mondays);
+
+    void deleteAllByChatroom(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/ranking/service/RankingService.java
+++ b/src/main/java/com/poortorich/ranking/service/RankingService.java
@@ -108,4 +108,9 @@ public class RankingService {
     public List<Ranking> findAllRankings(Chatroom chatroom, List<LocalDateTime> mondays) {
         return rankingRepository.findAllByChatroomWithDateIn(chatroom, mondays);
     }
+
+    @Transactional
+    public void deleteAllByChatroom(Chatroom chatroom) {
+        rankingRepository.deleteAllByChatroom(chatroom);
+    }
 }


### PR DESCRIPTION
## #️⃣504
 
 ## 📝작업 내용
 - LEAVE 메시지와 CLOSE 메시지 기능을 분리하여 구현하였음
   -  채팅방이 종료되어도 나가기 메시지가 정상적으로 브로드캐스트됨
 - 채팅방을 삭제할 때 랭킹, 공지, 사진도 삭제하도록 로직을 추가
 - deleteAll 로직에 `@Transactional` 애너테이션 추가
