### PR TITLE
[#605] 웹소켓 테스트 사이트 ORIGINS 삭제

### DIFF
--- a/src/main/java/com/poortorich/security/constants/SecurityConstants.java
+++ b/src/main/java/com/poortorich/security/constants/SecurityConstants.java
@@ -8,9 +8,7 @@ public class SecurityConstants {
             "https://localhost:5173",
             "https://localhost:4173",
             "https://poortorich.site",
-            "https://www.poortorich.site",
-            // STOMP 연결 테스트 사이트
-            "https://jiangxy.github.io"
+            "https://www.poortorich.site"
     );
     public static final List<String> ALLOWED_METHOD = List.of("GET", "POST", "PUT", "DELETE", "PATCH");
     public static final List<String> ALLOWED_HEADERS = List.of("authorization", "content-type", "x-auth-token");


### PR DESCRIPTION
## #️⃣605
 
 ## 📝작업 내용
-웹소켓 테스트 사이트 ORIGINS 삭제


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * 허용 오리진 목록에서 테스트용 도메인 1개를 제거하고 운영 및 로컬 도메인만 유지했습니다.
  * 영향: 제거된 도메인에서의 접속 및 WebSocket/STOMP 연결이 차단됩니다. 기존 지원 도메인 이용에는 변화가 없으며, 접근 범위가 보다 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->