### PR TITLE
[#567] 이전 채팅 조회 정렬 제공

### DIFF
--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -65,6 +65,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -331,7 +332,8 @@ public class ChatFacade {
         Long nextCursor = paginationProvider.getNextCursor(chatMessages);
         List<ChatMessageResponse> messages = chatMessages.getContent().stream()
                 .map(chatMessageMapper::mapToChatMessageResponse)
-                .toList();
+                .collect(Collectors.toList());
+        Collections.reverse(messages);
 
         return ChatMessagePageResponse.builder()
                 .nextCursor(nextCursor)


### PR DESCRIPTION
## #️⃣567
 
 ## 📝작업 내용
- 이전 채팅 메시지 리스트 정렬해서 제공



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 채팅 기록의 메시지 순서를 바로잡아 시간 흐름에 맞게 표시됩니다. 이제 최신 메시지가 상단에 노출되어 최근 대화를 더 빠르게 확인할 수 있습니다. 이를 통해 채팅 내 탐색성과 가독성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->