### PR TITLE
[#591] 랭킹 테스트 로직 삭제

### DIFF
--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -33,9 +33,6 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -301,28 +298,6 @@ public class ChatMessageService {
 
         ChatMessage rankingMessage = RankingMessageBuilder.buildRankingMessage(chatroom, ranking);
         rankingMessage = chatMessageRepository.save(rankingMessage);
-
-        return RankingResponsePayload.builder()
-                .messageId(rankingMessage.getId())
-                .rankingId(rankingMessage.getRankingId())
-                .chatroomId(rankingMessage.getChatroom().getId())
-                .rankedAt(rankingMessage.getSentAt().toLocalDate())
-                .sentAt(rankingMessage.getSentAt())
-                .saverRankings(rankerProfileMapper.mapToSavers(ranking))
-                .flexerRankings(rankerProfileMapper.mapToFlexer(ranking))
-                .type(rankingMessage.getType())
-                .messageType(rankingMessage.getMessageType())
-                .build();
-    }
-
-    // TODO: 테스트 이후 삭제
-    @Transactional
-    public RankingResponsePayload saveRankingMessage(Chatroom chatroom, Ranking ranking, LocalDate date) {
-        dateChangeDetector.detect(chatroom);
-
-        ChatMessage rankingMessage = RankingMessageBuilder.buildRankingMessage(chatroom, ranking);
-        rankingMessage = chatMessageRepository.save(rankingMessage);
-        rankingMessage.updateSentAt(date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)));
 
         return RankingResponsePayload.builder()
                 .messageId(rankingMessage.getId())

--- a/src/main/java/com/poortorich/ranking/controller/RankingController.java
+++ b/src/main/java/com/poortorich/ranking/controller/RankingController.java
@@ -4,22 +4,16 @@ import com.poortorich.global.response.BaseResponse;
 import com.poortorich.global.response.DataResponse;
 import com.poortorich.ranking.facade.RankingFacade;
 import com.poortorich.ranking.response.enums.RankingResponse;
-import com.poortorich.websocket.stomp.command.subscribe.endpoint.SubscribeEndpoint;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.LocalDate;
-import java.util.Objects;
 
 @RestController
 @RequestMapping("/chatrooms/{chatroomId}/rankings")
@@ -39,25 +33,6 @@ public class RankingController {
                 ? RankingResponse.GET_LATEST_RANKING_SUCCESS
                 : RankingResponse.GET_LATEST_RANKING_NOT_FOUND;
         return DataResponse.toResponseEntity(code, result.response());
-    }
-
-    @PostMapping("/test/calculate")
-    public ResponseEntity<BaseResponse> calculateRankingTest(
-            @AuthenticationPrincipal UserDetails userDetails,
-            @PathVariable Long chatroomId,
-            @RequestParam(name = "date", required = false) LocalDate date
-    ) {
-        if (Objects.isNull(date)) {
-            date = LocalDate.now();
-        }
-        var payload = rankingFacade.calculateRankingTest(chatroomId, date);
-        messagingTemplate.convertAndSend(
-                SubscribeEndpoint.CHATROOM_SUBSCRIBE_PREFIX + chatroomId,
-                payload.mapToBasePayload());
-        return DataResponse.toResponseEntity(
-                HttpStatus.OK,
-                "랭킹 집계 테스트 성공",
-                payload.mapToBasePayload());
     }
 
     @GetMapping("/all")

--- a/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
+++ b/src/main/java/com/poortorich/ranking/facade/RankingFacade.java
@@ -63,43 +63,6 @@ public class RankingFacade {
         return calculateRanking(chatroom);
     }
 
-    // TODO: 테스트 이후 삭제
-    @Transactional
-    public RankingResponsePayload calculateRankingTest(Long chatroomId, LocalDate date) {
-        Chatroom chatroom = chatroomService.findById(chatroomId);
-        return calculateRanking(chatroom, date);
-    }
-
-    // TODO: 테스트 이후 삭제
-    @Transactional
-    public RankingResponsePayload calculateRanking(Chatroom chatroom, LocalDate date) {
-        Rankers rankers = rankingCalculator.calculate(chatroom, date);
-        Ranking ranking = rankingService.create(
-                chatroom,
-                rankers,
-                date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)));
-
-        List<ChatParticipant> participants = chatParticipantService.findAllByChatroom(chatroom);
-        ChatParticipant prevSaver = chatParticipantService.findByChatroomAndRankingStatus(
-                chatroom,
-                RankingStatus.SAVER);
-
-        ChatParticipant prevFLexer = chatParticipantService.findByChatroomAndRankingStatus(
-                chatroom,
-                RankingStatus.FLEXER);
-
-        chatParticipantService.updateAllRankingStatus(participants, RankingStatus.NONE);
-        rankingService.updateRankingStatus(rankers);
-        if (!Objects.isNull(prevSaver)) {
-            eventPublisher.publishEvent(new UserProfileUpdateEvent(prevSaver.getUser().getUsername()));
-        }
-        if (!Objects.isNull(prevFLexer)) {
-            eventPublisher.publishEvent(new UserProfileUpdateEvent(prevFLexer.getUser().getUsername()));
-        }
-
-        return chatMessageService.saveRankingMessage(chatroom, ranking, date);
-    }
-
     @Transactional
     public RankingResponsePayload calculateRanking(Chatroom chatroom) {
         Rankers rankers = rankingCalculator.calculate(chatroom);
@@ -287,7 +250,7 @@ public class RankingFacade {
                     }
 
                     ChatParticipant chatParticipant = chatParticipantService.findByUserAndChatroom(user, chatroom);
-                   return profileMapper.mapToProfile(chatParticipant, i == 0 ? type : RankingStatus.NONE);
+                    return profileMapper.mapToProfile(chatParticipant, i == 0 ? type : RankingStatus.NONE);
                 })
                 .filter(Objects::nonNull)
                 .toList();

