### PR TITLE
[#558] 필터에서 토큰 삭제 로직 제거 

### DIFF
--- a/src/main/java/com/poortorich/security/filter/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/poortorich/security/filter/auth/JwtAuthenticationFilter.java
@@ -13,9 +13,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -28,6 +25,10 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -64,7 +65,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 processRefreshToken(request, response);
             }
         } catch (UnauthorizedException exception) {
-            jwtManager.clearAuthTokens(response);
             setResponseMessage(response, exception.getResponse());
             return;
         }

--- a/src/test/java/com/poortorich/security/filter/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/poortorich/security/filter/auth/JwtAuthenticationFilterTest.java
@@ -1,15 +1,5 @@
 package com.poortorich.security.filter.auth;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.poortorich.auth.jwt.fixture.JwtUserFixture;
@@ -24,9 +14,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -44,6 +31,20 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class JwtAuthenticationFilterTest {
@@ -132,7 +133,6 @@ public class JwtAuthenticationFilterTest {
 
         verify(response, never()).setStatus(anyInt());
         verify(response, never()).getWriter();
-        verify(cookieManager, never()).clearAuthTokens(response);
     }
 
     @Test
@@ -207,7 +207,6 @@ public class JwtAuthenticationFilterTest {
     private void verifyErrorResponse(String expectedJsonResponse) {
         assertThat(getActualJsonResponse()).isEqualTo(expectedJsonResponse);
 
-        verify(cookieManager).clearAuthTokens(response);
         verify(response).setStatus(HttpStatus.UNAUTHORIZED.value());
         verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
         verify(response).setCharacterEncoding("UTF-8");


### PR DESCRIPTION
## #️⃣558
 
 ## 📝작업 내용
 
 -필터에서 토큰 삭제 로직 제거 
 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 특정 인증 오류 발생 시 쿠키/토큰이 불필요하게 삭제되어 예기치 않은 로그아웃이 발생하던 문제를 수정했습니다. 이제 해당 오류 상황에서도 기존 세션이 유지되어 재시도와 추가 인증 절차가 원활해집니다. 사용자 경험과 안정성이 향상되었습니다.
- 테스트
  - 변경된 인증 동작에 맞춰 관련 테스트 검증 항목을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->