### PR TITLE
[#596] 이미지 업로드 타입 추가

### DIFF
--- a/src/main/java/com/poortorich/s3/constants/S3ValidationConstraints.java
+++ b/src/main/java/com/poortorich/s3/constants/S3ValidationConstraints.java
@@ -5,7 +5,7 @@ import java.util.List;
 public class S3ValidationConstraints {
 
     public static final List<String> ALLOWED_FILE_TYPES = List.of(
-            "image/jpeg", "image/jpg", "image/png"
+            "image/jpeg", "image/jpg", "image/png", "image/webp"
     );
 
     public static final long FILE_MAX_SIZE = 5 * 1024 * 1024;

--- a/src/main/java/com/poortorich/s3/util/WebpConverter.java
+++ b/src/main/java/com/poortorich/s3/util/WebpConverter.java
@@ -9,17 +9,23 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
 public class WebpConverter {
 
+    private boolean isWebp(byte[] bytes) {
+        if (bytes == null || bytes.length < 12) return false;
+        return bytes[0] == 'R' && bytes[1] == 'I' && bytes[2] == 'F' && bytes[3] == 'F'
+                && bytes[8] == 'W' && bytes[9] == 'E' && bytes[10] == 'B' && bytes[11] == 'P';
+    }
+
     public byte[] convertToWebp(MultipartFile file) {
         try {
             String contentType = file.getContentType();
-            if (Objects.nonNull(contentType) && contentType.equals("image/webp")) {
-                return file.getBytes();
+            byte[] bytes = file.getBytes();
+            if ("image/webp".equalsIgnoreCase(contentType) && isWebp(bytes)) {
+                return bytes;
             }
 
             return ImmutableImage.loader().fromBytes(file.getBytes())

--- a/src/main/java/com/poortorich/s3/util/WebpConverter.java
+++ b/src/main/java/com/poortorich/s3/util/WebpConverter.java
@@ -4,10 +4,12 @@ import com.poortorich.global.exceptions.InternalServerErrorException;
 import com.poortorich.s3.response.enums.S3Response;
 import com.sksamuel.scrimage.ImmutableImage;
 import com.sksamuel.scrimage.webp.WebpWriter;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
@@ -15,6 +17,11 @@ public class WebpConverter {
 
     public byte[] convertToWebp(MultipartFile file) {
         try {
+            String contentType = file.getContentType();
+            if (Objects.nonNull(contentType) && contentType.equals("image/webp")) {
+                return file.getBytes();
+            }
+
             return ImmutableImage.loader().fromBytes(file.getBytes())
                     .bytes(WebpWriter.DEFAULT.withQ(80));
         } catch (IOException exception) {


### PR DESCRIPTION
## #️⃣596
 ## 📝작업 내용
 - 이미지 업로드 타입 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - WebP 이미지 업로드를 지원합니다. 이제 JPEG/JPG/PNG와 함께 WebP 형식을 사용할 수 있습니다.
  - 이미 WebP인 파일은 재인코딩 없이 그대로 처리되어 업로드 속도가 빨라지고 원본 품질이 유지됩니다.
  - 불필요한 변환을 건너뛰어 처리 효율이 개선되며 업로드 흐름 전반에서 최신 이미지 포맷 활용이 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->