### PR TITLE
[#534] 참여중인 채팅방 목록 조회 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -63,6 +63,25 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             @Param("joinAt") LocalDateTime joinAt,
             @Param("messageType") ChatMessageType messageType);
 
+    @Query("""
+            SELECT MAX(m.id)
+            FROM ChatMessage m
+            LEFT JOIN UnreadChatMessage u
+                ON u.chatMessage = m
+                AND u.user = :user
+            WHERE m.chatroom = :chatroom
+            AND m.type = :messageType
+            AND m.sentAt >= :joinAt
+            AND m.sentAt <= :bannedAt
+            AND u.id IS NULL
+            """)
+    Long findLatestReadMessageId(
+            @Param("chatroom") Chatroom chatroom,
+            @Param("user") User user,
+            @Param("joinAt") LocalDateTime joinAt,
+            @Param("bannedAt") LocalDateTime bannedAt,
+            @Param("messageType") ChatMessageType messageType);
+
     Optional<ChatMessage> findTopByChatroomAndTypeInAndSentAtLessThanEqualOrderByIdDesc(
             Chatroom chatroom,
             List<ChatMessageType> chatMessage,

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -303,6 +303,16 @@ public class ChatMessageService {
 
     @Transactional(readOnly = true)
     public Long getLatestReadMessageId(ChatParticipant participant) {
+        if (ChatroomRole.BANNED.equals(participant.getRole())) {
+            return chatMessageRepository.findLatestReadMessageId(
+                    participant.getChatroom(),
+                    participant.getUser(),
+                    participant.getJoinAt(),
+                    participant.getBannedAt(),
+                    ChatMessageType.CHAT_MESSAGE
+            );
+        }
+
         return chatMessageRepository.findLatestReadMessageId(
                 participant.getChatroom(),
                 participant.getUser(),


### PR DESCRIPTION
## #️⃣534
 ## 📝작업 내용
- 참석자가 입장한 이후 메시지부터 조회하도록 수정
 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 채팅방 참가 시간(join)이 반영되어 참가 이전 메시지는 읽음으로 집계되지 않도록 읽음 기준이 조정되었습니다.
  - 차단된(BANNED) 참가자에 대해 차단 시점(bannedAt) 이후 메시지는 읽음 후보에서 제외되도록 추가 필터링이 적용되었습니다.
  - 위 변경으로 일부 사용자에서 발생하던 최신 읽은 메시지 계산 오류(읽지 않은 수 불일치, 잘못된 스크롤 위치)가 개선되었습니다.

- 성능 개선
  - 읽음 조회 범위가 제한되어 대화 기록이 많은 방에서도 최신 읽음 조회가 더 안정적으로 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->