### PR TITLE
[#536] 모두 읽음 처리 오류 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -36,9 +36,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -310,12 +311,12 @@ public class ChatMessageService {
     }
 
     @Transactional(readOnly = true)
-    public List<Long> getLatestReadMessageIds(List<PayloadContext> contexts) {
-        List<Long> latestReadMessageIds = new ArrayList<>();
+    public Map<Long, Long> getLatestReadMessageIds(List<PayloadContext> contexts) {
+        Map<Long, Long> latestReadMessageIdByChatroom = new LinkedHashMap<>();
         for (var context : contexts) {
             Long latestReadMessageId = getLatestReadMessageId(context.chatParticipant());
-            latestReadMessageIds.add(latestReadMessageId);
+            latestReadMessageIdByChatroom.put(context.chatroom().getId(), latestReadMessageId);
         }
-        return latestReadMessageIds;
+        return latestReadMessageIdByChatroom;
     }
 }


### PR DESCRIPTION
## #️⃣536
 
 ## 📝작업 내용
 - 모두 읽음 처리 로직을 리팩터링하여 오류를 수정하였음
 
 ### 스크린샷 (선택)
<img width="648" height="262" alt="image" src="https://github.com/user-attachments/assets/6e1c3528-f03d-43aa-83bb-c439d6d248e3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음

- 버그 수정
  - 채팅방별 마지막 읽은 메시지 식별이 더 정확하게 반영되어 읽음 상태 표시의 신뢰성이 향상되었습니다.
  - 읽음 처리 시 타임스탬프가 일관되게 적용되어 알림/배지 표시가 안정화되었습니다.

- 리팩터링
  - 읽음 처리 로직을 목록 기반에서 매핑 기반으로 재구성하여 데이터 매칭 방식을 개선했습니다.
  - 내부 스트림 처리 방식과 컬렉션 사용을 정리해 코드 일관성과 유지보수성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->