### PR TITLE
[#561] 채팅방 삭제 로직에서 누락된 채팅방 좋아요 삭제 추가

### DIFF
--- a/src/main/java/com/poortorich/chat/util/manager/ChatroomLeaveManager.java
+++ b/src/main/java/com/poortorich/chat/util/manager/ChatroomLeaveManager.java
@@ -9,6 +9,7 @@ import com.poortorich.chat.service.ChatParticipantService;
 import com.poortorich.chat.service.ChatroomService;
 import com.poortorich.chat.service.UnreadChatMessageService;
 import com.poortorich.chatnotice.service.ChatNoticeService;
+import com.poortorich.like.service.LikeService;
 import com.poortorich.photo.service.PhotoService;
 import com.poortorich.ranking.service.RankingService;
 import com.poortorich.report.service.ReportService;
@@ -30,6 +31,7 @@ public class ChatroomLeaveManager {
     private final ChatNoticeService chatNoticeService;
     private final UnreadChatMessageService unreadChatMessageService;
     private final ReportService reportService;
+    private final LikeService likeService;
 
     public ChatroomClosedResponsePayload leaveChatroom(ChatParticipant participant) {
         if (participant.getChatroom().getIsClosed()) {
@@ -50,6 +52,7 @@ public class ChatroomLeaveManager {
             rankingService.deleteAllByChatroom(chatroom);
             chatNoticeService.deleteAllByChatroom(chatroom);
             reportService.deleteAllByChatroom(chatroom);
+            likeService.deleteAllByChatroom(chatroom);
             chatParticipantService.deleteAllByChatroom(chatroom);
             chatroomService.deleteById(chatroom.getId());
             return null;

--- a/src/main/java/com/poortorich/like/repository/LikeRepository.java
+++ b/src/main/java/com/poortorich/like/repository/LikeRepository.java
@@ -14,4 +14,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByUserAndChatroom(User user, Chatroom chatroom);
 
     Long countByChatroomAndLikeStatusTrue(Chatroom chatroom);
+
+    void deleteByChatroom(Chatroom chatroom);
 }

--- a/src/main/java/com/poortorich/like/service/LikeService.java
+++ b/src/main/java/com/poortorich/like/service/LikeService.java
@@ -6,6 +6,7 @@ import com.poortorich.like.repository.LikeRepository;
 import com.poortorich.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -37,5 +38,10 @@ public class LikeService {
                         .likeStatus(isLiked)
                         .build()
                 );
+    }
+
+    @Transactional
+    public void deleteAllByChatroom(Chatroom chatroom) {
+        likeRepository.deleteByChatroom(chatroom);
     }
 }


### PR DESCRIPTION
## #️⃣561
 
 ## 📝작업 내용
 
채팅방 삭제 로직에서 누락된 채팅방 좋아요 삭제 추가
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 채팅방의 모든 참여자가 떠나거나 채팅방이 종료/삭제될 때, 해당 채팅방과 연관된 좋아요가 함께 정리되도록 개선했습니다.
  - 남아있는 좋아요 데이터로 인해 잘못된 좋아요 수가 표시되던 문제를 방지합니다.
  - 채팅방 정리 과정에서 관련 데이터(신고 등)와 함께 좋아요도 일괄 삭제되어 데이터 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->