### PR TITLE
[#507] 모두 읽음 처리 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -6,7 +6,6 @@ import com.poortorich.chat.model.MarkAllChatroomAsReadResult;
 import com.poortorich.chat.model.UserEnterChatroomResult;
 import com.poortorich.chat.realtime.facade.ChatRealTimeFacade;
 import com.poortorich.chat.realtime.payload.response.BasePayload;
-import com.poortorich.chat.realtime.payload.response.MessageReadPayload;
 import com.poortorich.chat.request.ChatroomCreateRequest;
 import com.poortorich.chat.request.ChatroomEnterRequest;
 import com.poortorich.chat.request.ChatroomLeaveAllRequest;
@@ -231,11 +230,12 @@ public class ChatController {
         MarkAllChatroomAsReadResult result = realTimeFacade.markAllChatroomAsRead(userDetails.getUsername());
 
         result.getBroadcastPayloads()
-                .forEach(basePayload -> {
-                    MessageReadPayload payload = (MessageReadPayload) basePayload.getPayload();
-                    messagingTemplate.convertAndSend(
-                            SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + payload.getChatroomId(),
-                            basePayload);
+                .forEach(payload -> {
+                    if (!Objects.isNull(payload)) {
+                        messagingTemplate.convertAndSend(
+                                SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + payload.getChatroomId(),
+                                payload.mapToBasePayload());
+                    }
                 });
 
         return DataResponse.toResponseEntity(ChatResponse.MARK_ALL_CHATROOM_AS_READ_SUCCESS, result.getApiResponse());

--- a/src/main/java/com/poortorich/chat/model/MarkAllChatroomAsReadResult.java
+++ b/src/main/java/com/poortorich/chat/model/MarkAllChatroomAsReadResult.java
@@ -1,15 +1,16 @@
 package com.poortorich.chat.model;
 
-import com.poortorich.chat.realtime.payload.response.BasePayload;
+import com.poortorich.chat.realtime.payload.response.MessageReadPayload;
 import com.poortorich.chat.response.MarkAllChatroomAsReadResponse;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
 public class MarkAllChatroomAsReadResult {
 
     private final MarkAllChatroomAsReadResponse apiResponse;
-    private final List<BasePayload> broadcastPayloads;
+    private final List<MessageReadPayload> broadcastPayloads;
 }

--- a/src/main/java/com/poortorich/chat/model/UnreadChatInfo.java
+++ b/src/main/java/com/poortorich/chat/model/UnreadChatInfo.java
@@ -1,0 +1,13 @@
+package com.poortorich.chat.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UnreadChatInfo {
+
+    private final Long chatroomId;
+    private final Long userId;
+    private final Long lastReadMessageId;
+}

--- a/src/main/java/com/poortorich/chat/model/UnreadChatInfo.java
+++ b/src/main/java/com/poortorich/chat/model/UnreadChatInfo.java
@@ -1,10 +1,12 @@
 package com.poortorich.chat.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
+@AllArgsConstructor
 public class UnreadChatInfo {
 
     private final Long chatroomId;

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -124,12 +124,13 @@ public class ChatRealTimeFacade {
     public MarkAllChatroomAsReadResult markAllChatroomAsRead(String username) {
         List<PayloadContext> contexts = payloadCollector.getAllPayloadContext(username);
 
-        List<Long> chatroomIds = contexts.stream().map(PayloadContext::chatroom).map(Chatroom::getId).toList();
-
-        List<BasePayload> broadcastPayloads = unreadChatMessageService.markAllMessageAsRead(contexts);
+        List<MessageReadPayload> broadcastPayloads = unreadChatMessageService.markAllMessageAsRead(contexts);
 
         eventPublisher.publishEvent(new UserChatroomUpdateEvent(contexts.getFirst().user()));
-
+        List<Long> chatroomIds = broadcastPayloads.stream()
+                .map(MessageReadPayload::getChatroomId)
+                .toList();
+        
         return MarkAllChatroomAsReadResult.builder()
                 .apiResponse(MarkAllChatroomAsReadResponse.builder().chatroomIds(chatroomIds).build())
                 .broadcastPayloads(broadcastPayloads)

--- a/src/main/java/com/poortorich/chat/repository/UnreadChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/UnreadChatMessageRepository.java
@@ -3,6 +3,7 @@ package com.poortorich.chat.repository;
 import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.UnreadChatMessage;
+import com.poortorich.chat.model.UnreadChatInfo;
 import com.poortorich.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -25,13 +26,17 @@ public interface UnreadChatMessageRepository extends JpaRepository<UnreadChatMes
     Long findLastUnreadMessageId(@Param("chatroom") Chatroom chatroom, @Param("user") User user);
 
     @Query("""
-            SELECT MAX(u.chatMessage.id)
+            SELECT new com.poortorich.chat.model.UnreadChatInfo(
+                u.chatroom.id,
+                u.user.id,
+                MAX(u.chatMessage.id)
+            )
             FROM UnreadChatMessage u
             WHERE u.chatroom IN :chatrooms
             AND u.user IN :users
             GROUP BY u.chatroom, u.user
             """)
-    List<Long> findLastUnreadMessageIds(@Param("chatrooms") List<Chatroom> chatrooms, @Param("users") List<User> user);
+    List<UnreadChatInfo> findLastUnreadMessageIds(@Param("chatrooms") List<Chatroom> chatrooms, @Param("users") List<User> user);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/poortorich/chat/service/UnreadChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/UnreadChatMessageService.java
@@ -4,8 +4,8 @@ import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.UnreadChatMessage;
+import com.poortorich.chat.model.UnreadChatInfo;
 import com.poortorich.chat.realtime.model.PayloadContext;
-import com.poortorich.chat.realtime.payload.response.BasePayload;
 import com.poortorich.chat.realtime.payload.response.MessageReadPayload;
 import com.poortorich.chat.repository.UnreadChatMessageRepository;
 import com.poortorich.user.entity.User;
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -61,21 +60,20 @@ public class UnreadChatMessageService {
     }
 
     @Transactional
-    public List<BasePayload> markAllMessageAsRead(List<PayloadContext> contexts) {
+    public List<MessageReadPayload> markAllMessageAsRead(List<PayloadContext> contexts) {
         List<Chatroom> chatrooms = contexts.stream().map(PayloadContext::chatroom).toList();
         List<User> users = contexts.stream().map(PayloadContext::user).toList();
 
-        List<Long> lastReadMessageIds = unreadChatMessageRepository.findLastUnreadMessageIds(chatrooms, users);
+        List<UnreadChatInfo> unreadChatInfos = unreadChatMessageRepository.findLastUnreadMessageIds(chatrooms, users);
         unreadChatMessageRepository.markAllMessageAsRead(chatrooms, users);
 
-        return IntStream.range(0, contexts.size())
-                .mapToObj(index -> MessageReadPayload.builder()
-                        .chatroomId(chatrooms.get(index).getId())
-                        .lastReadMessageId(lastReadMessageIds.get(index))
-                        .userId(users.get(index).getId())
+        return unreadChatInfos.stream()
+                .map(unreadChatInfo -> MessageReadPayload.builder()
+                        .chatroomId(unreadChatInfo.getChatroomId())
+                        .lastReadMessageId(unreadChatInfo.getLastReadMessageId())
+                        .userId(unreadChatInfo.getUserId())
                         .readAt(LocalDateTime.now())
-                        .build()
-                        .mapToBasePayload())
+                        .build())
                 .toList();
     }
 


### PR DESCRIPTION
## #️⃣507
 
 ## 📝작업 내용
 모두 읽음 처리 로직 도중 IndexOutOfBounds 예외 발생
* 원인: 안 읽은 메시지가 없는 채팅방이 있을 때 요청한 경우 

해당 예외를 회피하고 안 읽은 메시지가 있는 채팅방 동기화를 위해 UnreadChatInfo DTO를 추가하여 사용하도록 리팩터링 진행
 ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 전체 읽음 처리 시 방송된 읽음 정보가 누락되거나 잘못 전송되던 문제를 개선하여 읽음 표시와 알림이 모든 대상에 일관되게 전달됩니다.

- 리팩터
  - 실시간 읽음 이벤트의 방송 형식을 일관된 페이로드로 통합하고 전송 흐름을 단순화했습니다.
  - 미읽음 메시지 조회를 전용 데이터 DTO로 반환하도록 바꿔 데이터 매핑을 명확히 하고 안정성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->