### PR TITLE
[#540] 채팅방 나가기 시 공지 상태 초기화 로직

### DIFF
--- a/src/main/java/com/poortorich/chat/service/ChatroomLeaveService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatroomLeaveService.java
@@ -3,6 +3,7 @@ package com.poortorich.chat.service;
 import com.poortorich.chat.entity.ChatParticipant;
 import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.ChatroomRole;
+import com.poortorich.chat.entity.enums.NoticeStatus;
 import com.poortorich.chat.realtime.event.chatroom.ChatroomUpdateEvent;
 import com.poortorich.chat.realtime.payload.response.ChatroomClosedResponsePayload;
 import com.poortorich.chat.realtime.payload.response.UserLeaveResponsePayload;
@@ -47,6 +48,7 @@ public class ChatroomLeaveService {
     @Transactional
     public void leaveChatroom(ChatParticipant participant) {
         participantValidator.validateIsParticipate(participant);
+        participant.updateNoticeStatus(NoticeStatus.DEFAULT);
         participant.leave();
         if (ChatroomRole.HOST.equals(participant.getRole())) {
             deleteChatroom(participant.getChatroom());


### PR DESCRIPTION
## #️⃣540
 
 ## 📝작업 내용
 - 채팅방 나가기 시 공지 상태 초기화되도록 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 채팅방 나가기 시 참여자의 알림 상태를 기본값으로 초기화하여, 나간 이후 알림 배지/배너가 남거나 알림 동작이 비정상적으로 이어지던 문제를 개선했습니다.
  * 재참여 또는 다른 채팅방 이용 시에도 알림 설정이 꼬이지 않도록 정리되어, 나가기 직후부터 일관된 알림 경험을 제공합니다. 기존의 호스트 삭제, 이벤트 브로드캐스트, 나가기/닫기 메시지 전송 동작은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->