### PR TITLE
[#509] 강제 퇴장 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -57,6 +57,7 @@ public class ChatResponseMessage {
     public static final String CHATROOM_IS_CLOSED = "채팅방이 종료되었습니다.";
     public static final String GET_MY_CHATROOMS_SUCCESS = "참여중인 채팅방 목록 조회가 완료되었습니다.";
     public static final String MESSAGE_TYPE_INVALID = "유효하지 않은 메시지 타입입니다.";
+    public static final String CHAT_PARTICIPANT_BANNED = "채팅방에서 강제퇴장 되었습니다.";
 
     private ChatResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -287,15 +287,6 @@ public class ChatController {
                 chatroomId,
                 userId);
 
-        BasePayload basePayload = realTimeFacade.createUserKickMessage(apiResponse.getKickChatParticipant());
-
-        if (!Objects.isNull(basePayload)) {
-            messagingTemplate.convertAndSend(
-                    SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId,
-                    basePayload
-            );
-        }
-
         return DataResponse.toResponseEntity(ChatResponse.CHAT_PARTICIPANT_KICK_SUCCESS, apiResponse);
     }
 }

--- a/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
@@ -103,7 +103,9 @@ public class ChatParticipant {
 
     public void kick() {
         this.role = ChatroomRole.BANNED;
-        this.bannedAt = LocalDateTime.now();
+        if (Objects.isNull(this.bannedAt)) {
+            this.bannedAt = LocalDateTime.now();
+        }
     }
 
     public void updateRankingStatus(RankingStatus rankingStatus) {

--- a/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
@@ -67,6 +67,9 @@ public class ChatParticipant {
     @Column(name = "joinAt")
     private LocalDateTime joinAt;
 
+    @Column(name = "banned_at")
+    private LocalDateTime bannedAt;
+
     @UpdateTimestamp
     @Column(name = "updated_date")
     private LocalDateTime updatedDate;

--- a/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
@@ -103,6 +103,7 @@ public class ChatParticipant {
 
     public void kick() {
         this.role = ChatroomRole.BANNED;
+        this.bannedAt = LocalDateTime.now();
     }
 
     public void updateRankingStatus(RankingStatus rankingStatus) {

--- a/src/main/java/com/poortorich/chat/entity/enums/MessageType.java
+++ b/src/main/java/com/poortorich/chat/entity/enums/MessageType.java
@@ -12,6 +12,7 @@ public enum MessageType {
     RANKING,
     ENTER,
     LEAVE,
+    KICK,
     RANKING_STATUS,
     CLOSE,
     DELEGATE,

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -293,9 +293,8 @@ public class ChatFacade {
 
     @Transactional
     public ChatMessagePageResponse getChatMessages(String username, Long chatroomId, Long cursor, Long pageSize) {
-        User user = userService.findUserByUsername(username);
         ChatPaginationContext context = paginationProvider.getChatMessagesContext(username, chatroomId, cursor, pageSize);
-        chatParticipantValidator.validateIsParticipate(user, context.chatroom());
+        chatParticipantValidator.validateIsParticipate(context.chatParticipant().getUser(), context.chatroom());
 
         Slice<ChatMessage> chatMessages = chatMessageService.getChatMessages(context);
 

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -8,6 +8,7 @@ import com.poortorich.chat.model.ChatMessageResponse;
 import com.poortorich.chat.model.ChatPaginationContext;
 import com.poortorich.chat.model.ChatroomPaginationContext;
 import com.poortorich.chat.model.UserEnterChatroomResult;
+import com.poortorich.chat.realtime.event.chatparticipants.KickChatroomEvent;
 import com.poortorich.chat.realtime.event.chatroom.ChatroomUpdateEvent;
 import com.poortorich.chat.realtime.event.chatroom.ParticipantUpdateEvent;
 import com.poortorich.chat.realtime.event.chatroom.detector.ChatroomUpdateDetector;
@@ -393,6 +394,7 @@ public class ChatFacade {
         chatParticipantValidator.validateIsMember(kickChatParticipant);
         chatParticipantValidator.validateIsParticipate(kickChatParticipant);
 
+        eventPublisher.publishEvent(new KickChatroomEvent(kickChatParticipant.getId()));
         chatParticipantService.kickChatParticipant(kickChatParticipant);
 
         eventPublisher.publishEvent(new ChatroomUpdateEvent(host.getChatroom()));

--- a/src/main/java/com/poortorich/chat/realtime/builder/SystemMessageBuilder.java
+++ b/src/main/java/com/poortorich/chat/realtime/builder/SystemMessageBuilder.java
@@ -68,7 +68,7 @@ public class SystemMessageBuilder {
     public static ChatMessage buildKickChatParticipantMessage(ChatParticipant kickChatParticipant) {
         return ChatMessage.builder()
                 .userId(kickChatParticipant.getUser().getId())
-                .messageType(MessageType.LEAVE)
+                .messageType(MessageType.KICK)
                 .type(ChatMessageType.SYSTEM_MESSAGE)
                 .content(kickChatParticipant.getUser().getNickname() + KICK_CONTENT_SUFFIX)
                 .chatroom(kickChatParticipant.getChatroom())

--- a/src/main/java/com/poortorich/chat/realtime/event/chatparticipants/KickChatroomEvent.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatparticipants/KickChatroomEvent.java
@@ -1,0 +1,11 @@
+package com.poortorich.chat.realtime.event.chatparticipants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class KickChatroomEvent {
+
+    private final Long chatParticipantId;
+}

--- a/src/main/java/com/poortorich/chat/realtime/event/chatparticipants/KickChatroomEventListener.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatparticipants/KickChatroomEventListener.java
@@ -1,0 +1,34 @@
+package com.poortorich.chat.realtime.event.chatparticipants;
+
+import com.poortorich.chat.entity.ChatParticipant;
+import com.poortorich.chat.realtime.payload.response.KickChatParticipantMessagePayload;
+import com.poortorich.chat.service.ChatMessageService;
+import com.poortorich.chat.service.ChatParticipantService;
+import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class KickChatroomEventListener {
+
+    private final ChatParticipantService chatParticipantService;
+    private final ChatMessageService chatMessageService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @EventListener
+    public void onKickChatroomEvent(KickChatroomEvent event) {
+        ChatParticipant participant = chatParticipantService.findByIdOrThrow(event.getChatParticipantId());
+        KickChatParticipantMessagePayload payload = chatMessageService.saveKickChatParticipantMessage(participant);
+
+        if (Objects.nonNull(payload)) {
+            messagingTemplate.convertAndSend(
+                    SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + participant.getChatroom().getId(),
+                    payload.mapToBasePayload());
+        }
+    }
+}

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -96,7 +96,7 @@ public class ChatRealTimeFacade {
         ChatParticipant chatParticipant = chatParticipantService.findByUserAndChatroom(user, chatroom);
 
         chatroomValidator.validateIsOpened(chatroom);
-        participantValidator.validateIsParticipate(chatParticipant);
+        participantValidator.validateIsBanned(chatParticipant);
 
         List<ChatParticipant> chatMembers = chatParticipantService.findUnreadMembers(chatroom, user);
 

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -96,6 +96,7 @@ public class ChatRealTimeFacade {
         ChatParticipant chatParticipant = chatParticipantService.findByUserAndChatroom(user, chatroom);
 
         chatroomValidator.validateIsOpened(chatroom);
+        participantValidator.validateIsParticipate(chatParticipant);
         participantValidator.validateIsBanned(chatParticipant);
 
         List<ChatParticipant> chatMembers = chatParticipantService.findUnreadMembers(chatroom, user);

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -3,6 +3,7 @@ package com.poortorich.chat.realtime.facade;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatMessageType;
+import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.model.MarkAllChatroomAsReadResult;
 import com.poortorich.chat.realtime.collect.ChatPayloadCollector;
 import com.poortorich.chat.realtime.event.chatroom.ChatroomUpdateEvent;
@@ -72,6 +73,9 @@ public class ChatRealTimeFacade {
 
     public BasePayload createUserLeaveSystemMessage(String username, Long chatroomId) {
         PayloadContext context = payloadCollector.getPayloadContext(username, chatroomId);
+        if (ChatroomRole.BANNED.equals(context.chatParticipant().getRole())) {
+            return null;
+        }
         return chatMessageService.saveUserLeaveMessage(context.user(), context.chatroom()).mapToBasePayload();
     }
 
@@ -93,7 +97,7 @@ public class ChatRealTimeFacade {
 
         chatroomValidator.validateIsOpened(chatroom);
         participantValidator.validateIsParticipate(chatParticipant);
-        
+
         List<ChatParticipant> chatMembers = chatParticipantService.findUnreadMembers(chatroom, user);
 
         UserChatMessagePayload chatMessage = chatMessageService
@@ -139,7 +143,7 @@ public class ChatRealTimeFacade {
         List<Long> chatroomIds = broadcastPayloads.stream()
                 .map(MessageReadPayload::getChatroomId)
                 .toList();
-        
+
         return MarkAllChatroomAsReadResult.builder()
                 .apiResponse(MarkAllChatroomAsReadResponse.builder().chatroomIds(chatroomIds).build())
                 .broadcastPayloads(broadcastPayloads)

--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -4,6 +4,7 @@ import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatMessageType;
 import com.poortorich.chat.entity.enums.MessageType;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -30,6 +31,13 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             Long cursor,
             LocalDateTime joinedAt,
             Pageable pageable);
+
+    Slice<ChatMessage> findByChatroomAndIdLessThanEqualAndSentAtBetweenOrderByIdDesc(
+            Chatroom chatroom,
+            Long cursor,
+            LocalDateTime joinAt,
+            LocalDateTime bannedAt,
+            PageRequest pageRequest);
 
     boolean existsByContentAndMessageTypeAndChatroom(String content, MessageType messageType, Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -47,7 +47,8 @@ public enum ChatResponse implements Response {
     CHAT_PARTICIPANT_KICK_SUCCESS(HttpStatus.OK, ChatResponseMessage.CHAT_PARTICIPANT_KICK_SUCCESS, null),
     CHATROOM_IS_CLOSED(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_IS_CLOSED, null),
     GET_MY_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_MY_CHATROOMS_SUCCESS, null),
-    MESSAGE_TYPE_INVALID(HttpStatus.BAD_REQUEST, ChatResponseMessage.MESSAGE_TYPE_INVALID, null);
+    MESSAGE_TYPE_INVALID(HttpStatus.BAD_REQUEST, ChatResponseMessage.MESSAGE_TYPE_INVALID, null),
+    CHAT_PARTICIPANT_BANNED(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHAT_PARTICIPANT_BANNED, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -4,6 +4,7 @@ import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatMessageType;
+import com.poortorich.chat.entity.enums.ChatroomRole;
 import com.poortorich.chat.model.ChatPaginationContext;
 import com.poortorich.chat.realtime.builder.RankingMessageBuilder;
 import com.poortorich.chat.realtime.builder.RankingStatusChatMessageBuilder;
@@ -176,6 +177,15 @@ public class ChatMessageService {
             return new SliceImpl<>(Collections.emptyList(), context.pageRequest(), false);
         }
 
+        if (ChatroomRole.BANNED.equals(context.chatParticipant().getRole())) {
+            return chatMessageRepository.findByChatroomAndIdLessThanEqualAndSentAtBetweenOrderByIdDesc(
+                    context.chatroom(),
+                    context.cursor(),
+                    context.chatParticipant().getJoinAt(),
+                    context.chatParticipant().getBannedAt(),
+                    context.pageRequest()
+            );
+        }
         return chatMessageRepository.findByChatroomAndIdLessThanEqualAndSentAtAfterOrderByIdDesc(
                 context.chatroom(),
                 context.cursor(),

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -178,7 +178,6 @@ public class ChatParticipantService {
     @Transactional
     public void kickChatParticipant(ChatParticipant kickChatParticipant) {
         kickChatParticipant.kick();
-        kickChatParticipant.leave();
     }
 
     public Slice<ChatParticipant> getMyParticipants(ChatroomPaginationContext context) {

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -209,4 +209,9 @@ public class ChatParticipantService {
         return chatParticipantRepository.findByChatroomAndRankingStatus(chatroom, rankingStatus)
                 .orElse(null);
     }
+
+    public ChatParticipant findByIdOrThrow(Long chatParticipantId) {
+        return chatParticipantRepository.findById(chatParticipantId)
+                .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatMessageMapper.java
@@ -31,7 +31,7 @@ public class ChatMessageMapper {
             case RANKING -> rankingMessage(chatMessage);
             case RANKING_STATUS -> rankingStatusMessage(chatMessage);
             case ENTER -> userEnterMessage(chatMessage);
-            case LEAVE -> userLeaveMessage(chatMessage);
+            case LEAVE, KICK -> userLeaveMessage(chatMessage);
             case CLOSE -> chatroomClosedMessage(chatMessage);
             case TEXT, PHOTO -> userChatMessage(chatMessage);
             case DATE -> dateChangeMessage(chatMessage);

--- a/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
+++ b/src/main/java/com/poortorich/chat/validator/ChatParticipantValidator.java
@@ -49,8 +49,10 @@ public class ChatParticipantValidator {
         }
     }
 
-    // TODO: 채탕방에서 사용자가 차단되었다면 예외를 발생
-    public void validateIsBanned(User user, Chatroom chatroom) {
+    public void validateIsBanned(ChatParticipant participant) {
+        if (ChatroomRole.BANNED.equals(participant.getRole())) {
+            throw new BadRequestException(ChatResponse.CHAT_PARTICIPANT_BANNED);
+        }
     }
 
     // TODO: 채팅방에서 사용자가 퇴장한 상태이거나 없다면 예외를 발생


### PR DESCRIPTION
## #️⃣509
 
 ## 📝작업 내용
 - 강제 퇴장 시 is_participated를 true로 두어 이전 채팅 조회가 되도록 한다.
 - 강제 퇴장 당한 시점 이후에 채팅은 볼 수 없다.
 - 강제 퇴장 당한 참석자가 나가기 로직 수행시 SYSTEM_MESSAGE를 발행하지 않는다.
 
 ### 스크린샷 (선택)
 
 - `messageType`에 **`KICK`** 추가
 - `chat_participant`에 **`banned_at`** 필드 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 시스템 메시지에 ‘KICK’ 유형 추가로 추방 이벤트를 명확히 표시합니다.
  - 추방 시각을 기록해, 추방된 사용자는 입장 시각부터 추방 시각까지만 채팅 메시지를 볼 수 있도록 제한합니다.
  - 킥 알림이 이벤트 기반으로 전송되어 실시간 알림 흐름이 안정화됩니다.

- 버그 수정
  - 추방된 사용자의 퇴장 시스템 메시지 중복 노출을 방지합니다.
  - 킥 이벤트가 퇴장 메시지와 일관되게 렌더링되도록 매핑을 정비했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->