### PR TITLE
[#538] 차단 참석자 읽음 처리 로직 추가

### DIFF
--- a/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
+++ b/src/main/java/com/poortorich/chat/constants/ChatResponseMessage.java
@@ -58,6 +58,8 @@ public class ChatResponseMessage {
     public static final String GET_MY_CHATROOMS_SUCCESS = "참여중인 채팅방 목록 조회가 완료되었습니다.";
     public static final String MESSAGE_TYPE_INVALID = "유효하지 않은 메시지 타입입니다.";
     public static final String CHAT_PARTICIPANT_BANNED = "채팅방에서 강제퇴장 되었습니다.";
+    public static final String CHAT_PARTICIPANT_BANNED_ONLY_ALLOWED = "밴 당한 참석자만 이용할 수 있습니다.";
+    public static final String MARK_CHATROOM_AS_READ_SUCCESS = "읽음 처리를 완료했습니다.";
 
     private ChatResponseMessage() {
     }

--- a/src/main/java/com/poortorich/chat/controller/ChatController.java
+++ b/src/main/java/com/poortorich/chat/controller/ChatController.java
@@ -257,4 +257,23 @@ public class ChatController {
 
         return DataResponse.toResponseEntity(ChatResponse.CHAT_PARTICIPANT_KICK_SUCCESS, apiResponse);
     }
+
+    @DeleteMapping("/{chatroomId}/block-users/read")
+    public ResponseEntity<BaseResponse> markMessagesAsReadByBannedParticipant(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long chatroomId
+    ) {
+        BasePayload responsePayload = realTimeFacade.markMessagesAsReadByBannedParticipant(
+                userDetails.getUsername(),
+                chatroomId);
+
+        if (Objects.nonNull(responsePayload)) {
+            messagingTemplate.convertAndSend(
+                    SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId,
+                    responsePayload
+            );
+        }
+
+        return BaseResponse.toResponseEntity(ChatResponse.MARK_CHATROOM_AS_READ_SUCCESS);
+    }
 }

--- a/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
+++ b/src/main/java/com/poortorich/chat/response/enums/ChatResponse.java
@@ -48,7 +48,13 @@ public enum ChatResponse implements Response {
     CHATROOM_IS_CLOSED(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHATROOM_IS_CLOSED, null),
     GET_MY_CHATROOMS_SUCCESS(HttpStatus.OK, ChatResponseMessage.GET_MY_CHATROOMS_SUCCESS, null),
     MESSAGE_TYPE_INVALID(HttpStatus.BAD_REQUEST, ChatResponseMessage.MESSAGE_TYPE_INVALID, null),
-    CHAT_PARTICIPANT_BANNED(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHAT_PARTICIPANT_BANNED, null);
+    CHAT_PARTICIPANT_BANNED(HttpStatus.BAD_REQUEST, ChatResponseMessage.CHAT_PARTICIPANT_BANNED, null),
+    CHAT_PARTICIPANT_BANNED_ONLY_ALLOWED(
+            HttpStatus.FORBIDDEN,
+            ChatResponseMessage.CHAT_PARTICIPANT_BANNED_ONLY_ALLOWED,
+            null),
+
+    MARK_CHATROOM_AS_READ_SUCCESS(HttpStatus.OK, ChatResponseMessage.MARK_CHATROOM_AS_READ_SUCCESS, null);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -22,11 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -135,6 +131,7 @@ public class ChatParticipantService {
 
         return chatParticipantRepository.findAllByChatroomAndIsParticipatedTrueAndUserNot(chatroom, user).stream()
                 .filter(chatParticipant -> !activeSubscribers.contains(chatParticipant.getUser().getUsername()))
+                .filter(chatParticipant -> !ChatroomRole.BANNED.equals(chatParticipant.getRole()))
                 .toList();
     }
 


### PR DESCRIPTION
## #️⃣538
 
 ## 📝작업 내용
 - 차단당한 참석자가 읽음 처리를 할 수 있는 REST API 추가
 - 차단 당한 사람이 안읽은메시지에 추가되는 로직 수정
 
 ### 스크린샷 (선택)
 
<img width="554" height="560" alt="image" src="https://github.com/user-attachments/assets/211f9145-e016-432a-bebe-46006325df78" />

