### PR TITLE
[#523] 참여중인 채팅 조회 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -4,10 +4,13 @@ import com.poortorich.chat.entity.ChatMessage;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatMessageType;
 import com.poortorich.chat.entity.enums.MessageType;
+import com.poortorich.user.entity.User;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -42,4 +45,15 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     Optional<ChatMessage> findTopByChatroomAndTypeInOrderByIdDesc(
             Chatroom chatroom,
             Collection<ChatMessageType> chatMessage);
+
+    @Query("""
+            SELECT MAX(m.id)
+            FROM ChatMessage m
+            LEFT JOIN UnreadChatMessage u
+                ON u.chatMessage = m
+                AND u.user = :user
+            WHERE m.chatroom = :chatroom
+            AND u.id IS NULL
+            """)
+    Long findLatestReadMessageId(@Param("chatroom") Chatroom chatroom, @Param("user") User user);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -53,7 +53,16 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
                 ON u.chatMessage = m
                 AND u.user = :user
             WHERE m.chatroom = :chatroom
+            AND m.type = :messageType
             AND u.id IS NULL
             """)
-    Long findLatestReadMessageId(@Param("chatroom") Chatroom chatroom, @Param("user") User user);
+    Long findLatestReadMessageId(
+            @Param("chatroom") Chatroom chatroom,
+            @Param("user") User user,
+            @Param("messageType") ChatMessageType messageType);
+
+    Optional<ChatMessage> findTopByChatroomAndTypeInAndSentAtBeforeOrderByIdDesc(
+            Chatroom chatroom,
+            List<ChatMessageType> chatMessage,
+            LocalDateTime bannedAt);
 }

--- a/src/main/java/com/poortorich/chat/repository/UnreadChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/UnreadChatMessageRepository.java
@@ -57,5 +57,4 @@ public interface UnreadChatMessageRepository extends JpaRepository<UnreadChatMes
     void deleteByChatroom(Chatroom chatroom);
 
     Long countByUserAndChatroom(User user, Chatroom chatroom);
-
 }

--- a/src/main/java/com/poortorich/chat/response/MyChatroom.java
+++ b/src/main/java/com/poortorich/chat/response/MyChatroom.java
@@ -14,6 +14,7 @@ public class MyChatroom implements Comparable<MyChatroom> {
     private final Boolean isHost;
     private final String chatroomTitle;
     private final Long currentMemberCount;
+    private final Long latestReadMessageId;
     private final String lastMessage;
     private final LocalDateTime lastMessageTime;
     private final Long unreadMessageCount;

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -293,4 +293,8 @@ public class ChatMessageService {
                 .messageType(rankingMessage.getMessageType())
                 .build();
     }
+
+    public Long getLatestReadMessageId(ChatParticipant participant) {
+        return chatMessageRepository.findLatestReadMessageId(participant.getChatroom(), participant.getUser());
+    }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -246,9 +246,15 @@ public class ChatMessageService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<ChatMessage> getLastMessage(Chatroom chatroom) {
+    public Optional<ChatMessage> getLastMessage(ChatParticipant participant) {
+        if (ChatroomRole.BANNED.equals(participant.getRole())) {
+            return chatMessageRepository.findTopByChatroomAndTypeInAndSentAtBeforeOrderByIdDesc(
+                    participant.getChatroom(),
+                    List.of(ChatMessageType.CHAT_MESSAGE, ChatMessageType.RANKING_MESSAGE),
+                    participant.getBannedAt());
+        }
         return chatMessageRepository.findTopByChatroomAndTypeInOrderByIdDesc(
-                chatroom,
+                participant.getChatroom(),
                 List.of(ChatMessageType.CHAT_MESSAGE, ChatMessageType.RANKING_MESSAGE));
     }
 
@@ -295,6 +301,9 @@ public class ChatMessageService {
     }
 
     public Long getLatestReadMessageId(ChatParticipant participant) {
-        return chatMessageRepository.findLatestReadMessageId(participant.getChatroom(), participant.getUser());
+        return chatMessageRepository.findLatestReadMessageId(
+                participant.getChatroom(),
+                participant.getUser(),
+                ChatMessageType.CHAT_MESSAGE);
     }
 }

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
@@ -30,6 +30,7 @@ public class ChatroomMapper {
         Long unreadMessageCount = unreadChatMessageService.countByUnreadChatMessage(
                 participant.getUser(),
                 participant.getChatroom());
+        Long latestReadMessageId = chatMessageService.getLatestReadMessageId(participant);
 
         return MyChatroom.builder()
                 .chatroomId(chatroom.getId())
@@ -37,6 +38,7 @@ public class ChatroomMapper {
                 .isHost(ChatroomRole.HOST.equals(participant.getRole()))
                 .chatroomTitle(chatroom.getTitle())
                 .currentMemberCount(chatParticipantService.countByChatroom(chatroom))
+                .latestReadMessageId(latestReadMessageId)
                 .lastMessage(lastMessage.map(contentMapper::mapToContent)
                         .orElseGet(() -> contentMapper.mapToContent(participant)))
                 .lastMessageTime(lastMessage.map(ChatMessage::getSentAt)

--- a/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
+++ b/src/main/java/com/poortorich/chat/util/mapper/ChatroomMapper.java
@@ -26,7 +26,7 @@ public class ChatroomMapper {
     public MyChatroom mapToMyChatroom(ChatParticipant participant) {
         Chatroom chatroom = participant.getChatroom();
 
-        Optional<ChatMessage> lastMessage = chatMessageService.getLastMessage(participant.getChatroom());
+        Optional<ChatMessage> lastMessage = chatMessageService.getLastMessage(participant);
         Long unreadMessageCount = unreadChatMessageService.countByUnreadChatMessage(
                 participant.getUser(),
                 participant.getChatroom());


### PR DESCRIPTION
## #️⃣523
 
 ## 📝작업 내용
- latestReadMessageId 필드 추가 작업
- 마지막 메시지 조회를 `BANNED` 회원 추가 작업 수행
    - `bannedAt` 이후 채팅 메시지가 조회되는 현상 존재
  