--- a/src/main/java/com/poortorich/ranking/service/RankingService.java
+++ b/src/main/java/com/poortorich/ranking/service/RankingService.java
@@ -47,27 +47,6 @@ public class RankingService {
         return rankingRepository.save(ranking);
     }
 
-    // TODO: 테스트 이후 삭제
-    public Ranking create(Chatroom chatroom, Rankers rankers, LocalDate date) {
-        if (rankers == null) {
-            return null;
-        }
-
-        Ranking ranking = Ranking.builder()
-                .chatroom(chatroom)
-                .saverFirst(rankers.firstSaver())
-                .saverSecond(rankers.secondSaver())
-                .saverThird(rankers.thirdSaver())
-                .flexerFirst(rankers.firstFlexer())
-                .flexerSecond(rankers.secondFlexer())
-                .flexerThird(rankers.thirdFlexer())
-                .build();
-
-        ranking = rankingRepository.save(ranking);
-        ranking.updateCreatedDate(date);
-        return rankingRepository.save(ranking);
-    }
-
     @Transactional
     public void updateAll(List<ChatParticipant> participants, RankingStatus rankingStatus) {
         participants.forEach(participant -> participant.updateRankingStatus(rankingStatus));

--- a/src/main/java/com/poortorich/ranking/util/calculator/RankingCalculator.java
+++ b/src/main/java/com/poortorich/ranking/util/calculator/RankingCalculator.java
@@ -19,7 +19,6 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component
@@ -31,8 +30,7 @@ public class RankingCalculator {
 
     public Rankers calculate(Chatroom chatroom) {
         List<ChatParticipant> participants = participantService.findAllByChatroom(chatroom);
-        // TODO: null 파라미터 삭제
-        RankingCalculationData rankingCalculationData = getRankingCalculationData(participants, null);
+        RankingCalculationData rankingCalculationData = getRankingCalculationData(participants);
 
         if (!rankingCalculationData.isCalculate()) {
             return null;
@@ -44,24 +42,8 @@ public class RankingCalculator {
                 .build();
     }
 
-    // TODO: 테스트 이후 삭제
-    public Rankers calculate(Chatroom chatroom, LocalDate date) {
-        List<ChatParticipant> participants = participantService.findAllByChatroom(chatroom);
-        RankingCalculationData rankingCalculationData = getRankingCalculationData(participants, date);
-
-        if (!rankingCalculationData.isCalculate()) {
-            return null;
-        }
-
-        return Rankers.builder()
-                .savers(calculateSaver(rankingCalculationData))
-                .flexers(calculateFlexer(rankingCalculationData))
-                .build();
-    }
-
-    // TODO: 테스트 이후 date 파라미터 삭제
-    private RankingCalculationData getRankingCalculationData(List<ChatParticipant> participants, LocalDate date) {
-        LocalDate today = (Objects.nonNull(date)) ? date : LocalDate.now();
+    private RankingCalculationData getRankingCalculationData(List<ChatParticipant> participants) {
+        LocalDate today = LocalDate.now();
         LocalDate lastWeekSunday = today.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY));
         LocalDate lastWeekMonday = lastWeekSunday.with(TemporalAdjusters.previous(DayOfWeek.MONDAY));
 


### PR DESCRIPTION
## #️⃣591
 
 ## 📝작업 내용
- 랭킹 테스트 로직 삭제
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 랭킹 계산이 항상 지난주(월~일) 기준으로 수행되며 날짜 지정 옵션이 제거되었습니다.
  - 랭킹 메시지 생성 시 임의 날짜 지정 흐름을 정리해 동작을 단순화했습니다.
- Chores
  - 테스트용 랭킹 계산 POST 엔드포인트(/chatrooms/{id}/rankings/test/calculate)를 제거했습니다.
  - 불필요한 날짜 관련 처리와 의존성을 정리하여 유지보수성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->