### PR TITLE
[#593] 전체채팅방 목록 조회 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatroomRepository.java
@@ -37,7 +37,6 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
                         AND l.likeStatus = true
                   LEFT JOIN ChatParticipant cp ON cp.chatroom = c
                         AND cp.isParticipated = true
-                  LEFT JOIN Tag t ON t.chatroom = c
                 WHERE c.isClosed = false
                 GROUP BY c.id
                 ORDER BY MAX(cm.sentAt) DESC,
@@ -51,21 +50,10 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
     @Query("""
                 SELECT c
                   FROM Chatroom c
-                WHERE c.isClosed = false
-                  AND c.id < :cursor
-                ORDER BY c.id DESC
-            """)
-    Slice<Chatroom> findByCursorSortByCreatedAt(@Param("cursor") Long cursor, Pageable pageable);
-
-    @Query("""
-                SELECT c
-                  FROM Chatroom c
-                  LEFT JOIN ChatMessage cm ON cm.chatroom = c
                   LEFT JOIN Like l ON l.chatroom = c
                         AND l.likeStatus = true
                   LEFT JOIN ChatParticipant cp ON cp.chatroom = c
                         AND cp.isParticipated = true
-                  LEFT JOIN Tag t ON t.chatroom = c
                 WHERE c.isClosed = false
                 GROUP BY c.id
                 ORDER BY COUNT(DISTINCT l.id) DESC,
@@ -74,6 +62,15 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
                          c.id ASC
             """)
     List<Chatroom> findChatroomsSortByLike();
+
+    @Query("""
+                SELECT c
+                  FROM Chatroom c
+                WHERE c.isClosed = false
+                  AND c.id < :cursor
+                ORDER BY c.id DESC
+            """)
+    Slice<Chatroom> findByCursorSortByCreatedAt(@Param("cursor") Long cursor, Pageable pageable);
 
     @Query("""
                 SELECT DISTINCT c

--- a/src/main/java/com/poortorich/chat/repository/RedisChatRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/RedisChatRepository.java
@@ -22,9 +22,6 @@ public class RedisChatRepository {
         String idsKey = getRedisIdsKey(sortBy.name());
         String timesKey = getRedisTimesKey(sortBy.name());
 
-        String idsTmp = idsKey  + ":tmp";
-        String timesTmp = timesKey + ":tmp";
-
         if (chatroomIds == null || lastMessageTimes == null) {
             return;
         }
@@ -39,8 +36,8 @@ public class RedisChatRepository {
         redisTemplate.opsForList().rightPushAll(idsKey, stringIds);
         redisTemplate.opsForList().rightPushAll(timesKey, lastMessageTimes);
 
-        redisTemplate.expire(idsTmp, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
-        redisTemplate.expire(timesTmp, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
+        redisTemplate.expire(idsKey, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
+        redisTemplate.expire(timesKey, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
     }
 
     public void save(SortBy sortBy, List<Long> chatroomIds, List<String> lastMessageTimes) {

--- a/src/main/java/com/poortorich/chat/repository/RedisChatRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/RedisChatRepository.java
@@ -3,163 +3,139 @@ package com.poortorich.chat.repository;
 import com.poortorich.chat.request.enums.SortBy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeParseException;
 import java.util.List;
-import java.util.Objects;
-import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
 public class RedisChatRepository {
 
-    private static final String REDIS_CHAT_ZSET_KEY = "chatrooms:zset:%s";
+    private static final String REDIS_CHAT_KEY = "chatrooms:list:%s:ids";
+    private static final String REDIS_LAST_MESSAGE_TIME_KEY = "chatrooms:list:%s:times";
     private static final int CHAT_KEY_EXPIRATION_TIME = 5;
 
     private final RedisTemplate<String, String> redisTemplate;
 
     public void overwrite(SortBy sortBy, List<Long> chatroomIds, List<String> lastMessageTimes) {
-        String key = getRedisKey(sortBy.name());
-        redisTemplate.delete(key);
+        String idsKey = getRedisIdsKey(sortBy.name());
+        String timesKey = getRedisTimesKey(sortBy.name());
 
-        save(sortBy, chatroomIds, lastMessageTimes);
+        String idsTmp = idsKey  + ":tmp";
+        String timesTmp = timesKey + ":tmp";
+
+        if (chatroomIds == null || lastMessageTimes == null) {
+            return;
+        }
+
+        redisTemplate.delete(idsKey);
+        redisTemplate.delete(timesKey);
+
+        List<String> stringIds = chatroomIds.stream()
+                .map(String::valueOf)
+                .toList();
+
+        redisTemplate.opsForList().rightPushAll(idsKey, stringIds);
+        redisTemplate.opsForList().rightPushAll(timesKey, lastMessageTimes);
+
+        redisTemplate.expire(idsTmp, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
+        redisTemplate.expire(timesTmp, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
     }
 
     public void save(SortBy sortBy, List<Long> chatroomIds, List<String> lastMessageTimes) {
-        String key = getRedisKey(sortBy.name());
-        ZSetOperations<String, String> zset = redisTemplate.opsForZSet();
+        String idsKey = getRedisIdsKey(sortBy.name());
+        String timesKey = getRedisTimesKey(sortBy.name());
 
-        for (int i = 0; i < chatroomIds.size(); i++) {
-            String member = String.valueOf(chatroomIds.get(i));
-            double score = toEpochMillis(lastMessageTimes.get(i));
-            zset.add(key, member, score);
-        }
+        List<String> stringIds = chatroomIds.stream()
+                .map(String::valueOf)
+                .toList();
 
-        redisTemplate.expire(key, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
+        redisTemplate.opsForList().rightPushAll(idsKey, stringIds);
+        redisTemplate.opsForList().rightPushAll(timesKey, lastMessageTimes);
+
+        redisTemplate.expire(idsKey, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
+        redisTemplate.expire(timesKey, Duration.ofMinutes(CHAT_KEY_EXPIRATION_TIME));
     }
 
     public List<Long> getChatroomIds(SortBy sortBy, Long cursor, int size) {
-        var tuples = getWindowTuples(sortBy, cursor, size);
-        if (tuples.isEmpty()) {
+        String key = getRedisIdsKey(sortBy.name());
+        List<String> allIds = redisTemplate.opsForList().range(key, 0, -1);
+        if (allIds == null || allIds.isEmpty()) {
             return List.of();
         }
 
-        return tuples.stream()
-                .map(t -> Long.parseLong(Objects.requireNonNull(t.getValue())))
+        if (cursor == 0 || cursor == -1) {
+            return allIds.subList(0, Math.min(size, allIds.size())).stream()
+                    .map(Long::parseLong)
+                    .toList();
+        }
+
+        int startIndex = allIds.indexOf(cursor.toString());
+        List<String> result = allIds.subList(startIndex, Math.min(startIndex + size, allIds.size()));
+        return result.stream()
+                .map(Long::parseLong)
                 .toList();
     }
 
     public List<String> getLastMessageTimes(SortBy sortBy, Long cursor, int size) {
-        var tuples = getWindowTuples(sortBy, cursor, size);
-        if (tuples.isEmpty()) {
+        String key = getRedisTimesKey(sortBy.name());
+        List<String> allTimes = redisTemplate.opsForList().range(key, 0, -1);
+        if (allTimes == null || allTimes.isEmpty()) {
             return List.of();
         }
 
-        return tuples.stream()
-                .map(t -> {
-                    Double s = t.getScore();
-                    if (s == null || s.doubleValue() == 0D) return null; // 메시지 없음은 null
-                    return Instant.ofEpochMilli(s.longValue())
-                            .atZone(ZoneId.of("Asia/Seoul"))
-                            .toLocalDateTime()
-                            .toString();
-                })
-                .toList();
-    }
-
-    private Set<ZSetOperations.TypedTuple<String>> getWindowTuples(SortBy sortBy, Long cursor, int size) {
-        String key = getRedisKey(sortBy.name());
-        ZSetOperations<String, String> zset = redisTemplate.opsForZSet();
-
-        Long total = zset.size(key);
-        if (total == null || total == 0) {
-            return Set.of();
+        if (cursor == 0 || cursor == -1) {
+            return allTimes.subList(0, Math.min(size, allTimes.size()));
         }
 
-        long startIndex;
-        if (cursor == null || cursor == 0 || cursor == -1) {
-            startIndex = 0;
-        } else {
-            Long rank = zset.reverseRank(key, String.valueOf(cursor));
-            if (rank == null) return Set.of();
-            startIndex = rank + 1;
-        }
-        long endIndex = Math.min(startIndex + size - 1, total - 1);
-        if (startIndex > endIndex) return Set.of();
-
-        Set<ZSetOperations.TypedTuple<String>> tuples = zset.reverseRangeWithScores(key, startIndex, endIndex);
-        return (tuples == null) ? Set.of() : tuples;
+        int startIndex = allTimes.indexOf(cursor.toString());
+        return allTimes.subList(startIndex, Math.min(startIndex + size, allTimes.size()));
     }
 
     public boolean existsBySortBy(SortBy sortBy) {
-        String key = getRedisKey(sortBy.name());
+        String key = getRedisIdsKey(sortBy.name());
         return redisTemplate.hasKey(key);
     }
 
     public Boolean hasNext(SortBy sortBy, Long lastChatroomId) {
-        String zsetKey = getRedisKey(sortBy.name());
-        ZSetOperations<String, String> zset = redisTemplate.opsForZSet();
-
-        Long total = zset.size(zsetKey);
-        if (total == null || total == 0) {
+        List<String> stringIds = getAllList(sortBy);
+        if (stringIds == null || stringIds.isEmpty()) {
             return false;
         }
 
-        Long rank = zset.reverseRank(zsetKey, String.valueOf(lastChatroomId));
-        return rank != null && (rank + 1) < total;
+        int idx = stringIds.indexOf(lastChatroomId.toString());
+        return hasNext(idx, stringIds.size());
     }
 
     public Long getNextCursor(SortBy sortBy, Long lastChatroomId) {
-        String zsetKey = getRedisKey(sortBy.name());
-        ZSetOperations<String, String> zset = redisTemplate.opsForZSet();
-
-        Long total = zset.size(zsetKey);
-        if (total == null || total == 0) {
-            return null;
-        }
-        Long rank = zset.reverseRank(zsetKey, String.valueOf(lastChatroomId));
-        if (rank == null) {
-            return null;
-        }
-        long nextIndex = rank + 1;
-        if (nextIndex >= total) {
-            return null;
-        }
-        Set<String> range = zset.reverseRange(zsetKey, nextIndex, nextIndex);
-        if (range == null || range.isEmpty()) {
+        List<String> stringIds = getAllList(sortBy);
+        if (stringIds == null || stringIds.isEmpty()) {
             return null;
         }
 
-        return Long.parseLong(range.iterator().next());
+        int idx = stringIds.indexOf(lastChatroomId.toString());
+        if (hasNext(idx, stringIds.size())) {
+            return Long.parseLong(stringIds.get(idx + 1));
+        }
+
+        return null;
     }
 
-    private String getRedisKey(String sortBy) {
-        return String.format(REDIS_CHAT_ZSET_KEY, sortBy);
+    private List<String> getAllList(SortBy sortBy) {
+        String key = getRedisIdsKey(sortBy.name());
+        return redisTemplate.opsForList().range(key, 0, -1);
     }
 
-    private double toEpochMillis(String isoDateTime) {
-        if (isoDateTime == null || isoDateTime.isBlank()) {
-            return 0D;
-        }
+    private Boolean hasNext(int idx, int size) {
+        return idx != -1 && idx + 1 < size;
+    }
 
-        try {
-            return (double) Instant.parse(isoDateTime).toEpochMilli();
-        } catch (DateTimeParseException ignored) { }
-        try {
-            return (double) java.time.LocalDateTime.parse(isoDateTime)
-                    .atZone(ZoneId.of("Asia/Seoul"))
-                    .toInstant()
-                    .toEpochMilli();
-        } catch (DateTimeParseException ignored) { }
-        try {
-            return Double.parseDouble(isoDateTime);
-        } catch (NumberFormatException ignored) {
-            return 0D;
-        }
+    private String getRedisIdsKey(String sortBy) {
+        return String.format(REDIS_CHAT_KEY, sortBy);
+    }
+
+    private String getRedisTimesKey(String sortBy) {
+        return String.format(REDIS_LAST_MESSAGE_TIME_KEY, sortBy);
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -94,7 +94,7 @@ public class ChatMessageService {
         return chatMessageRepository.findTopByChatroomAndTypeInOrderByIdDesc(
                         chatroom, List.of(ChatMessageType.CHAT_MESSAGE, ChatMessageType.RANKING_MESSAGE))
                 .map(chatMessage -> chatMessage.getSentAt().toString())
-                .orElse(null);
+                .orElse("");
     }
 
     @Transactional

--- a/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/poortorich/chat/facade/ChatFacadeTest.java
@@ -226,8 +226,8 @@ class ChatFacadeTest {
         when(chatroomService.getNextCursor(sortBy, 2L)).thenReturn(3L);
         when(tagService.getTagNames(any())).thenReturn(hashtags);
         when(chatParticipantService.countByChatroom(any())).thenReturn(3L);
-        when(chatMessageService.getLastMessageTime(any())).thenReturn("2025-07-31T02:30");
-        when(chatBuilder.buildChatroomResponse(chatroom1, hashtags, 3L, "2025-07-31T02:30"))
+        when(chatroomService.getAllLastMessageTimes(sortBy, cursor)).thenReturn(List.of("", "2025-07-31T02:30"));
+        when(chatBuilder.buildChatroomResponse(chatroom1, hashtags, 3L, ""))
                 .thenReturn(ChatroomResponse.builder()
                         .chatroomId(chatroom1.getId())
                         .chatroomTitle(chatroom1.getTitle())
@@ -236,7 +236,7 @@ class ChatFacadeTest {
                         .hashtags(hashtags)
                         .currentMemberCount(3L)
                         .maxMemberCount(chatroom1.getMaxMemberCount())
-                        .lastMessageTime("2025-07-31T02:30")
+                        .lastMessageTime("")
                         .build());
 
         when(chatBuilder.buildChatroomResponse(chatroom2, hashtags, 3L, "2025-07-31T02:30"))


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#593 
 
 ## 📝작업 내용
 
- 전체채팅방 목록 조회 쿼리문 조인 삭제
- 전체채팅방 목록 레디스 로직 재수정
  - zset -> list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 채팅방 목록에 커서 기반 페이지네이션 도입으로 스크롤/더보기 탐색이 매끄러워졌습니다.
* Refactor
  * Redis 저장 구조를 ZSET에서 IDs/Times 리스트 2키 방식으로 변경해 목록 로딩 안정성 및 TTL 처리를 개선했습니다.
  * 채팅방 조회 쿼리에서 불필요한 태그 조인을 제거해 조회 성능을 향상했습니다.
* Bug Fixes
  * 마지막 메시지 시간이 없을 경우 null 대신 빈 문자열로 반환해 예외를 방지합니다.
* Tests
  * 마지막 메시지 시간 조회를 배치 방식으로 전환해 테스트를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->