### PR TITLE
[#586] 전체 채팅방 조회 스냅샷 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -66,6 +66,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -127,6 +128,7 @@ public class ChatFacade {
         }
 
         List<Chatroom> chatrooms = chatroomService.getAllChatrooms(sortBy, cursor);
+        List<String> lastMessageTimes = chatroomService.getAllLastMessageTimes(sortBy, cursor);
 
         if (chatrooms.isEmpty()) {
             return getAllChatroomsResponseEmptyChatroom();
@@ -135,8 +137,28 @@ public class ChatFacade {
         return AllChatroomsResponse.builder()
                 .hasNext(chatroomService.hasNext(sortBy, chatrooms.getLast().getId()))
                 .nextCursor(chatroomService.getNextCursor(sortBy, chatrooms.getLast().getId()))
-                .chatrooms(getChatroomResponses(chatrooms))
+                .chatrooms(getChatroomResponses(chatrooms, lastMessageTimes))
                 .build();
+    }
+
+    private List<ChatroomResponse> getChatroomResponses(List<Chatroom> chatrooms, List<String> lastMessageTimes) {
+        List<ChatroomResponse> chatroomResponses = new ArrayList<>();
+        for (int i = 0; i < chatrooms.size(); i++) {
+            Chatroom chatroom = chatrooms.get(i);
+            if (chatroom == null) {
+                continue;
+            }
+
+            chatroomResponses.add(
+                    chatBuilder.buildChatroomResponse(
+                            chatroom,
+                            tagService.getTagNames(chatroom),
+                            chatParticipantService.countByChatroom(chatroom),
+                            lastMessageTimes.get(i))
+            );
+        }
+
+        return chatroomResponses;
     }
 
     private AllChatroomsResponse getAllChatroomsSortByCreatedAt(Long cursor) {

--- a/src/main/java/com/poortorich/chat/repository/RedisChatRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/RedisChatRepository.java
@@ -3,59 +3,97 @@ package com.poortorich.chat.repository;
 import com.poortorich.chat.request.enums.SortBy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
 public class RedisChatRepository {
 
-    private static final String REDIS_CHAT_KEY = "chatrooms:list:%s";
+    private static final String REDIS_CHAT_ZSET_KEY = "chatrooms:zset:%s";
     private static final int CHAT_KEY_EXPIRATION_TIME = 5;
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void save(SortBy sortBy, List<Long> chatroomIds) {
+    public void overwrite(SortBy sortBy, List<Long> chatroomIds, List<String> lastMessageTimes) {
         String key = getRedisKey(sortBy.name());
-        List<String> stringIds = chatroomIds.stream()
-                .map(String::valueOf)
-                .toList();
+        redisTemplate.delete(key);
 
-        redisTemplate.opsForList().rightPushAll(key, stringIds);
-        redisTemplate.expire(key, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
+        save(sortBy, chatroomIds, lastMessageTimes);
     }
 
-    public void overwrite(SortBy sortBy, List<Long> chatroomIds) {
+    public void save(SortBy sortBy, List<Long> chatroomIds, List<String> lastMessageTimes) {
         String key = getRedisKey(sortBy.name());
-        List<String> stringIds = chatroomIds.stream().map(String::valueOf).toList();
+        ZSetOperations<String, String> zset = redisTemplate.opsForZSet();
 
-        redisTemplate.delete(key);
-        if (!stringIds.isEmpty()) {
-            redisTemplate.opsForList().rightPushAll(key, stringIds);
+        for (int i = 0; i < chatroomIds.size(); i++) {
+            String member = String.valueOf(chatroomIds.get(i));
+            double score = toEpochMillis(lastMessageTimes.get(i));
+            zset.add(key, member, score);
         }
+
         redisTemplate.expire(key, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
     }
 
     public List<Long> getChatroomIds(SortBy sortBy, Long cursor, int size) {
-        String key = getRedisKey(sortBy.name());
-        List<String> allIds = redisTemplate.opsForList().range(key, 0, -1);
-        if (allIds == null || allIds.isEmpty()) {
+        var tuples = getWindowTuples(sortBy, cursor, size);
+        if (tuples.isEmpty()) {
             return List.of();
         }
 
-        if (cursor == 0 || cursor == -1) {
-            return allIds.subList(0, Math.min(size, allIds.size())).stream()
-                    .map(Long::parseLong)
-                    .toList();
+        return tuples.stream()
+                .map(t -> Long.parseLong(Objects.requireNonNull(t.getValue())))
+                .toList();
+    }
+
+    public List<String> getLastMessageTimes(SortBy sortBy, Long cursor, int size) {
+        var tuples = getWindowTuples(sortBy, cursor, size);
+        if (tuples.isEmpty()) {
+            return List.of();
         }
 
-        int startIndex = allIds.indexOf(cursor.toString());
-        List<String> result = allIds.subList(startIndex, Math.min(startIndex + size, allIds.size()));
-        return result.stream()
-                .map(Long::parseLong)
+        return tuples.stream()
+                .map(t -> {
+                    Double s = t.getScore();
+                    if (s == null || s.doubleValue() == 0D) return null; // 메시지 없음은 null
+                    return Instant.ofEpochMilli(s.longValue())
+                            .atZone(ZoneId.of("Asia/Seoul"))
+                            .toLocalDateTime()
+                            .toString();
+                })
                 .toList();
+    }
+
+    private Set<ZSetOperations.TypedTuple<String>> getWindowTuples(SortBy sortBy, Long cursor, int size) {
+        String key = getRedisKey(sortBy.name());
+        ZSetOperations<String, String> zset = redisTemplate.opsForZSet();
+
+        Long total = zset.size(key);
+        if (total == null || total == 0) {
+            return Set.of();
+        }
+
+        long startIndex;
+        if (cursor == null || cursor == 0 || cursor == -1) {
+            startIndex = 0;
+        } else {
+            Long rank = zset.reverseRank(key, String.valueOf(cursor));
+            if (rank == null) return Set.of();
+            startIndex = rank + 1;
+        }
+        long endIndex = Math.min(startIndex + size - 1, total - 1);
+        if (startIndex > endIndex) return Set.of();
+
+        Set<ZSetOperations.TypedTuple<String>> tuples = zset.reverseRangeWithScores(key, startIndex, endIndex);
+        return (tuples == null) ? Set.of() : tuples;
     }
 
     public boolean existsBySortBy(SortBy sortBy) {
@@ -64,39 +102,64 @@ public class RedisChatRepository {
     }
 
     public Boolean hasNext(SortBy sortBy, Long lastChatroomId) {
-        List<String> stringIds = getAllList(sortBy);
-        if (stringIds == null || stringIds.isEmpty()) {
+        String zsetKey = getRedisKey(sortBy.name());
+        ZSetOperations<String, String> zset = redisTemplate.opsForZSet();
+
+        Long total = zset.size(zsetKey);
+        if (total == null || total == 0) {
             return false;
         }
 
-        int idx = stringIds.indexOf(lastChatroomId.toString());
-        return hasNext(idx, stringIds.size());
+        Long rank = zset.reverseRank(zsetKey, String.valueOf(lastChatroomId));
+        return rank != null && (rank + 1) < total;
     }
 
     public Long getNextCursor(SortBy sortBy, Long lastChatroomId) {
-        List<String> stringIds = getAllList(sortBy);
-        if (stringIds == null || stringIds.isEmpty()) {
+        String zsetKey = getRedisKey(sortBy.name());
+        ZSetOperations<String, String> zset = redisTemplate.opsForZSet();
+
+        Long total = zset.size(zsetKey);
+        if (total == null || total == 0) {
+            return null;
+        }
+        Long rank = zset.reverseRank(zsetKey, String.valueOf(lastChatroomId));
+        if (rank == null) {
+            return null;
+        }
+        long nextIndex = rank + 1;
+        if (nextIndex >= total) {
+            return null;
+        }
+        Set<String> range = zset.reverseRange(zsetKey, nextIndex, nextIndex);
+        if (range == null || range.isEmpty()) {
             return null;
         }
 
-        int idx = stringIds.indexOf(lastChatroomId.toString());
-        if (hasNext(idx, stringIds.size())) {
-            return Long.parseLong(stringIds.get(idx + 1));
-        }
-
-        return null;
-    }
-
-    private List<String> getAllList(SortBy sortBy) {
-        String key = getRedisKey(sortBy.name());
-        return redisTemplate.opsForList().range(key, 0, -1);
-    }
-
-    private Boolean hasNext(int idx, int size) {
-        return idx != -1 && idx + 1 < size;
+        return Long.parseLong(range.iterator().next());
     }
 
     private String getRedisKey(String sortBy) {
-        return String.format(REDIS_CHAT_KEY, sortBy);
+        return String.format(REDIS_CHAT_ZSET_KEY, sortBy);
+    }
+
+    private double toEpochMillis(String isoDateTime) {
+        if (isoDateTime == null || isoDateTime.isBlank()) {
+            return 0D;
+        }
+
+        try {
+            return (double) Instant.parse(isoDateTime).toEpochMilli();
+        } catch (DateTimeParseException ignored) { }
+        try {
+            return (double) java.time.LocalDateTime.parse(isoDateTime)
+                    .atZone(ZoneId.of("Asia/Seoul"))
+                    .toInstant()
+                    .toEpochMilli();
+        } catch (DateTimeParseException ignored) { }
+        try {
+            return Double.parseDouble(isoDateTime);
+        } catch (NumberFormatException ignored) {
+            return 0D;
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#586 
 
 ## 📝작업 내용
 
- 마지막 메세지 시간을 함께 저장하도록 로직 수정 (zset 사용)
- 추후 리팩토링 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 채팅방 목록에서 생성일 외 다른 정렬 옵션 사용 시에도 각 채팅방의 마지막 메시지 시각이 일관되게 표시됩니다.
  - 마지막 메시지 시각이 한국 시간(Asia/Seoul) 기준으로 표시됩니다.
- Bug Fixes
  - 채팅방 목록의 다음 페이지 이동/더보기 동작이 더 정확하고 안정적으로 동작합니다.
  - 일부 채팅방에서 마지막 메시지 시각이 누락되거나 잘못 표기되던 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->