### PR TITLE
[#524] 랭킹 조회 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -141,13 +141,5 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             """)
     Slice<ChatParticipant> findMyParticipants(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
 
-    @Query("""
-                SELECT cp
-                 FROM ChatParticipant cp
-                 JOIN FETCH cp.user u
-                WHERE cp.id In :ids
-            """)
-    List<ChatParticipant> findAllByIdIn(@Param("ids") List<Long> ids);
-
     Optional<ChatParticipant> findByChatroomAndRankingStatus(Chatroom chatroom, RankingStatus rankingStatus);
 }

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -188,18 +188,6 @@ public class ChatParticipantService {
                         context.pageRequest());
     }
 
-    public List<ChatParticipant> findAllByIdIn(List<Long> chatParticipantIds) {
-        List<ChatParticipant> participants = chatParticipantRepository.findAllByIdIn(chatParticipantIds);
-
-        Map<Long, ChatParticipant> participantMap = participants.stream()
-                .collect(Collectors.toMap(ChatParticipant::getId, Function.identity()));
-
-        return chatParticipantIds.stream()
-                .map(participantMap::get)
-                .filter(Objects::nonNull)
-                .toList();
-    }
-
     @Transactional
     public void updateAllRankingStatus(List<ChatParticipant> participants, RankingStatus rankingStatus) {
         participants.forEach(participant -> participant.updateRankingStatus(rankingStatus));

--- a/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
+++ b/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
@@ -244,7 +244,7 @@ public class RankingFacade {
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
                 .rankings(rankings.entrySet().stream()
-                        .limit(rankings.size() - 1)
+                        .limit(Math.max(1, rankings.size() - 1L))
                         .map(entry -> buildRankingInfoResponse(entry.getKey(), entry.getValue(), chatroom))
                         .toList())
                 .build();

--- a/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/poortorich/ranking/repository/RankingRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -23,10 +24,10 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
                 SELECT r
                   FROM Ranking r
                  WHERE r.chatroom = :chatroom
-                   AND r.createdDate IN :mondays
+                   AND function('date', r.createdDate) IN :mondays
                  ORDER BY r.createdDate DESC
             """)
-    List<Ranking> findAllByChatroomWithDateIn(Chatroom chatroom, List<LocalDateTime> mondays);
+    List<Ranking> findAllByChatroomWithDateIn(Chatroom chatroom, List<LocalDate> mondays);
 
     void deleteByChatroom(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/ranking/service/RankingService.java
+++ b/src/main/java/com/poortorich/ranking/service/RankingService.java
@@ -105,7 +105,7 @@ public class RankingService {
                 .orElse(null);
     }
 
-    public List<Ranking> findAllRankings(Chatroom chatroom, List<LocalDateTime> mondays) {
+    public List<Ranking> findAllRankings(Chatroom chatroom, List<LocalDate> mondays) {
         return rankingRepository.findAllByChatroomWithDateIn(chatroom, mondays);
     }
 

--- a/src/main/java/com/poortorich/ranking/util/RankingBuilder.java
+++ b/src/main/java/com/poortorich/ranking/util/RankingBuilder.java
@@ -14,7 +14,7 @@ public class RankingBuilder {
 
     public static LatestRankingResponse buildNotFoundLatestRankingResponse(LocalDateTime rankedAt) {
         return LatestRankingResponse.builder()
-                .rankedAt(rankedAt.toString())
+                .rankedAt(rankedAt.toLocalDate().toString())
                 .rankingId(null)
                 .saver(null)
                 .flexer(null)

--- a/src/main/java/com/poortorich/user/repository/UserRepository.java
+++ b/src/main/java/com/poortorich/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.poortorich.user.repository;
 
 import com.poortorich.user.entity.User;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByEmail(String email);
+
+    List<User> findAllByIdIn(List<Long> userIds);
 }

--- a/src/main/java/com/poortorich/user/service/UserService.java
+++ b/src/main/java/com/poortorich/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.poortorich.user.service;
 
+import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.global.exceptions.NotFoundException;
 import com.poortorich.s3.constants.S3Constants;
 import com.poortorich.user.entity.User;
@@ -16,6 +17,12 @@ import com.poortorich.user.response.enums.UserResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -125,5 +132,17 @@ public class UserService {
         userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException(UserResponse.USER_NOT_FOUND))
                 .updateRole(role);
+    }
+
+    public List<User> findAllByIdIn(List<Long> userIds) {
+        List<User> users = userRepository.findAllByIdIn(userIds);
+
+        Map<Long, User> userMap = users.stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        return userIds.stream()
+                .map(userMap::get)
+                .filter(Objects::nonNull)
+                .toList();
     }
 }

--- a/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/com/poortorich/chat/service/ChatParticipantServiceTest.java
@@ -338,21 +338,4 @@ class ChatParticipantServiceTest {
         assertThat(result).hasSize(4);
         assertThat(result).containsExactly(member1, member2, member3, member4);
     }
-
-    @Test
-    @DisplayName("채팅방 참여자 아이디 목록으로 채팅방 참여자 조회 성공")
-    void findAllByIdInSuccess() {
-        List<Long> ids = List.of(1L, 2L, 3L);
-        ChatParticipant participant1 = ChatParticipant.builder().id(1L).build();
-        ChatParticipant participant2 = ChatParticipant.builder().id(2L).build();
-        ChatParticipant participant3 = ChatParticipant.builder().id(3L).build();
-
-        when(chatParticipantRepository.findAllByIdIn(ids))
-                .thenReturn(List.of(participant1, participant2, participant3));
-
-        List<ChatParticipant> result = chatParticipantService.findAllByIdIn(ids);
-
-        assertThat(result).hasSize(3);
-        assertThat(result).containsExactly(participant1, participant2, participant3);
-    }
 }

--- a/src/test/java/com/poortorich/ranking/facade/RankingFacadeTest.java
+++ b/src/test/java/com/poortorich/ranking/facade/RankingFacadeTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Optional;
@@ -51,10 +52,9 @@ class RankingFacadeTest {
     private RankingFacade rankingFacade;
 
     private final LocalDateTime now = LocalDateTime.now();
-    private final LocalDateTime lastMonday = now
+    private final LocalDate lastMonday = now
             .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-            .toLocalDate()
-            .atStartOfDay();
+            .toLocalDate();
 
     @Test
     @DisplayName("최신 랭킹 조회 성공")
@@ -97,7 +97,7 @@ class RankingFacadeTest {
 
         when(userService.findUserByUsername(username)).thenReturn(user);
         when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
-        when(rankingService.findLatestRanking(eq(chatroom), eq(lastMonday), any(LocalDateTime.class)))
+        when(rankingService.findLatestRanking(eq(chatroom), eq(lastMonday.atStartOfDay()), any(LocalDateTime.class)))
                 .thenReturn(ranking);
         when(chatParticipantService.findByUserIdAndChatroom(saverId, chatroom)).thenReturn(saver);
         when(chatParticipantService.findByUserIdAndChatroom(flexerId, chatroom)).thenReturn(flexer);
@@ -122,7 +122,7 @@ class RankingFacadeTest {
 
         when(userService.findUserByUsername(username)).thenReturn(user);
         when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
-        when(rankingService.findLatestRanking(eq(chatroom), eq(lastMonday), any(LocalDateTime.class)))
+        when(rankingService.findLatestRanking(eq(chatroom), eq(lastMonday.atStartOfDay()), any(LocalDateTime.class)))
                 .thenReturn(null);
 
         var result = rankingFacade.getLatestRanking(username, chatroomId);

--- a/src/test/java/com/poortorich/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/poortorich/ranking/service/RankingServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
@@ -29,10 +30,9 @@ class RankingServiceTest {
     private RankingService rankingService;
 
     private final LocalDateTime now = LocalDateTime.now();
-    private final LocalDateTime lastMonday = now
+    private final LocalDate lastMonday = now
             .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-            .toLocalDate()
-            .atStartOfDay();
+            .toLocalDate();
 
     @Test
     @DisplayName("최신 랭킹 조회 성공")
@@ -40,10 +40,13 @@ class RankingServiceTest {
         Chatroom chatroom = Chatroom.builder().build();
         Ranking ranking = Ranking.builder().chatroom(chatroom).build();
 
-        when(rankingRepository.findFirstByChatroomAndCreatedDateBetweenOrderByCreatedDateDesc(chatroom, lastMonday, now))
-                .thenReturn(Optional.of(ranking));
+        when(rankingRepository.findFirstByChatroomAndCreatedDateBetweenOrderByCreatedDateDesc(
+                chatroom,
+                lastMonday.atStartOfDay(),
+                now)
+        ).thenReturn(Optional.of(ranking));
 
-        Ranking result = rankingService.findLatestRanking(chatroom, lastMonday, now);
+        Ranking result = rankingService.findLatestRanking(chatroom, lastMonday.atStartOfDay(), now);
 
         assertThat(result).isEqualTo(ranking);
         assertThat(result.getChatroom()).isEqualTo(chatroom);
@@ -54,10 +57,13 @@ class RankingServiceTest {
     void findLatestRankingNull() {
         Chatroom chatroom = Chatroom.builder().build();
 
-        when(rankingRepository.findFirstByChatroomAndCreatedDateBetweenOrderByCreatedDateDesc(chatroom, lastMonday, now))
-                .thenReturn(Optional.empty());
+        when(rankingRepository.findFirstByChatroomAndCreatedDateBetweenOrderByCreatedDateDesc(
+                chatroom,
+                lastMonday.atStartOfDay(),
+                now)
+        ).thenReturn(Optional.empty());
 
-        Ranking result = rankingService.findLatestRanking(chatroom, lastMonday, now);
+        Ranking result = rankingService.findLatestRanking(chatroom, lastMonday.atStartOfDay(), now);
 
         assertThat(result).isNull();
     }
@@ -66,7 +72,7 @@ class RankingServiceTest {
     @DisplayName("전체 랭킹 목록 조회 구현")
     void getAllRankingsSuccess() {
         Chatroom chatroom = Chatroom.builder().build();
-        List<LocalDateTime> mondays = List.of(lastMonday);
+        List<LocalDate> mondays = List.of(lastMonday);
         Ranking ranking = Ranking.builder().chatroom(chatroom).build();
 
         when(rankingRepository.findAllByChatroomWithDateIn(chatroom, mondays)).thenReturn(List.of(ranking));

--- a/src/test/java/com/poortorich/user/service/UserServiceTest.java
+++ b/src/test/java/com/poortorich/user/service/UserServiceTest.java
@@ -22,6 +22,8 @@ import com.poortorich.user.response.UserEmailResponse;
 import com.poortorich.user.response.enums.UserResponse;
 import com.poortorich.user.util.ProfileUpdateRequestTestBuilder;
 import com.poortorich.user.util.UserRegistrationRequestTestBuilder;
+
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -175,5 +177,22 @@ public class UserServiceTest {
         assertThat(mockUser.getPassword()).isEqualTo(encodedNewPassword);
 
         verify(userRepository, times(1)).findByUsername(anyString());
+    }
+
+    @Test
+    @DisplayName("유저 아이디 목록으로 유저 조회 성공")
+    void findAllByIdInSuccess() {
+        List<Long> ids = List.of(1L, 2L, 3L);
+        User user1 = User.builder().id(1L).build();
+        User user2 = User.builder().id(2L).build();
+        User user3 = User.builder().id(3L).build();
+
+        when(userRepository.findAllByIdIn(ids))
+                .thenReturn(List.of(user1, user2, user3));
+
+        List<User> result = userService.findAllByIdIn(ids);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactly(user1, user2, user3);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#524
 
 ## 📝작업 내용
 
- 전체 랭킹 조회시 조회가 안되던 오류 수정
  - Saver, Flexer Id로 조회시 `ChatParticipant`를 `User`로 조회하도록 수정
  - 랭킹을 조회할 때 `LocalDate` 값으로 조회하도록 수정
  - limit 필터 값 수정
- 최신 랭킹 조회
  - `LocalDate` 값을 반환하도록 수정
