### PR TITLE
[#552] 참여중인 채팅방 조회 마지막 채팅 메시지 필터 로직 추가

### DIFF
--- a/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/poortorich/chat/entity/ChatParticipant.java
@@ -67,6 +67,12 @@ public class ChatParticipant {
     @Column(name = "joinAt")
     private LocalDateTime joinAt;
 
+    @Column(name = "enter_message_id")
+    private Long enterMessageId;
+
+    @Column(name = "kick_message_id")
+    private Long kickMessageId;
+
     @Column(name = "banned_at")
     private LocalDateTime bannedAt;
 
@@ -114,5 +120,13 @@ public class ChatParticipant {
             return;
         }
         this.rankingStatus = rankingStatus;
+    }
+
+    public void updateEnterMessageId(Long messageId) {
+        this.enterMessageId = messageId;
+    }
+
+    public void updateKickMessageId(Long messageId) {
+        this.kickMessageId = messageId;
     }
 }

--- a/src/main/java/com/poortorich/chat/realtime/event/chatparticipants/KickChatroomEventListener.java
+++ b/src/main/java/com/poortorich/chat/realtime/event/chatparticipants/KickChatroomEventListener.java
@@ -24,7 +24,8 @@ public class KickChatroomEventListener {
     public void onKickChatroomEvent(KickChatroomEvent event) {
         ChatParticipant participant = chatParticipantService.findByIdOrThrow(event.getChatParticipantId());
         KickChatParticipantMessagePayload payload = chatMessageService.saveKickChatParticipantMessage(participant);
-
+        participant.updateKickMessageId(participant.getKickMessageId());
+        
         if (Objects.nonNull(payload)) {
             messagingTemplate.convertAndSend(
                     SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + participant.getChatroom().getId(),

--- a/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
+++ b/src/main/java/com/poortorich/chat/realtime/facade/ChatRealTimeFacade.java
@@ -69,6 +69,7 @@ public class ChatRealTimeFacade {
         }
 
         UserEnterResponsePayload payload = chatMessageService.saveUserEnterMessage(user, chatroom);
+        chatParticipantService.updateEnterMessageId(user, chatroom, payload.getMessageId());
 
         return BasePayload.builder()
                 .type(ChatMessageType.SYSTEM_MESSAGE)
@@ -117,7 +118,7 @@ public class ChatRealTimeFacade {
         if (!ChatroomRole.BANNED.equals(context.chatParticipant().getRole())) {
             throw new ForbiddenException(ChatResponse.CHAT_PARTICIPANT_BANNED_ONLY_ALLOWED);
         }
-        
+
         Long latestReadMessageId = chatMessageService.getLatestReadMessageId(context.chatParticipant());
         MessageReadPayload payload = unreadChatMessageService.markMessageAsRead(context.chatParticipant());
         payload.setLastReadMessageId(latestReadMessageId);

--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -25,7 +25,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     void deleteByChatroom(Chatroom chatroom);
 
-    Slice<ChatMessage> findByChatroomAndIdLessThanEqualAndSentAtAfterOrderByIdDesc(
+    Slice<ChatMessage> findByChatroomAndIdLessThanEqualAndSentAtGreaterThanOrderByIdDesc(
             Chatroom chatroom,
             Long cursor,
             LocalDateTime joinedAt,

--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -25,17 +25,17 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     void deleteByChatroom(Chatroom chatroom);
 
-    Slice<ChatMessage> findByChatroomAndIdLessThanEqualAndSentAtGreaterThanOrderByIdDesc(
+    Slice<ChatMessage> findByChatroomAndIdLessThanEqualAndIdBetweenOrderByIdDesc(
             Chatroom chatroom,
             Long cursor,
-            LocalDateTime joinedAt,
+            Long enterMessageId,
+            Long kickMessageId,
             Pageable pageable);
 
-    Slice<ChatMessage> findByChatroomAndIdLessThanEqualAndSentAtBetweenOrderByIdDesc(
+    Slice<ChatMessage> findByChatroomAndIdLessThenEqualAndIdGreaterThanEqualOrderByIdDesc(
             Chatroom chatroom,
             Long cursor,
-            LocalDateTime joinAt,
-            LocalDateTime bannedAt,
+            Long enterMessageId,
             PageRequest pageRequest);
 
     boolean existsByContentAndMessageTypeAndChatroom(String content, MessageType messageType, Chatroom chatroom);

--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -93,4 +93,11 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             Long cursor,
             LocalDateTime joinAt,
             PageRequest pageRequest);
+
+    Slice<ChatMessage> findByChatroomAndIdLessThanEqualAndSentAtBetweenOrderByIdDesc(
+            Chatroom chatroom,
+            Long cursor,
+            LocalDateTime joinAt,
+            LocalDateTime bannedAt,
+            PageRequest pageRequest);
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -42,9 +42,10 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     Optional<ChatMessage> findTopByChatroomOrderByIdDesc(Chatroom chatroom);
 
-    Optional<ChatMessage> findTopByChatroomAndTypeInOrderByIdDesc(
+    Optional<ChatMessage> findTopByChatroomAndTypeInAndSentAtAfterOrderByIdDesc(
             Chatroom chatroom,
-            Collection<ChatMessageType> chatMessage);
+            Collection<ChatMessageType> chatMessage,
+            LocalDateTime joinAt);
 
     @Query("""
             SELECT MAX(m.id)

--- a/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatMessageRepository.java
@@ -32,7 +32,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             Long kickMessageId,
             Pageable pageable);
 
-    Slice<ChatMessage> findByChatroomAndIdLessThenEqualAndIdGreaterThanEqualOrderByIdDesc(
+    Slice<ChatMessage> findByChatroomAndIdLessThanEqualAndIdGreaterThanEqualOrderByIdDesc(
             Chatroom chatroom,
             Long cursor,
             Long enterMessageId,
@@ -87,4 +87,10 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             Chatroom chatroom,
             List<ChatMessageType> chatMessage,
             LocalDateTime bannedAt);
+
+    Slice<ChatMessage> findByChatroomAndIdLessThanEqualAndSentAtGreaterThanOrderByIdDesc(
+            Chatroom chatroom,
+            Long cursor,
+            LocalDateTime joinAt,
+            PageRequest pageRequest);
 }

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -255,9 +255,10 @@ public class ChatMessageService {
                     List.of(ChatMessageType.CHAT_MESSAGE, ChatMessageType.RANKING_MESSAGE),
                     participant.getBannedAt());
         }
-        return chatMessageRepository.findTopByChatroomAndTypeInOrderByIdDesc(
+        return chatMessageRepository.findTopByChatroomAndTypeInAndSentAtAfterOrderByIdDesc(
                 participant.getChatroom(),
-                List.of(ChatMessageType.CHAT_MESSAGE, ChatMessageType.RANKING_MESSAGE));
+                List.of(ChatMessageType.CHAT_MESSAGE, ChatMessageType.RANKING_MESSAGE),
+                participant.getJoinAt());
     }
 
     @Transactional

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -188,7 +188,7 @@ public class ChatMessageService {
                     context.pageRequest()
             );
         }
-        return chatMessageRepository.findByChatroomAndIdLessThanEqualAndSentAtAfterOrderByIdDesc(
+        return chatMessageRepository.findByChatroomAndIdLessThanEqualAndSentAtGreaterThanOrderByIdDesc(
                 context.chatroom(),
                 context.cursor(),
                 context.chatParticipant().getJoinAt(),

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -178,21 +178,22 @@ public class ChatMessageService {
         if (Objects.isNull(context.cursor())) {
             return new SliceImpl<>(Collections.emptyList(), context.pageRequest(), false);
         }
+        ChatParticipant participant = context.chatParticipant();
 
         if (ChatroomRole.BANNED.equals(context.chatParticipant().getRole())) {
-            return chatMessageRepository.findByChatroomAndIdLessThanEqualAndSentAtBetweenOrderByIdDesc(
+            return chatMessageRepository.findByChatroomAndIdLessThanEqualAndIdBetweenOrderByIdDesc(
                     context.chatroom(),
                     context.cursor(),
-                    context.chatParticipant().getJoinAt(),
-                    context.chatParticipant().getBannedAt(),
-                    context.pageRequest()
-            );
+                    participant.getEnterMessageId(),
+                    participant.getKickMessageId(),
+                    context.pageRequest());
         }
-        return chatMessageRepository.findByChatroomAndIdLessThanEqualAndSentAtGreaterThanOrderByIdDesc(
+        return chatMessageRepository.findByChatroomAndIdLessThenEqualAndIdGreaterThanEqualOrderByIdDesc(
                 context.chatroom(),
                 context.cursor(),
-                context.chatParticipant().getJoinAt(),
-                context.pageRequest());
+                participant.getEnterMessageId(),
+                context.pageRequest()
+        );
     }
 
     @Transactional

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -188,7 +188,14 @@ public class ChatMessageService {
                     participant.getKickMessageId(),
                     context.pageRequest());
         }
-        return chatMessageRepository.findByChatroomAndIdLessThenEqualAndIdGreaterThanEqualOrderByIdDesc(
+        if (ChatroomRole.HOST.equals(participant.getRole())) {
+            return chatMessageRepository.findByChatroomAndIdLessThanEqualAndSentAtGreaterThanOrderByIdDesc(
+                    context.chatroom(),
+                    context.cursor(),
+                    context.chatParticipant().getJoinAt(),
+                    context.pageRequest());
+        }
+        return chatMessageRepository.findByChatroomAndIdLessThanEqualAndIdGreaterThanEqualOrderByIdDesc(
                 context.chatroom(),
                 context.cursor(),
                 participant.getEnterMessageId(),

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -194,4 +194,18 @@ public class ChatParticipantService {
         return chatParticipantRepository.findById(chatParticipantId)
                 .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND));
     }
+
+    @Transactional
+    public void updateEnterMessageId(User user, Chatroom chatroom, Long messageId) {
+        chatParticipantRepository.findByUserAndChatroom(user, chatroom)
+                .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND))
+                .updateEnterMessageId(messageId);
+    }
+
+    @Transactional
+    public void updateKickMessageId(User user, Chatroom chatroom, Long messageId) {
+        chatParticipantRepository.findByUserAndChatroom(user, chatroom)
+                .orElseThrow(() -> new NotFoundException(ChatResponse.CHAT_PARTICIPANT_NOT_FOUND))
+                .updateKickMessageId(messageId);
+    }
 }


### PR DESCRIPTION
## #️⃣552
 
 ## 📝작업 내용
 - 참여중인 채팅방 조회 마지막 채팅 메시지를 조회할 때 `ChatParticipant.getJoinAt()` 이후 메시지가 조회될 수 있도록 수정했습니다.
 - 이전 채팅 조회 오류 수정
   - 입장 메시지 이전 것이 보인다거나, 강제 퇴장 이후 메시지가 보이는 현상 제거 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 채팅 메시지 페이징·마지막 메시지 조회 로직을 시간 기반에서 메시지 ID 범위 및 참여 시점(join) 기준으로 재정비하여 참여·강퇴 경계에서의 메시지 표시가 더 일관되고 정확해졌습니다.
  - 일부 기존 시간기반 조회 방식이 교체되거나 제거되어 관련 경계 처리 안정성이 향상되었습니다.

- **신규 기능**
  - 참가자별 입장/강퇴 시스템 메시지 ID를 저장·갱신하는 기능과 이를 이용한 조회 경로가 추가되어 시스템 메시지 표시·조회 정확도가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->