### PR TITLE
[#521] PENDING 역할 로그아웃 처리

### DIFF
--- a/src/main/java/com/poortorich/security/config/SecurityConfig.java
+++ b/src/main/java/com/poortorich/security/config/SecurityConfig.java
@@ -79,6 +79,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/user/reset", "/user/leave").hasRole("USER")
                         .requestMatchers("/user/oauth/**").hasRole("PENDING")
                         .requestMatchers(HttpMethod.GET, "/user/role").hasAnyRole("ADMIN", "USER", "TEST", "PENDING")
+                        .requestMatchers(HttpMethod.POST, "/auth/logout").hasAnyRole("ADMIN", "USER", "TEST", "PENDING")
                         .anyRequest().hasAnyRole("USER", "TEST", "ADMIN")
                 )
                 .exceptionHandling(exception -> exception.accessDeniedHandler(accessDeniedHandler))


### PR DESCRIPTION
## #️⃣521
 
 ## 📝작업 내용
- 클라이언트 요청에 따라 `PENDING` 역할도 로그아웃할 수 있게 수정
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 로그아웃 API 접근 권한을 확대하여 PENDING 상태 계정도 POST /auth/logout 요청으로 정상적으로 로그아웃할 수 있습니다.
  * 일부 계정에서 로그아웃이 불가능하거나 인증 오류가 발생하던 문제를 해소해, 세션 정리와 이탈 시 보안성을 개선했습니다.
  * 기존 ADMIN/USER/TEST 권한의 동작에는 변화가 없으며, 다른 엔드포인트의 권한 정책에도 영향이 없습니다.
  * 기대 효과: 더 일관된 로그아웃 경험과 오류 감소.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->