### PR TITLE
[#542] 사진이 없는 경우 빈 배열 반환 로직 추가

### DIFF
--- a/src/main/java/com/poortorich/photo/facade/PhotoFacade.java
+++ b/src/main/java/com/poortorich/photo/facade/PhotoFacade.java
@@ -28,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -77,6 +78,15 @@ public class PhotoFacade {
         LocalDateTime cursorDate = DateParser.parseDateTime(date);
         Pageable pageable = PageRequest.of(0, 20);
         Slice<Photo> photos = photoService.getAllPhotosByCursor(chatroom, cursorDate, id, pageable);
+
+        if (photos.getContent().isEmpty()) {
+            return PhotoBuilder.buildAllPhotosResponse(
+                    null,
+                    null,
+                    null,
+                    List.of()
+            );
+        }
 
         String nextDate = photos.getContent().getLast().getCreatedDate()
                 .format(DateTimeFormatter.ofPattern(DatePattern.LOCAL_DATE_TIME_PATTERN));

--- a/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
+++ b/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
@@ -39,14 +39,16 @@ public class PhotoBuilder {
             Long nextId,
             List<Photo> photos
     ) {
+        List<PhotoInfoResponse> photoInfoResponse = photos.stream()
+                .filter(Objects::nonNull)
+                .map(PhotoBuilder::buildPhotoInfoByDateResponse)
+                .toList();
+
         return AllPhotosResponse.builder()
                 .hasNext(hasNext)
                 .nextCursor(buildPhotoCursorResponse(nextDate, nextId))
-                .photoCount((long) photos.size())
-                .photos(photos.stream()
-                        .filter(Objects::nonNull)
-                        .map(PhotoBuilder::buildPhotoInfoByDateResponse)
-                        .toList())
+                .photoCount((long) photoInfoResponse.size())
+                .photos(photoInfoResponse)
                 .build();
     }
 

--- a/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
+++ b/src/main/java/com/poortorich/photo/util/PhotoBuilder.java
@@ -44,6 +44,7 @@ public class PhotoBuilder {
                 .nextCursor(buildPhotoCursorResponse(nextDate, nextId))
                 .photoCount((long) photos.size())
                 .photos(photos.stream()
+                        .filter(Objects::nonNull)
                         .map(PhotoBuilder::buildPhotoInfoByDateResponse)
                         .toList())
                 .build();

--- a/src/test/java/com/poortorich/photo/facade/PhotoFacadeTest.java
+++ b/src/test/java/com/poortorich/photo/facade/PhotoFacadeTest.java
@@ -250,7 +250,9 @@ class PhotoFacadeTest {
         assertThat(result).isNotNull();
         assertThat(result.getHasNext()).isNull();
         assertThat(result.getNextCursor().getId()).isNull();
-        assertThat(result.getPhotos()).hasSize(0);
+        assertThat(result.getNextCursor().getDate()).isNull();
+        assertThat(result.getPhotoCount()).isZero();
+        assertThat(result.getPhotos()).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/poortorich/photo/facade/PhotoFacadeTest.java
+++ b/src/test/java/com/poortorich/photo/facade/PhotoFacadeTest.java
@@ -228,6 +228,32 @@ class PhotoFacadeTest {
     }
 
     @Test
+    @DisplayName("채팅방에 조회할 사진이 없는 경우 빈 배열 반환 성공")
+    void getAllPhotosByCursorEmpty() {
+        String username = "test";
+        Long chatroomId = 1L;
+        String dateString = "20250826010000";
+        LocalDateTime date = DateParser.parseDateTime(dateString);
+        Long photoId = 99L;
+        Pageable pageable = PageRequest.of(0, 20);
+        User user = User.builder().username(username).build();
+        Chatroom chatroom = Chatroom.builder().id(chatroomId).build();
+
+        Slice<Photo> slice = new SliceImpl<>(List.of(), pageable, false);
+
+        when(userService.findUserByUsername(username)).thenReturn(user);
+        when(chatroomService.findById(chatroomId)).thenReturn(chatroom);
+        when(photoService.getAllPhotosByCursor(chatroom, date, photoId, pageable)).thenReturn(slice);
+
+        AllPhotosResponse result = photoFacade.getAllPhotosByCursor(username, chatroomId, dateString, photoId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getHasNext()).isNull();
+        assertThat(result.getNextCursor().getId()).isNull();
+        assertThat(result.getPhotos()).hasSize(0);
+    }
+
+    @Test
     @DisplayName("사진 상세 조회 성공")
     void getPhotoDetailsSuccess() {
         String username = "test";


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#542
 
 ## 📝작업 내용
 
-  채팅방에 사진이 없는 경우 빈 배열 반환 로직 추가
 
 ### 스크린샷

<img width="1044" height="415" alt="image" src="https://github.com/user-attachments/assets/a824a362-9620-40bb-b6f9-3c4f04777a72" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 사진 목록이 비어도 오류 없이 응답을 반환하도록 개선했습니다(메타데이터는 null, 사진 목록은 빈 배열).
  - 목록 내 드문 null 항목을 자동으로 제외해 앱 크래시/NPE를 예방합니다.
  - 기존 페이지네이션 동작(다음 커서 계산 등)은 변경 없이 유지됩니다.
- 테스트
  - 빈 결과 시 커서 기반 조회의 반환값(메타, 카운트, 목록 등)을 검증하는 단위 테스트를 추가해 안정성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->