### PR TITLE
[#600] 참여중인 채팅방 목록 조회 커서 변경에 따른 로직 수정

### DIFF
--- a/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
+++ b/src/main/java/com/poortorich/chat/controller/UserChatroomController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
@@ -24,7 +26,7 @@ public class UserChatroomController {
     @GetMapping("/me/chatrooms")
     public ResponseEntity<BaseResponse> getMyChatrooms(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam(required = false) Long cursor
+            @RequestParam(required = false) LocalDateTime cursor
     ) {
         MyChatroomsResponse response = chatFacade.getMyChatrooms(userDetails.getUsername(), cursor);
         return DataResponse.toResponseEntity(ChatResponse.GET_MY_CHATROOMS_SUCCESS, response);

--- a/src/main/java/com/poortorich/chat/facade/ChatFacade.java
+++ b/src/main/java/com/poortorich/chat/facade/ChatFacade.java
@@ -66,6 +66,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -84,7 +85,7 @@ public class ChatFacade {
     private final FileUploadService fileUploadService;
     private final UnreadChatMessageService unreadChatMessageService;
     private final TagService tagService;
-    
+
     private final ChatBuilder chatBuilder;
     private final ChatMessageMapper chatMessageMapper;
     private final ChatroomMapper chatroomMapper;
@@ -375,12 +376,12 @@ public class ChatFacade {
     }
 
     @Transactional
-    public MyChatroomsResponse getMyChatrooms(String username, Long cursor) {
+    public MyChatroomsResponse getMyChatrooms(String username, LocalDateTime cursor) {
         ChatroomPaginationContext context = paginationProvider.getMyChatroomsContext(username, cursor);
 
         Slice<ChatParticipant> participants = chatParticipantService.getMyParticipants(context);
 
-        Long nextCursor = paginationProvider.getChatroomNextCursor(participants);
+        LocalDateTime nextCursor = paginationProvider.getChatroomNextCursor(participants);
 
         List<MyChatroom> myChatrooms = participants.stream()
                 .map(chatroomMapper::mapToMyChatroom)

--- a/src/main/java/com/poortorich/chat/model/ChatroomPaginationContext.java
+++ b/src/main/java/com/poortorich/chat/model/ChatroomPaginationContext.java
@@ -4,10 +4,12 @@ import com.poortorich.user.entity.User;
 import lombok.Builder;
 import org.springframework.data.domain.PageRequest;
 
+import java.time.LocalDateTime;
+
 @Builder
 public record ChatroomPaginationContext(
         User user,
-        Long cursor,
+        LocalDateTime cursor,
         PageRequest pageRequest
 ) {
 }

--- a/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/poortorich/chat/repository/ChatParticipantRepository.java
@@ -5,12 +5,12 @@ import com.poortorich.chat.entity.Chatroom;
 import com.poortorich.chat.entity.enums.RankingStatus;
 import com.poortorich.user.entity.User;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -136,17 +136,34 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             @Param("nickname") String nickname
     );
 
-    @Query("""
-            SELECT cp
-            FROM ChatParticipant cp
-            JOIN FETCH cp.chatroom cr
-            JOIN FETCH cp.user u
-            WHERE u = :user
-            AND cp.isParticipated = true
-            AND cr.id >= :cursor
-            ORDER BY cr.id ASC
-            """)
-    Slice<ChatParticipant> findMyParticipants(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
+    @Query(value = """
+            SELECT cp.*,
+                COALESCE(
+                    lm.last_sent_at,
+                    CASE WHEN cp.role = 'HOST' THEN cr.created_date ELSE cp.join_at END
+                ) as latest_message_time
+            FROM chat_participant cp
+            JOIN chatroom cr ON cp.chatroom_id = cr.id
+            JOIN user u ON cp.user_id = u.id
+            LEFT JOIN (
+                SELECT chatroom_id, MAX(sent_at) as last_sent_at
+                FROM chat_message
+                WHERE type IN ('CHAT_MESSAGE', 'RANKING_MESSAGE')
+                GROUP BY chatroom_id
+            ) lm ON cr.id = lm.chatroom_id
+            WHERE u.id = :userId
+            AND cp.is_participated = true
+            AND (:cursor IS NULL OR COALESCE(
+                    lm.last_sent_at,
+                    CASE WHEN cp.role = 'HOST' THEN cr.created_date ELSE cp.join_at END) < :cursor
+                )
+            ORDER BY latest_message_time DESC
+            LIMIT :#{#pageable.pageSize + 1}
+            """, nativeQuery = true)
+    List<ChatParticipant> findMyParticipants(
+            @Param("userId") Long userId,
+            @Param("cursor") LocalDateTime cursor,
+            Pageable pageable);
 
     Optional<ChatParticipant> findByChatroomAndRankingStatus(Chatroom chatroom, RankingStatus rankingStatus);
 }

--- a/src/main/java/com/poortorich/chat/response/MyChatroomsResponse.java
+++ b/src/main/java/com/poortorich/chat/response/MyChatroomsResponse.java
@@ -3,6 +3,7 @@ package com.poortorich.chat.response;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -10,6 +11,6 @@ import java.util.List;
 public class MyChatroomsResponse {
 
     private boolean hasNext;
-    private Long nextCursor;
+    private LocalDateTime nextCursor;
     private List<MyChatroom> chatrooms;
 }

--- a/src/main/java/com/poortorich/chat/service/ChatMessageService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatMessageService.java
@@ -33,6 +33,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -355,5 +356,10 @@ public class ChatMessageService {
     public void updateLatestMessageId(ChatParticipant chatParticipant) {
         Long latestMessageId = chatMessageRepository.findLatestMessageIdByChatroom(chatParticipant.getChatroom());
         chatParticipant.updateLatestReadMessageId(latestMessageId);
+    }
+
+    public LocalDateTime getLatestMessageTimeByUser(User user) {
+        Optional<LocalDateTime> latestTime = chatMessageRepository.findLatestMessageTimeByUser(user);
+        return latestTime.orElse(null);
     }
 }

--- a/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/poortorich/chat/service/ChatParticipantService.java
@@ -18,6 +18,7 @@ import com.poortorich.user.entity.User;
 import com.poortorich.websocket.stomp.service.SubscribeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -172,11 +173,17 @@ public class ChatParticipantService {
     }
 
     public Slice<ChatParticipant> getMyParticipants(ChatroomPaginationContext context) {
-        return chatParticipantRepository
-                .findMyParticipants(
-                        context.user(),
-                        context.cursor(),
-                        context.pageRequest());
+        List<ChatParticipant> myParticipants = chatParticipantRepository.findMyParticipants(
+                context.user().getId(),
+                context.cursor(),
+                context.pageRequest());
+
+        boolean hasNext = myParticipants.size() > context.pageRequest().getPageSize();
+        if (hasNext) {
+            myParticipants.removeLast();
+        }
+
+        return new SliceImpl<>(myParticipants, context.pageRequest(), hasNext);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣600
 
 ## 📝작업 내용
 - cursor를 `chatroomId`에서 `latestChatMessage::sentAt`으로 수정
 - `latestChatMessage`는 참여중인 채팅방 중 가장 최근 메시지의 전송 시간
 
 ### 스크린샷 (선택)
 
<img width="560" height="594" alt="image" src="https://github.com/user-attachments/assets/5f173671-2b06-407c-9bc7-f6bd0463e41e" />

 ## 💬리뷰 요구사항(선택)
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 >
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - “내 채팅방” 목록에 시간 기반 커서 페이지네이션 도입으로 최신 활동 순 정렬 및 더 자연스러운 이어보기 지원
  - 첫 페이지에서 최근 활동 시각을 자동 기준으로 사용하여 시작 지점 개선

- 변경 사항
  - 공개 API 커서 타입이 Long에서 LocalDateTime(ISO-8601)으로 변경: 요청 쿼리(cursor)와 응답 nextCursor 모두 타임스탬프 사용 필요
  - 동일한 엔드포인트에서 정렬 기준이 최신 활동 시각으로 통일

- 리팩터
  - 페이징 처리 안정성 향상 및 조회 로직 정비

<!-- end of auto-generated comment: release notes by coderabbit.ai -->